### PR TITLE
Closes #793, Accept functions for `allowEscapeKey` and `allowEnterKey`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ Configuration
 | `timer`                  | `null`                | Auto close timer of the modal. Set in ms (milliseconds). |
 | `animation`              | `true`                | If set to `false`, modal CSS animation will be disabled. |
 | `allowOutsideClick`      | `true`                | If set to `false`, the user can't dismiss the modal by clicking outside it. You can also pass a custom function returning a boolean value, e.g. if you want to disable outside clicks for the loading state of a modal. |
-| `allowEscapeKey`         | `true`                | If set to `false`, the user can't dismiss the modal by pressing the <kbd>Esc</kbd> key. |
-| `allowEnterKey`          | `true`                | If set to `false`, the user can't confirm the modal by pressing the <kbd>Enter</kbd> or <kbd>Space</kbd> keys, unless they manually focus the confirm button. |
+| `allowEscapeKey`         | `true`                | If set to `false`, the user can't dismiss the modal by pressing the <kbd>Esc</kbd> key. You can also pass a custom function returning a boolean value, e.g. if you want to disable the escape key for the loading state of a modal. |
+| `allowEnterKey`          | `true`                | If set to `false`, the user can't confirm the modal by pressing the <kbd>Enter</kbd> or <kbd>Space</kbd> keys, unless they manually focus the confirm button. You can also pass a custom function returning a boolean value. |
 | `showConfirmButton`      | `true`                | If set to `false`, a "Confirm"-button will not be shown. It can be useful when you're using `html` parameter for custom HTML description. |
 | `showCancelButton`       | `false`               | If set to `true`, a "Cancel"-button will be shown, which the user can click on to dismiss the modal. |
 | `confirmButtonText`      | `'OK'`                | Use this to change the text on the "Confirm"-button. |

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -1,6 +1,6 @@
 import defaultParams, { deprecatedParams } from './utils/params.js'
 import { swalClasses, iconTypes } from './utils/classes.js'
-import { colorLuminance, warn, error, warnOnce } from './utils/utils.js'
+import { colorLuminance, warn, error, warnOnce, callIfFunction } from './utils/utils.js'
 import * as dom from './utils/dom.js'
 
 let popupParams = Object.assign({}, defaultParams)
@@ -724,14 +724,8 @@ const sweetAlert = (...args) => {
         if (e.target !== container) {
           return
         }
-        if (params.allowOutsideClick) {
-          if (typeof params.allowOutsideClick === 'function') {
-            if (params.allowOutsideClick()) {
-              dismissWith('overlay')
-            }
-          } else {
-            dismissWith('overlay')
-          }
+        if (callIfFunction(params.allowOutsideClick)) {
+          dismissWith('overlay')
         }
       }
     }
@@ -824,7 +818,7 @@ const sweetAlert = (...args) => {
         }
 
       // ESC
-      } else if ((e.key === 'Escape' || e.key === 'Esc') && params.allowEscapeKey === true) {
+      } else if ((e.key === 'Escape' || e.key === 'Esc') && callIfFunction(params.allowEscapeKey) === true) {
         dismissWith('esc')
       }
     }
@@ -1135,7 +1129,7 @@ const sweetAlert = (...args) => {
     openPopup(params.animation, params.onBeforeOpen, params.onOpen)
 
     if (!params.toast) {
-      if (!params.allowEnterKey) {
+      if (!callIfFunction(params.allowEnterKey)) {
         if (document.activeElement) {
           document.activeElement.blur()
         }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -69,3 +69,10 @@ export const warnOnce = (message) => {
     warn(message)
   }
 }
+
+/**
+ * If `arg` is a function, call it (with no arguments or context) and return the result.
+ * Otherwise, just pass the value through
+ * @param arg
+ */
+export const callIfFunction = (arg) => typeof arg === 'function' ? arg() : arg

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -592,6 +592,36 @@ QUnit.test('esc key', (assert) => {
     key: 'Escape'
   }))
 })
+
+QUnit.test('allowEscapeKey as a function', (assert) => {
+  const done = assert.async()
+
+  let functionWasCalled = false
+  const allowEscapeKey = () => {
+    functionWasCalled = true
+    return false
+  }
+
+  swal({
+    title: 'allowEscapeKey as a function',
+    allowEscapeKey,
+    animation: false,
+    onOpen: () => {
+      assert.equal(functionWasCalled, false)
+
+      $(document).trigger($.Event('keydown', {
+        key: 'Escape'
+      }))
+
+      setTimeout(() => {
+        assert.equal(functionWasCalled, true)
+        assert.ok(swal.isVisible())
+
+        done()
+      })
+    }
+  })
+})
 QUnit.test('close button', (assert) => {
   const done = assert.async()
 


### PR DESCRIPTION
Closes #793, Accept functions for `allowEscapeKey` and `allowEnterKey`

TODO:
- [ ] TypeScript typings
- [ ] Update sweetalert2.github.io
