### PR TITLE
Redo #697, Remove pointless and confusing script tags

### DIFF
--- a/test/qunit/index.html
+++ b/test/qunit/index.html
@@ -11,11 +11,6 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.4.1/core.js"></script>
   <script src="../../dist/sweetalert2.js"></script>
-
-  <script src="./outside-click.js"></script>
-  <script src="./deprecated.js"></script>
-  <script src="./toast.js"></script>
-  <script src="./tests.js"></script>
 </head>
 <body>
   <div id="qunit"></div>


### PR DESCRIPTION
Redo #697, Remove pointless and confusing script tags

@limonte Why did you add these back? As far as I can tell they don't do anything but create confusion / imply that contributors need to keep the tests indexed individually.