### PR TITLE
Make header flex column to be able to reorder its children

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -519,6 +519,11 @@ body {
     overflow-y: hidden;
   }
 
+  .swal2-header {
+    display: flex;
+    flex-direction: column;
+  }
+
   .swal2-title {
     color: lighten($swal2-black, 35);
     font-size: 30px;


### PR DESCRIPTION
With this change, #805 can be done like this

```css
swal2-title {
  order: -1;
}
```

Or, more cleaner, classnames-independent way:

```js
onOpen: () => swal.getTitlte().style.order = -1
```