### PR TITLE
Set height: auto for html and body when swal2 is shown

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -12,6 +12,7 @@ body {
       '.swal2-toast-shown'
     ) {
       overflow-y: hidden;
+      height: auto; // #781
     }
   }
 }


### PR DESCRIPTION
Fix #781 

Many CSS frameworks do this:

```css
html,
body {
  height: 100%;
}
```

This causes unwanted scrolling to the top of page.

E.g. Foundation 5.

Before this change: https://jsfiddle.net/gvh2can8/embedded/result/

With this change:  https://jsfiddle.net/gvh2can8/5/embedded/result/