### PR TITLE
Use rems instead of px for font-sizes

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -527,7 +527,7 @@ body {
 
   .swal2-title {
     color: lighten($swal2-black, 35);
-    font-size: 30px;
+    font-size: $swal2-title-font-size;
     text-align: center;
     font-weight: 600;
     text-transform: none;
@@ -603,7 +603,7 @@ body {
     box-shadow: none;
     color: $swal2-white;
     cursor: pointer;
-    font-size: 17px;
+    font-size: $swal2-buttons-font-size;
     font-weight: 500;
     margin: 15px 5px 0;
     padding: 10px 32px;
@@ -651,7 +651,7 @@ body {
   }
 
   .swal2-content {
-    font-size: 18px;
+    font-size: $swal2-content-font-size;
     text-align: center;
     font-weight: 300;
     position: relative;
@@ -677,7 +677,7 @@ body {
   .swal2-textarea {
     width: 100%;
     box-sizing: border-box;
-    font-size: 18px;
+    font-size: $swal2-input-font-size;
     border-radius: 3px;
     border: 1px solid $swal2-input-border;
     box-shadow: inset 0 1px 1px $swal2-input-box-shadow;
@@ -733,7 +733,7 @@ body {
   }
 
   .swal2-file {
-    font-size: 20px;
+    font-size: $swal2-input-font-size;
   }
 
   .swal2-textarea {
@@ -743,7 +743,7 @@ body {
 
   .swal2-select {
     color: lighten($swal2-black, 33);
-    font-size: inherit;
+    font-size: $swal2-input-font-size;
     padding: 5px 10px;
     min-width: 40%;
     max-width: 100%;
@@ -783,7 +783,7 @@ body {
     overflow: hidden;
     padding: 10px;
     color: lighten($swal2-black, 50);
-    font-size: 16px;
+    font-size: $swal2-validation-font-size;
     font-weight: 300;
     display: none;
 

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -25,3 +25,9 @@ $swal2-validationerror-color:      $swal2-white !default;
 $swal2-focus-outline: rgba(50, 100, 150, .4);
 
 $swal2-font: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+
+$swal2-title-font-size: 1.875rem;
+$swal2-content-font-size: 1.125rem;
+$swal2-input-font-size: 1.125rem;
+$swal2-validation-font-size: 1rem;
+$swal2-buttons-font-size: 1.0625rem;


### PR DESCRIPTION
Connected to #25 

Why rems? To be accessible for people who are using devices with non-default basic font-size.

Before (SweetAlert2 doesn't react anyhow on changing the font size setting):

![peek 2018-01-17 17-59](https://user-images.githubusercontent.com/6059356/35053029-bae4df08-fbb1-11e7-931d-86505931f1b1.gif)

After (fonts are resized nicely):

![peek 2018-01-17 17-591](https://user-images.githubusercontent.com/6059356/35053039-c047b088-fbb1-11e7-88e7-5eaa4167eeaf.gif)

I'm planning to adjust other details (width, height, paddings, etc.) to use rems instead of px, but I'll do that in other PRs.