### PR TITLE
Remove Firefox's inner focus indicator for buttons

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -364,6 +364,10 @@ body {
       outline: none;
       box-shadow: 0 0 0 2px $swal2-white, 0 0 0 4px $swal2-focus-outline;
     }
+
+    &::-moz-focus-inner {
+      border:0;
+    }
   }
 
   .swal2-image {


### PR DESCRIPTION
Closes https://github.com/sweetalert2/sweetalert2/issues/832