### PR TITLE
Add "confirm" to package keywords

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,8 +34,11 @@
     "dist/sweetalert2.css"
   ],
   "keywords": [
+    "sweetalert",
+    "sweetalert2",
     "alert",
-    "modal"
+    "modal",
+    "confirm"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "sweetalert",
     "sweetalert2",
     "alert",
-    "prompt"
+    "prompt",
+    "confirm"
   ],
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
As titled: Add "confirm" to package keywords. 

Because this package can also mimic `window.confirm('OK or cancel?')`

Also changes bower.json "keywords" to match those in package.json