### PR TITLE
Remove CJS build since UMD works in CJS environments

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,14 +13,7 @@ const run = require('gulp-run')
 const pack = require('./package.json')
 const utils = require('./config/utils.js')
 
-gulp.task('compress', ['js-lint', 'commonjs', 'dev', 'production', 'all', 'all.min'])
-
-gulp.task('commonjs', () => {
-  return utils.packageRollup({
-    dest: 'dist/' + pack.name + '.common.js',
-    format: 'cjs'
-  })
-})
+gulp.task('compress', ['js-lint', 'dev', 'production', 'all', 'all.min'])
 
 gulp.task('dev', () => {
   return utils.packageRollup({


### PR DESCRIPTION
As titled: Remove CJS (CommonJS) build since UMD (Universal Module Definition) works in CJS environments

This is a breaking change so note that this PR is aimed at the `canary` branch. I think it is a good idea to stage changes for the next major release there.
