### PR TITLE
list all common scripts in `package.scripts`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
   # xvfb-run is needed for headless testing with Chrome and Firefox
   - xvfb-run npm test
 
+after_script:
   # repeat unit tests against dist/sweetalert2.all.min.js
   - sed -i 's/sweetalert2.js/sweetalert2.all.min.js/g' testem.json
   - xvfb-run npm run check:tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,13 @@ addons:
   firefox: latest
   google-chrome: latest
 
-before_script:
-  - gulp
-  - bundlesize -f dist/sweetalert2.all.min.js -s 15kB
-
 script:
-  # unit tests against dist/sweetalert2.js
-  - xvfb-run testem ci --reporter dot
+  # xvfb-run is needed for headless testing with Chrome and Firefox
+  - xvfb-run npm test
 
-  # unit tests against dist/sweetalert2.all.min.js
+  # repeat unit tests against dist/sweetalert2.all.min.js
   - sed -i 's/sweetalert2.js/sweetalert2.all.min.js/g' testem.json
-  - xvfb-run testem ci --reporter dot
+  - xvfb-run npm run check:tests
 
 deploy:
   api_key:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -93,7 +93,9 @@ gulp.task('ts-lint', () => {
     .pipe(tslint.report())
 })
 
-gulp.task('default', ['sass', 'ts', 'compress'])
+gulp.task('build', ['sass', 'ts', 'compress'])
+
+gulp.task('default', ['build'])
 
 gulp.task('watch', () => {
   run('npm run assume-dist-unchanged').exec()

--- a/package.json
+++ b/package.json
@@ -66,9 +66,14 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "testem ci",
-    "lint-dts": "tslint sweetalert2.d.ts --format verbose",
-    "check-dts": "tsc sweetalert2.d.ts && npm run lint-dts",
+    "start": "gulp watch",
+    "fix:lint": "standard --fix",
+    "test": "npm run build && npm run check",
+    "build": "gulp build",
+    "check": "npm run check:bundlesize && npm run check:tests && npm run check:ts",
+    "check:bundlesize": "bundlesize -f dist/sweetalert2.all.min.js -s 15kB",
+    "check:tests": "testem ci",
+    "check:ts": "tsc sweetalert2.d.ts",
     "assume-dist-unchanged": "git ls-files dist | tr '\\n' ' ' | xargs git update-index --assume-unchanged",
     "no-assume-dist-unchanged": "git ls-files dist | tr '\\n' ' ' | xargs git update-index --no-assume-unchanged"
   },


### PR DESCRIPTION
list all common scripts in `package.scripts`, to be used in local development and on CI

Only `start` and `fix:lint` are for [local] development only; the rest can and should be used on CI also.

I will leave some comments on the lines of individual package scripts