### PR TITLE
feature(ci-build): check for magic numbers with buddy.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
 before_script:
   - gulp
   - bundlesize -f dist/sweetalert2.all.min.js -s 15kB
+  # check for magic numbers
+  - buddy src/*.js
 
 script:
   # unit tests against dist/sweetalert2.js

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-plugin-transform-object-assign": "latest",
     "babel-preset-es2015": "latest",
     "browser-sync": "^2.23.3",
+    "buddy.js": "^0.9.3",
     "bundlesize": "^0.15.3",
     "gulp": "latest",
     "gulp-autoprefixer": "^4.1.0",

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -152,7 +152,7 @@ const setParameters = (params) => {
 
   // Progress steps
   let progressStepsContainer = dom.getProgressSteps()
-  let currentProgressStep = parseInt(params.currentProgressStep === null ? sweetAlert.getQueueStep() : params.currentProgressStep, 10)
+  let currentProgressStep = parseInt(params.currentProgressStep === null ? sweetAlert.getQueueStep() : params.currentProgressStep)
   if (params.progressSteps.length) {
     dom.show(progressStepsContainer)
     dom.empty(progressStepsContainer)
@@ -403,7 +403,7 @@ const iOSfix = () => {
 
 const undoIOSfix = () => {
   if (dom.hasClass(document.body, swalClasses.iosfix)) {
-    const offset = parseInt(document.body.style.top, 10)
+    const offset = parseInt(document.body.style.top)
     dom.removeClass(document.body, swalClasses.iosfix)
     document.body.style.top = ''
     document.body.scrollTop = (offset * -1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,10 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
+acorn@^5.0.3:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+
 acorn@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
@@ -775,7 +779,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.1.1, bluebird@^3.4.6:
+bluebird@*, bluebird@^3.1.1, bluebird@^3.4.6:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -881,6 +885,17 @@ bs-recipes@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/bs-recipes/-/bs-recipes-1.3.4.tgz#0d2d4d48a718c8c044769fdc4f89592dc8b69585"
 
+buddy.js@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/buddy.js/-/buddy.js-0.9.3.tgz#4e3a8968dc33c2fb51eac387d57a877dc1793e36"
+  dependencies:
+    acorn "^5.0.3"
+    bluebird "*"
+    chalk "*"
+    commander "*"
+    node-filepaths "0.0.2"
+    strip-json-comments "1.0.2"
+
 buffer-from@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-0.1.1.tgz#57b18b1da0a19ec06f33837a5275a242351bd75e"
@@ -955,6 +970,14 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
+chalk@*, chalk@^2.1.0, chalk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -968,14 +991,6 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
 chalk@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
-
-chalk@^2.1.0, chalk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -1088,13 +1103,13 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@*, commander@^2.12.1, commander@~2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+
 commander@^2.11.0, commander@^2.6.0, commander@^2.8.1, commander@~2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-
-commander@^2.12.1, commander@~2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
 commander@^2.2.0:
   version "2.12.2"
@@ -1877,6 +1892,10 @@ file-entry-cache@^2.0.0:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
+
+file@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/file/-/file-0.2.2.tgz#c3dfd8f8cf3535ae455c2b423c2e52635d76b4d3"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -3674,6 +3693,12 @@ node-fetch@1.6.3:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-filepaths@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/node-filepaths/-/node-filepaths-0.0.2.tgz#775a8a332c5c4bf38aaf264320912963b04ad7ce"
+  dependencies:
+    file "0.2.2"
+
 node-gyp@^3.3.1:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.2.tgz#9bfbe54562286284838e750eac05295853fa1c60"
@@ -5074,6 +5099,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-json-comments@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.2.tgz#5a48ab96023dbac1b7b8d0ffabf6f63f1677be9f"
 
 strip-json-comments@~1.0.1:
   version "1.0.4"


### PR DESCRIPTION
I got this idea from https://github.com/ryanmcdermott/clean-code-javascript#use-searchable-names

Nobody like magic number in the codebase, [buddy.js](https://github.com/danielstjules/buddy.js) will prevent contributors from adding them.