### PR TITLE
chore(dev-workflow): do not perform heavy tasks for active development

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,7 @@ gulp.task('commonjs', () => {
   })
 })
 
-gulp.task('dev', () => {
+gulp.task('dev', ['js-lint'], () => {
   return utils.packageRollup({
     dest: 'dist/' + pack.name + '.js',
     format: 'umd'
@@ -54,15 +54,18 @@ gulp.task('all.min', ['sass'], () => {
   })
 })
 
-gulp.task('sass', ['sass-lint'], (cb) => {
-  gulp.src('src/sweetalert2.scss')
+gulp.task('sass', ['sass-lint'], () => {
+  return gulp.src('src/sweetalert2.scss')
     .pipe(sass())
     .pipe(autoprefix())
     .pipe(gulp.dest('dist'))
+})
+
+gulp.task('css.min', ['sass'], () => {
+  return gulp.src('dist/sweetalert2.css')
     .pipe(cleanCSS())
     .pipe(rename({extname: '.min.css'}))
     .pipe(gulp.dest('dist'))
-    .on('end', cb)
 })
 
 gulp.task('ts', ['ts-lint'], () => {
@@ -93,7 +96,7 @@ gulp.task('ts-lint', () => {
     .pipe(tslint.report())
 })
 
-gulp.task('build', ['sass', 'ts', 'compress'])
+gulp.task('build', ['sass', 'ts', 'compress', 'css.min'])
 
 gulp.task('default', ['build'])
 
@@ -112,13 +115,11 @@ gulp.task('watch', ['default'], () => {
   gulp.watch([
     'test/sandbox.html',
     'test/qunit/*.js',
-    'dist/sweetalert2.all.min.js'
+    'dist/sweetalert2.js',
+    'dist/sweetalert2.css'
   ]).on('change', browserSync.reload)
 
-  gulp.watch([
-    'src/**/*.js',
-    'test/*.js'
-  ], ['compress'])
+  gulp.watch(['src/**/*.js'], ['dev'])
 
-  gulp.watch(['src/*.scss'], ['sass', 'compress'])
+  gulp.watch(['src/*.scss'], ['sass'])
 })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -122,4 +122,6 @@ gulp.task('watch', ['default'], () => {
   gulp.watch(['src/**/*.js'], ['dev'])
 
   gulp.watch(['src/*.scss'], ['sass'])
+
+  gulp.watch(['sweetalert2.d.ts'], ['ts'])
 })


### PR DESCRIPTION
Related to #842 

Now watcher will perform:
- SASS linting and SASS -> CSS compilation (`dist/sweetalert2.css`) for changes in `src/*.scss` files
- JS linting and JS compilation (`dist/sweetalert2.js`) for changes in `src/**/*.js` files
- TS linting for changes in `sweetalert2.d.ts`