### PR TITLE
Fix gulp watch task to run the build upon initialization

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -95,7 +95,7 @@ gulp.task('ts-lint', () => {
 
 gulp.task('default', ['sass', 'ts', 'compress'])
 
-gulp.task('watch', () => {
+gulp.task('watch', ['default'], () => {
   run('npm run assume-dist-unchanged').exec()
 
   browserSync.init({


### PR DESCRIPTION
As titled: Fix gulp watch task to run the build upon initialization

Some change *like* this is needed. It may need to be adjusted depending on the pending PRs.

It seems that this is already expected to happen:
- I expected it would happen
- The docs say it will "automatically serve, build, and minify the SCSS and JS-files" (it currently does not, until you make changes)
- > you need to build the dist folder before running test, gulp watch should do that automatically https://github.com/sweetalert2/sweetalert2/issues/816#issuecomment-357445456 by @limonte 