### PR TITLE
Font is inherited by default

### DIFF
--- a/src/variables.scss
+++ b/src/variables.scss
@@ -29,7 +29,7 @@ $swal2-focus-outline: rgba(50, 100, 150, .4);
 $swal2-confirm-button-color: #3085d6 !default;
 $swal2-cancel-button-color: #aaa !default;
 
-$swal2-font: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+$swal2-font: inherit;
 $swal2-font-size: 1rem;
 
 $swal2-width: 32em;


### PR DESCRIPTION
This is a better default than Helvetica Neue.

closes #846