### PR TITLE
Issue with `uniqueArray`. 

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -5,12 +5,12 @@ export const consolePrefix = 'SweetAlert2:'
  * @param arr
  */
 export const uniqueArray = (arr) => {
-  var result = []
-  arr.map(i => {
-    if (result.indexOf(i) === -1) {
-      result.push(i)
+  const result = []
+  for (let elem of arr) {
+    if (result.indexOf(elem) === -1) {
+      result.push(elem)
     }
-  })
+  }
   return result
 }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -5,12 +5,12 @@ export const consolePrefix = 'SweetAlert2:'
  * @param arr
  */
 export const uniqueArray = (arr) => {
-  const result = []
-  for (var i in arr) {
-    if (result.indexOf(arr[i]) === -1) {
-      result.push(arr[i])
+  var result = []
+  arr.map(i => {
+    if (result.indexOf(i) === -1) {
+      result.push(i)
     }
-  }
+  })
   return result
 }
 


### PR DESCRIPTION
In certain cases, using a for in loop will loop over the dom [NodeList](https://developer.mozilla.org/en-US/docs/Web/API/NodeList) prototype, yielding unexpected behavior. I can't reproduce this on jsfiddle but please see the screen shots. Using `.map()` instead of `for...in` solves this pretty easily. 

![image](https://user-images.githubusercontent.com/13888239/35593640-687b86cc-05de-11e8-9090-3687e3b04324.png)
 - above input (`arr.length = 9`) is longer than output (`result.length` = 17

![image](https://user-images.githubusercontent.com/13888239/35593709-a6a960d6-05de-11e8-82c9-831da115f19b.png)

I believe the only place its called is in `getFocusableElements()`.