### PR TITLE
fix(release): reset dist to the state of origin/dist

### DIFF
--- a/release.js
+++ b/release.js
@@ -35,6 +35,7 @@ assert.ok(['patch', 'minor', 'major'].includes(semver), 'Must specify the valid 
 
   log('Switching to the dist branch...')
   await execute('git checkout dist')
+  await execute('git reset --hard origin/dist')
 
   log(`Merging from "${branchToPublish}" branch...`)
   await execute(`git merge ${branchToPublish}`)


### PR DESCRIPTION
Connected to https://github.com/sweetalert2/sweetalert2/issues/820

@zenflow you published the release yesterday.  I tried to release today but it wasn't successful because of

```
Pushing to Github...
    (pid:7032)	[cmd]	git push origin dist:dist --tags
    (pid:7032)	[ERR]	To github.com:sweetalert2/sweetalert2.git
    (pid:7032)	[ERR]	 * [new tag]         v7.8.7 -> v7.8.7
    (pid:7032)	[ERR]	error: failed to push some refs to 'git@github.com:sweetalert2/sweetalert2.git'
    (pid:7032)	[ERR]	hint: Updates were rejected because the tip of your current branch is behind
    (pid:7032)	[ERR]	hint: its remote counterpart. Integrate the remote changes (e.g.
    (pid:7032)	[ERR]	hint: 'git pull ...') before pushing again.
    (pid:7032)	[ERR]	hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```