### PR TITLE
fix(toast): success icon animation adjustment

### DIFF
--- a/src/toasts.scss
+++ b/src/toasts.scss
@@ -215,8 +215,8 @@ body {
 
         &[class$='right'] {
           border-radius: 0 64px 64px 0;
-          top: -5px;
-          left: 14px;
+          top: -4px;
+          left: 15px;
           transform-origin: 0 32px;
         }
       }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -48,7 +48,7 @@ $swal2-buttons-font-size: 1.0625em !default;
 $swal2-footer-font-size: 1em !default;
 
 $swal2-toast-title-font-size: 1em !default;
-$swal2-toast-content-font-size: .875em !default;
+$swal2-toast-content-font-size: 1em !default;
 $swal2-toast-input-font-size: 1em !default;
 $swal2-toast-validation-font-size: 1em !default;
 $swal2-toast-buttons-font-size: 1em !default;


### PR DESCRIPTION
Fixes #878 

Also, fix the visible vertical misalignment of a header and a content from the picture from #878 

![](https://user-images.githubusercontent.com/22635845/35738335-783266f4-0826-11e8-8d40-dfb3f7681918.png)