### PR TITLE
feat(release): use npm version instead of manual commits

### DIFF
--- a/utils/get-git-tags.js
+++ b/utils/get-git-tags.js
@@ -1,8 +1,0 @@
-const execute = require('./execute')
-
-async function getGitTags () {
-  const {stdout} = await execute('git tag', {skipLogging: true})
-  return stdout.split(/\r?\n/).filter(Boolean)
-}
-
-module.exports = getGitTags


### PR DESCRIPTION
I'd like to propose the improvement of our beautiful release script - [npm version](https://docs.npmjs.com/cli/version)

Before:
```sh
vim package.json # manual version change
# trying to exit Vim
git add package.json
git commit -m "<new_version_which_i_should_remember_and_i_hate_remembering_numbers>"
git push
npm run release
```

After:
```
npm run release patch
```

Pros:
 - 1 command instead of 5 
 - less code in the release scripts
 - no useless version commits in master