### PR TITLE
(release script) Handle pulling latest master and dist from Github

### DIFF
--- a/release.js
+++ b/release.js
@@ -23,6 +23,9 @@ assert.ok(['patch', 'minor', 'major'].includes(semver), 'Must specify the valid 
   }
   assert.equal(isCleanWorkingTree, true, 'Must have clean working tree')
 
+  log(`Pulling the latest ${branchToPublish} branch from Github...`)
+  await execute('git pull origin')
+
   log(`Running npm version ${semver}...`)
   await execute(`npm version --no-git-tag-version ${semver}`)
   const {version} = require('./package.json')

--- a/release.js
+++ b/release.js
@@ -36,6 +36,9 @@ assert.ok(['patch', 'minor', 'major'].includes(semver), 'Must specify the valid 
   log('Switching to the dist branch...')
   await execute('git checkout dist')
 
+  log('Pulling the latest dist branch from Github...')
+  await execute('git pull origin')
+
   log(`Merging from "${branchToPublish}" branch...`)
   await execute(`git merge ${branchToPublish}`)
 


### PR DESCRIPTION
This will ensure that you are working with the latest master and dist branches when you do a release. 

With this change you don't need to manually pull the master branch (e.g. after merging a PR on Github) or the dist branch (which I would be prone to forgetting).

Important if more than one person is working with master & dist. 