### PR TITLE
Darken buttons backgorund for :hover and :active without images

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -306,13 +306,11 @@ body {
         }
 
         &:hover {
-          // darken technique, the black pixel with 0.1 opacity
-          background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNikAQAACIAHF/uBd8AAAAASUVORK5CYII=');
+          background-image: linear-gradient($swal2-button-darken-hover, $swal2-button-darken-hover);
         }
 
         &:active {
-          // the black pixel with 0.2 opacity
-          background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNiMAYAADwANpiOMBYAAAAASUVORK5CYII=');
+          background-image: linear-gradient($swal2-button-darken-active, $swal2-button-darken-active);
         }
       }
     }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -29,6 +29,9 @@ $swal2-focus-outline: rgba(50, 100, 150, .4) !default;
 $swal2-confirm-button-color: #3085d6 !default;
 $swal2-cancel-button-color: #aaa !default;
 
+$swal2-button-darken-hover: rgba($swal2-black, .1) !default;
+$swal2-button-darken-active: rgba($swal2-black, .2) !default;
+
 $swal2-footer-border-color: #eee !default;
 
 $swal2-font: inherit !default;


### PR DESCRIPTION
Fixes #877 

Nice bonus we're getting with this PR: users will be able to customize the way of changing the background color of `:hover` and `:active` states.

Tested in IE11, works well :)