### PR TITLE
Enable property-sort-order for sass-lint

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -8,4 +8,6 @@ rules:
   no-url-domains: 0
   no-url-protocols: 0
   no-vendor-prefixes: 0
-  property-sort-order: 0
+  property-sort-order:
+    - 1
+    - order: smacss

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -13,8 +13,8 @@ body {
       '.swal2-no-backdrop',
       '.swal2-toast-shown'
     ) {
-      overflow-y: hidden;
       height: auto; // #781
+      overflow-y: hidden;
     }
   }
 }
@@ -22,17 +22,17 @@ body {
 body {
   &.swal2-iosfix {
     position: fixed;
-    left: 0;
     right: 0;
+    left: 0;
   }
 
   &.swal2-no-backdrop {
 
     .swal2-shown {
       top: auto;
+      right: auto;
       bottom: auto;
       left: auto;
-      right: auto;
       background-color: transparent;
 
       & > .swal2-modal {
@@ -91,8 +91,8 @@ body {
 
       &.swal2-bottom-end,
       &.swal2-bottom-right {
-        bottom: 0;
         right: 0;
+        bottom: 0;
       }
     }
   }
@@ -101,21 +101,21 @@ body {
 .swal2-container {
   // centering
   display: flex;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  position: fixed;
   padding: 10px;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  overflow-x: hidden;
 
   // backdrop
   background-color: transparent;
 
   z-index: 1060;
+  overflow-x: hidden;
 
   &.swal2-top {
     align-items: flex-start;
@@ -252,20 +252,20 @@ body {
 
 
 .swal2-popup {
+  display: none;
+  position: relative;
   flex-direction: column;
+  justify-content: center;
+  width: $swal2-width;
+  max-width: 100%;
+  padding: $swal2-padding;
+  border-radius: .3125em;
   background-color: $swal2-background-color;
   font-family: $swal2-font;
   font-size: $swal2-font-size;
-  padding: $swal2-padding;
-  border-radius: .3125em;
   box-sizing: border-box;
-  justify-content: center;
   overflow-x: hidden;
   overflow-y: auto;
-  display: none;
-  position: relative;
-  width: $swal2-width;
-  max-width: 100%;
 
   &:focus {
     outline: none;
@@ -282,22 +282,22 @@ body {
   }
 
   .swal2-title {
-    color: lighten($swal2-black, 35);
-    font-size: $swal2-title-font-size;
-    text-align: center;
-    font-weight: 600;
-    text-transform: none;
+    display: block;
     position: relative;
     margin: 0 0 .4em;
     padding: 0;
-    display: block;
+    color: lighten($swal2-black, 35);
+    font-size: $swal2-title-font-size;
+    font-weight: 600;
+    text-align: center;
+    text-transform: none;
     word-wrap: break-word;
   }
 
   .swal2-actions {
-    margin-top: 1.25em;
     align-items: center;
     justify-content: center;
+    margin-top: 1.25em;
 
     &:not(.swal2-loading) {
       .swal2-styled {
@@ -318,24 +318,24 @@ body {
     &.swal2-loading {
       .swal2-styled {
         &.swal2-confirm {
-          box-sizing: border-box;
-          border: .25em solid transparent;
-          border-color: transparent;
           width: 2.5em;
           height: 2.5em;
-          padding: 0;
           margin: .46875em;
+          padding: 0;
+          border: .25em solid transparent;
+          border-radius: 100%;
+          border-color: transparent;
           background-color: transparent !important;
           color: transparent;
           cursor: default;
-          border-radius: 100%;
+          box-sizing: border-box;
           animation: rotate-loading 1.5s linear 0s infinite normal;
           user-select: none;
         }
 
         &.swal2-cancel {
-          margin-left: 30px;
           margin-right: 30px;
+          margin-left: 30px;
         }
       }
 
@@ -343,14 +343,14 @@ body {
         &.swal2-confirm {
           &::after {
             display: inline-block;
-            content: '';
-            margin-left: 5px;
-            height: 15px;
             width: 15px;
+            height: 15px;
+            margin-left: 5px;
             border: 3px solid lighten($swal2-black, 60);
-            box-shadow: 1px 1px 1px $swal2-white;
-            border-right-color: transparent;
             border-radius: 50%;
+            border-right-color: transparent;
+            box-shadow: 1px 1px 1px $swal2-white;
+            content: '';
             animation: rotate-loading 1.5s linear 0s infinite normal;
           }
         }
@@ -359,14 +359,14 @@ body {
   }
 
   .swal2-styled {
+    margin: 0 .3125em;
+    padding: .625em 2em;
     border: 0;
     border-radius: .25em;
-    box-shadow: none;
     color: $swal2-white;
     font-size: $swal2-buttons-font-size;
     font-weight: 500;
-    margin: 0 .3125em;
-    padding: .625em 2em;
+    box-shadow: none;
 
     &:not([disabled]) {
       cursor: pointer;
@@ -391,37 +391,37 @@ body {
   }
 
   .swal2-footer {
-    font-size: $swal2-footer-font-size;
-    border-top: 1px solid $swal2-footer-border-color;
     justify-content: center;
     margin-top: 1.25em;
     padding-top: 1em;
+    border-top: 1px solid $swal2-footer-border-color;
+    font-size: $swal2-footer-font-size;
   }
 
   .swal2-image {
-    margin: 1.25em auto;
     max-width: 100%;
+    margin: 1.25em auto;
   }
 
   .swal2-close {
-    background: $swal2-transparent;
-    border: 0;
-    margin: 0;
-    padding: 0;
-    width: 1.2em;
-    min-width: 1.2em;
-    height: 1.2em;
-    // calc is needed for the correct focus outline, w/o calc: https://goo.gl/T3NYRm
-    font-size: calc(#{$swal2-close-button-size} - #{$swal2-close-button-size*.1});
-    line-height: 1.2em;
-    justify-content: center;
-    font-family: serif;
     position: absolute;
     top: 5px;
     right: 8px;
-    cursor: pointer;
-    color: $swal2-close-button;
+    justify-content: center;
+    width: 1.2em;
+    min-width: 1.2em;
+    height: 1.2em;
+    margin: 0;
+    padding: 0;
     transition: color .1s ease;
+    border: 0;
+    background: $swal2-transparent;
+    // calc is needed for the correct focus outline, w/o calc: https://goo.gl/T3NYRm
+    color: $swal2-close-button;
+    font-family: serif;
+    font-size: calc(#{$swal2-close-button-size} - #{$swal2-close-button-size*.1});
+    line-height: 1.2em;
+    cursor: pointer;
 
     &:hover {
       color: $swal2-close-button-hover;
@@ -438,13 +438,13 @@ body {
   }
 
   .swal2-content {
-    font-size: $swal2-content-font-size;
     justify-content: center;
-    font-weight: 300;
     margin: 0;
     padding: 0;
-    line-height: normal;
     color: lighten($swal2-black, 33);
+    font-size: $swal2-content-font-size;
+    font-weight: 300;
+    line-height: normal;
     word-wrap: break-word;
   }
 
@@ -465,12 +465,12 @@ body {
   .swal2-file,
   .swal2-textarea {
     width: 100%;
-    box-sizing: border-box;
-    font-size: $swal2-input-font-size;
-    border-radius: 3px;
-    border: 1px solid $swal2-input-border;
-    box-shadow: inset 0 1px 1px $swal2-input-box-shadow;
     transition: border-color .3s, box-shadow .3s;
+    border: 1px solid $swal2-input-border;
+    border-radius: 3px;
+    font-size: $swal2-input-font-size;
+    box-shadow: inset 0 1px 1px $swal2-input-box-shadow;
+    box-sizing: border-box;
 
     &.swal2-inputerror {
       border-color: $swal2-error !important;
@@ -478,8 +478,8 @@ body {
     }
 
     &:focus {
-      outline: none;
       border: 1px solid $swal2-input-border-focus;
+      outline: none;
       box-shadow: 0 0 3px $swal2-input-box-shadow-focus;
     }
 
@@ -501,11 +501,11 @@ body {
 
     input,
     output {
-      font-size: $swal2-input-font-size;
       height: 2.625em;
-      line-height: 2.625em;
       margin: 1em auto;
       padding: 0;
+      font-size: $swal2-input-font-size;
+      line-height: 2.625em;
     }
   }
 
@@ -528,21 +528,21 @@ body {
   }
 
   .swal2-select {
-    color: lighten($swal2-black, 33);
-    font-size: $swal2-input-font-size;
-    padding: .375em .625em;
     min-width: 50%;
     max-width: 100%;
+    padding: .375em .625em;
+    color: lighten($swal2-black, 33);
+    font-size: $swal2-input-font-size;
   }
 
   .swal2-radio,
   .swal2-checkbox {
-    justify-content: center;
     align-items: center;
+    justify-content: center;
 
     label {
-      font-size: $swal2-input-font-size;
       margin: 0 .6em;
+      font-size: $swal2-input-font-size;
     }
 
     input {
@@ -551,28 +551,28 @@ body {
   }
 
   .swal2-validationerror {
+    display: none;
     align-items: center;
     justify-content: center;
-    background-color: lighten($swal2-black, 94);
-    overflow: hidden;
     padding: .625em;
+    background-color: lighten($swal2-black, 94);
     color: lighten($swal2-black, 50);
     font-size: $swal2-validation-font-size;
     font-weight: 300;
-    display: none;
+    overflow: hidden;
 
     &::before {
-      content: '!';
       display: inline-block;
       width: 1.5em;
       height: 1.5em;
+      margin: 0 .625em;
       border-radius: 50%;
       background-color: $swal2-validationerror-background;
       color: $swal2-validationerror-color;
-      line-height: 1.5em;
       font-weight: 600;
+      line-height: 1.5em;
       text-align: center;
-      margin: 0 .625em;
+      content: '!';
     }
   }
 }
@@ -602,16 +602,16 @@ body {
 }
 
 .swal2-icon {
+  position: relative;
+  justify-content: center;
   width: 80px;
   height: 80px;
-  line-height: 80px;
+  margin: 1.25em auto 1.875em;
   border: 4px solid transparent;
   border-radius: 50%;
-  margin: 1.25em auto 1.875em;
-  justify-content: center;
-  position: relative;
-  box-sizing: content-box;
+  line-height: 80px;
   cursor: default;
+  box-sizing: content-box;
   user-select: none;
 
   &.swal2-error {
@@ -623,22 +623,22 @@ body {
     }
 
     [class^='swal2-x-mark-line'] {
-      position: absolute;
-      height: 5px;
-      width: 47px;
-      background-color: $swal2-error;
       display: block;
+      position: absolute;
       top: 37px;
+      width: 47px;
+      height: 5px;
       border-radius: 2px;
+      background-color: $swal2-error;
 
       &[class$='left'] {
-        transform: rotate(45deg);
         left: 17px;
+        transform: rotate(45deg);
       }
 
       &[class$='right'] {
-        transform: rotate(-45deg);
         right: 16px;
+        transform: rotate(-45deg);
       }
     }
   }
@@ -646,104 +646,94 @@ body {
   &.swal2-warning,
   &.swal2-info,
   &.swal2-question {
+    margin: .333333em auto .5em;
     font-family: $swal2-font;
     font-size: 3.75em;
-    margin: .333333em auto .5em;
   }
 
   &.swal2-warning {
-    color: $swal2-warning;
     border-color: lighten($swal2-warning, 7);
+    color: $swal2-warning;
   }
 
   &.swal2-info {
-    color: $swal2-info;
     border-color: lighten($swal2-info, 20);
+    color: $swal2-info;
   }
 
   &.swal2-question {
-    color: $swal2-question;
     border-color: lighten($swal2-question, 20);
+    color: $swal2-question;
   }
 
   &.swal2-success {
     border-color: $swal2-success;
 
     [class^='swal2-success-circular-line'] { // Emulate moving circular line
-      border-radius: 50%;
       position: absolute;
       width: 60px;
       height: 120px;
       transform: rotate(45deg);
+      border-radius: 50%;
 
       &[class$='left'] {
-        border-radius: 120px 0 0 120px;
         top: -7px;
         left: -33px;
-
         transform: rotate(-45deg);
         transform-origin: 60px 60px;
+        border-radius: 120px 0 0 120px;
       }
 
       &[class$='right'] {
-        border-radius: 0 120px 120px 0;
         top: -11px;
         left: 30px;
-
         transform: rotate(-45deg);
         transform-origin: 0 60px;
+        border-radius: 0 120px 120px 0;
       }
     }
 
     .swal2-success-ring { // Ring
+      position: absolute;
+      top: -4px;
+      left: -4px;
       width: 80px;
       height: 80px;
       border: 4px solid $swal2-success-border;
       border-radius: 50%;
-      box-sizing: content-box;
-
-      position: absolute;
-      left: -4px;
-      top: -4px;
       z-index: 2;
+      box-sizing: content-box;
     }
 
     .swal2-success-fix { // Hide corners left from animation
+      position: absolute;
+      top: 8px;
+      left: 26px;
       width: 7px;
       height: 90px;
-
-      position: absolute;
-      left: 26px;
-      top: 8px;
-      z-index: 1;
-
       transform: rotate(-45deg);
+      z-index: 1;
     }
 
     [class^='swal2-success-line'] {
-      height: 5px;
-      background-color: $swal2-success;
       display: block;
-      border-radius: 2px;
-
       position: absolute;
+      height: 5px;
+      border-radius: 2px;
+      background-color: $swal2-success;
       z-index: 2;
 
       &[class$='tip'] {
-        width: 25px;
-
-        left: 14px;
         top: 46px;
-
+        left: 14px;
+        width: 25px;
         transform: rotate(45deg);
       }
 
       &[class$='long'] {
-        width: 47px;
-
-        right: 8px;
         top: 38px;
-
+        right: 8px;
+        width: 47px;
         transform: rotate(-45deg);
       }
     }
@@ -754,10 +744,10 @@ body {
   $lightblue: #add8e6;
   $blue: #3085d6;
 
-  font-weight: 600;
-  padding: 0;
-  margin: 0 0 1.25em;
   align-items: center;
+  margin: 0 0 1.25em;
+  padding: 0;
+  font-weight: 600;
 
   li {
     display: inline-block;
@@ -765,13 +755,13 @@ body {
   }
 
   .swal2-progresscircle {
-    background: $blue;
-    border-radius: 2em;
-    color: $swal2-white;
+    width: 2em;
     height: 2em;
+    border-radius: 2em;
+    background: $blue;
+    color: $swal2-white;
     line-height: 2em;
     text-align: center;
-    width: 2em;
     z-index: 20;
 
     &:first-child {
@@ -796,10 +786,10 @@ body {
   }
 
   .swal2-progressline {
-    background: $blue;
-    height: .4em;
     width: $swal2-progress-steps-distance;
+    height: .4em;
     margin: 0 -1px;
+    background: $blue;
     z-index: 10;
   }
 }
@@ -861,8 +851,8 @@ body {
 // Right-to-left support
 [dir='rtl'] {
   .swal2-close {
-    left: 8px;
     right: auto;
+    left: 8px;
   }
 }
 
@@ -871,59 +861,59 @@ body {
 
 @keyframes animate-success-tip {
   0% {
-    width: 0;
-    left: 1px;
     top: 19px;
+    left: 1px;
+    width: 0;
   }
 
   54% {
-    width: 0;
-    left: 2px;
     top: 17px;
+    left: 2px;
+    width: 0;
   }
 
   70% {
-    width: 50px;
-    left: -6px;
     top: 35px;
+    left: -6px;
+    width: 50px;
   }
 
   84% {
-    width: 17px;
-    left: 21px;
     top: 48px;
+    left: 21px;
+    width: 17px;
   }
 
   100% {
-    width: 25px;
-    left: 14px;
     top: 45px;
+    left: 14px;
+    width: 25px;
   }
 }
 
 @keyframes animate-success-long {
   0% {
-    width: 0;
-    right: 46px;
     top: 54px;
+    right: 46px;
+    width: 0;
   }
 
   65% {
-    width: 0;
-    right: 46px;
     top: 54px;
+    right: 46px;
+    width: 0;
   }
 
   84% {
-    width: 55px;
-    right: 0;
     top: 35px;
+    right: 0;
+    width: 55px;
   }
 
   100% {
-    width: 47px;
-    right: 8px;
     top: 38px;
+    right: 8px;
+    width: 47px;
   }
 }
 
@@ -982,25 +972,25 @@ body {
 
 @keyframes animate-x-mark {
   0% {
-    transform: scale(.4);
     margin-top: 26px;
+    transform: scale(.4);
     opacity: 0;
   }
 
   50% {
-    transform: scale(.4);
     margin-top: 26px;
+    transform: scale(.4);
     opacity: 0;
   }
 
   80% {
-    transform: scale(1.15);
     margin-top: -6px;
+    transform: scale(1.15);
   }
 
   100% {
-    transform: scale(1);
     margin-top: 0;
+    transform: scale(1);
     opacity: 1;
   }
 }

--- a/src/toasts.scss
+++ b/src/toasts.scss
@@ -18,8 +18,8 @@ body {
 
         .swal2-input {
           height: 2em;
-          font-size: $swal2-toast-input-font-size;
           margin: .3125em auto;
+          font-size: $swal2-toast-input-font-size;
         }
 
         .swal2-validationerror {
@@ -38,76 +38,76 @@ body {
 
       &.swal2-top {
         top: 0;
-        left: 50%;
-        bottom: auto;
         right: auto;
+        bottom: auto;
+        left: 50%;
         transform: translateX(-50%);
       }
 
       &.swal2-top-end,
       &.swal2-top-right {
         top: 0;
-        left: auto;
-        bottom: auto;
         right: 0;
+        bottom: auto;
+        left: auto;
       }
 
       &.swal2-top-start,
       &.swal2-top-left {
         top: 0;
-        left: 0;
-        bottom: auto;
         right: auto;
+        bottom: auto;
+        left: 0;
       }
 
       &.swal2-center-start,
       &.swal2-center-left {
         top: 50%;
-        left: 0;
-        bottom: auto;
         right: auto;
+        bottom: auto;
+        left: 0;
         transform: translateY(-50%);
       }
 
       &.swal2-center {
         top: 50%;
-        left: 50%;
-        bottom: auto;
         right: auto;
+        bottom: auto;
+        left: 50%;
         transform: translate(-50%, -50%);
       }
 
       &.swal2-center-end,
       &.swal2-center-right {
         top: 50%;
-        left: auto;
-        bottom: auto;
         right: 0;
+        bottom: auto;
+        left: auto;
         transform: translateY(-50%);
       }
 
       &.swal2-bottom-start,
       &.swal2-bottom-left {
         top: auto;
-        left: 0;
-        bottom: 0;
         right: auto;
+        bottom: 0;
+        left: 0;
       }
 
       &.swal2-bottom {
         top: auto;
-        left: 50%;
-        bottom: 0;
         right: auto;
+        bottom: 0;
+        left: 50%;
         transform: translateX(-50%);
       }
 
       &.swal2-bottom-end,
       &.swal2-bottom-right {
         top: auto;
-        left: auto;
-        bottom: 0;
         right: 0;
+        bottom: 0;
+        left: auto;
       }
     }
   }
@@ -115,21 +115,21 @@ body {
 
 .swal2-popup {
   &.swal2-toast {
-    width: $swal2-toast-width;
-    padding: $swal2-toast-padding;
     flex-direction: row;
     align-items: center;
-    overflow-y: hidden;
+    width: $swal2-toast-width;
+    padding: $swal2-toast-padding;
     box-shadow: 0 0 10px $swal2-box-shadow;
+    overflow-y: hidden;
 
     .swal2-header {
       flex-direction: row;
     }
 
     .swal2-title {
-      font-size: $swal2-toast-title-font-size;
       justify-content: flex-start;
       margin: 0 .6em;
+      font-size: $swal2-toast-title-font-size;
     }
 
     .swal2-close {
@@ -137,8 +137,8 @@ body {
     }
 
     .swal2-content {
-      font-size: $swal2-toast-content-font-size;
       justify-content: flex-start;
+      font-size: $swal2-toast-content-font-size;
     }
 
     .swal2-icon {
@@ -180,8 +180,8 @@ body {
     }
 
     .swal2-actions {
-      margin: 0 .3125em;
       height: auto;
+      margin: 0 .3125em;
     }
 
     .swal2-styled {
@@ -198,26 +198,25 @@ body {
       border-color: $swal2-success;
 
       [class^='swal2-success-circular-line'] { // Emulate moving circular line
-        border-radius: 50%;
         position: absolute;
         width: 32px;
         height: 45px;
         transform: rotate(45deg);
+        border-radius: 50%;
 
         &[class$='left'] {
-          border-radius: 64px 0 0 64px;
           top: -4px;
           left: -15px;
-
           transform: rotate(-45deg);
           transform-origin: 32px 32px;
+          border-radius: 64px 0 0 64px;
         }
 
         &[class$='right'] {
-          border-radius: 0 64px 64px 0;
           top: -4px;
           left: 15px;
           transform-origin: 0 32px;
+          border-radius: 0 64px 64px 0;
         }
       }
 
@@ -227,25 +226,25 @@ body {
       }
 
       .swal2-success-fix {
+        top: 0;
+        left: 7px;
         width: 7px;
         height: 43px;
-        left: 7px;
-        top: 0;
       }
 
       [class^='swal2-success-line'] {
         height: 5px;
 
         &[class$='tip'] {
-          width: 12px;
-          left: 3px;
           top: 18px;
+          left: 3px;
+          width: 12px;
         }
 
         &[class$='long'] {
-          width: 22px;
-          right: 3px;
           top: 15px;
+          right: 3px;
+          width: 22px;
         }
       }
     }
@@ -308,58 +307,58 @@ body {
 
 @keyframes animate-toast-success-tip {
   0% {
-    width: 0;
-    left: 1px;
     top: 9px;
+    left: 1px;
+    width: 0;
   }
 
   54% {
-    width: 0;
-    left: 2px;
     top: 2px;
+    left: 2px;
+    width: 0;
   }
 
   70% {
-    width: 26px;
-    left: -4px;
     top: 10px;
+    left: -4px;
+    width: 26px;
   }
 
   84% {
-    width: 8px;
-    left: 12px;
     top: 17px;
+    left: 12px;
+    width: 8px;
   }
 
   100% {
-    width: 12px;
-    left: 3px;
     top: 18px;
+    left: 3px;
+    width: 12px;
   }
 }
 
 @keyframes animate-toast-success-long {
   0% {
-    width: 0;
-    right: 22px;
     top: 26px;
+    right: 22px;
+    width: 0;
   }
 
   65% {
-    width: 0;
-    right: 15px;
     top: 20px;
+    right: 15px;
+    width: 0;
   }
 
   84% {
-    width: 18px;
-    right: 0;
     top: 15px;
+    right: 0;
+    width: 18px;
   }
 
   100% {
-    width: 22px;
-    right: 3px;
     top: 15px;
+    right: 3px;
+    width: 22px;
   }
 }


### PR DESCRIPTION
This PR doesn't change anything except CSS properties order.

---

While working on theming I realized that it's very hard to structure variables and CSS properties without the order.

Available options:
 - alphabetically
 - concentric, recess, smacss: https://github.com/brigade/scss-lint/tree/master/data/property-sort-orders

I decided to choose the smacss as it's the maintainable one. It's almost the same as https://9elements.com/css-rule-order/ and I like that structure logic.

Contributors, if you have any objections to introducing the CSS properties order or to smacss, please raise your voice.