### PR TITLE
Prevent dialog closing by 'return false' in preConfirm

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -575,7 +575,7 @@ const sweetAlert = (...args) => {
         } else {
           preConfirmPromise.then(
             (preConfirmValue) => {
-              if (dom.isVisible(dom.getValidationError())) {
+              if (dom.isVisible(dom.getValidationError()) || preConfirmValue === false) {
                 sweetAlert.hideLoading()
               } else {
                 succeedWith(preConfirmValue || value)

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -846,3 +846,15 @@ QUnit.test('backdrop accepts css background param', (assert) => {
   assert.ok($('.swal2-container')[0].style.background.includes(backdrop))
 })
 
+QUnit.test('preConfirm return false', (assert) => {
+  swal({
+    preConfirm: () => {
+      return false
+    },
+    animation: false
+  })
+
+  swal.clickConfirm()
+  assert.ok(swal.isVisible())
+})
+


### PR DESCRIPTION
Maybe fixes #896 

If `preConfirm` returns `false`, it prevent a dialog from closing.

Example:

```js
preConfirm: () => confirm('Are you sure?')
```