### PR TITLE
.d.ts public API cleanup

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -237,9 +237,6 @@ declare module 'sweetalert2' {
 
     export type SweetAlertInputOptions = Map<string, string> | { [inputValue: string]: string };
 
-    export interface SweetAlertInputAttributes {
-        [attribute: string]: string;
-    }
 
     type ValueOrThunk<T> = T | (() => T);
 
@@ -625,7 +622,7 @@ declare module 'sweetalert2' {
          *
          * @default null
          */
-        inputAttributes?: SweetAlertInputAttributes;
+        inputAttributes?: { [attribute: string]: string; };
 
         /**
          * Validator for input field, may be async (Promise-returning) or sync.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -235,8 +235,6 @@ declare module 'sweetalert2' {
         timer = 'timer',
     }
 
-    export type SweetAlertInputOptions = Map<string, string> | { [inputValue: string]: string };
-
     type SyncOrAsync<T> = T | Promise<T>;
 
     type ValueOrThunk<T> = T | (() => T);
@@ -599,7 +597,7 @@ declare module 'sweetalert2' {
          * If input parameter is set to "select" or "radio", you can provide options.
          * Object keys will represent options values, object values will represent options text values.
          */
-        inputOptions?: SyncOrAsync<SweetAlertInputOptions>;
+        inputOptions?: SyncOrAsync<Map<string, string> | { [inputValue: string]: string }>;
 
         /**
          * Automatically remove whitespaces from both ends of a result string.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -235,13 +235,13 @@ declare module 'sweetalert2' {
         timer = 'timer',
     }
 
-    export type SweetAlertBooleanFunction = () => boolean;
-
     export type SweetAlertInputOptions = Map<string, string> | { [inputValue: string]: string };
 
     export interface SweetAlertInputAttributes {
         [attribute: string]: string;
     }
+
+    type ValueOrThunk<T> = T | (() => T);
 
     export interface SweetAlertOptions {
         /**
@@ -381,7 +381,7 @@ declare module 'sweetalert2' {
          *
          * @default true
          */
-        animation?: boolean | SweetAlertBooleanFunction;
+        animation?: ValueOrThunk<boolean>;
 
         /**
          * If set to false, the user can't dismiss the modal by clicking outside it.
@@ -390,7 +390,7 @@ declare module 'sweetalert2' {
          *
          * @default true
          */
-        allowOutsideClick?: boolean | SweetAlertBooleanFunction;
+        allowOutsideClick?: ValueOrThunk<boolean>;
 
         /**
          * If set to false, the user can't dismiss the modal by pressing the Escape key.
@@ -399,7 +399,7 @@ declare module 'sweetalert2' {
          *
          * @default true
          */
-        allowEscapeKey?: boolean | SweetAlertBooleanFunction;
+        allowEscapeKey?: ValueOrThunk<boolean>;
 
         /**
          * If set to false, the user can't confirm the modal by pressing the Enter or Space keys,
@@ -408,7 +408,7 @@ declare module 'sweetalert2' {
          *
          * @default true
          */
-        allowEnterKey?: boolean | SweetAlertBooleanFunction;
+        allowEnterKey?: ValueOrThunk<boolean>;
 
         /**
          * If set to false, a "Confirm"-button will not be shown.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -221,12 +221,6 @@ declare module 'sweetalert2' {
         function noop(): void;
     }
 
-    export type SweetAlertType = 'success' | 'error' | 'warning' | 'info' | 'question' | undefined;
-
-    export type SweetAlertInputType =
-        'text' | 'email' | 'password' | 'number' | 'tel' | 'range' | 'textarea' | 'select' | 'radio' | 'checkbox' |
-        'file' | 'url' | undefined;
-
     export enum SweetAlertDismissReason {
         cancel = 'cancel',
         backdrop = 'overlay',
@@ -234,6 +228,8 @@ declare module 'sweetalert2' {
         esc = 'esc',
         timer = 'timer',
     }
+
+    export type SweetAlertType = 'success' | 'error' | 'warning' | 'info' | 'question';
 
     type SyncOrAsync<T> = T | Promise<T>;
 
@@ -318,7 +314,9 @@ declare module 'sweetalert2' {
          *
          * @default null
          */
-        input?: SweetAlertInputType;
+        input?:
+            'text' | 'email' | 'password' | 'number' | 'tel' | 'range' | 'textarea' | 'select' | 'radio' | 'checkbox' |
+            'file' | 'url';
 
         /**
          * Modal window width, including paddings (box-sizing: border-box). Can be in px or %.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -237,6 +237,7 @@ declare module 'sweetalert2' {
 
     export type SweetAlertInputOptions = Map<string, string> | { [inputValue: string]: string };
 
+    type SyncOrAsync<T> = T | Promise<T>;
 
     type ValueOrThunk<T> = T | (() => T);
 
@@ -543,7 +544,7 @@ declare module 'sweetalert2' {
          *
          * @default null
          */
-        preConfirm?: (inputValue: any) => Promise<any | void> | any | void;
+        preConfirm?: (inputValue: any) => SyncOrAsync<any | void>;
 
         /**
          * Add a customized icon for the modal. Should contain a string with the path or URL to the image.
@@ -598,7 +599,7 @@ declare module 'sweetalert2' {
          * If input parameter is set to "select" or "radio", you can provide options.
          * Object keys will represent options values, object values will represent options text values.
          */
-        inputOptions?: SweetAlertInputOptions | Promise<SweetAlertInputOptions>;
+        inputOptions?: SyncOrAsync<SweetAlertInputOptions>;
 
         /**
          * Automatically remove whitespaces from both ends of a result string.
@@ -636,7 +637,7 @@ declare module 'sweetalert2' {
          *
          * @default null
          */
-        inputValidator?: (inputValue: any) => Promise<string | null> | string | null;
+        inputValidator?: (inputValue: any) => SyncOrAsync<string | null>;
 
         /**
          * A custom CSS class for the input field.


### PR DESCRIPTION
I removed a few one-off types that have been created by imitation, and I've introduced `ValueOrThunk<T>` and `SyncOrAsync<T>` to replace them.

The new types are internal and are not exported for public use (<s>`import { ValueOrThunk } from ...`</s>).

The removal of previously-exposed types is a breaking change, but like in a similar scenario we've had recently, users are not likely to have used them directly (ie. imported) anyway.