### PR TITLE
chore(travis): re-enable bundlesize

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "fix:lint": "standard --fix",
     "test": "npm run build && npm run check",
     "build": "gulp build",
-    "check": "npm run check:tests && npm run check:ts",
+    "check": "npm run check:bundlesize && npm run check:tests && npm run check:ts",
     "check:bundlesize": "bundlesize -f dist/sweetalert2.all.min.js -s 15kB",
     "check:tests": "testem ci",
     "check:ts": "tsc sweetalert2.d.ts",


### PR DESCRIPTION
Fixes https://github.com/sweetalert2/sweetalert2/issues/912

Something happened to the bundlesize token. I've refreshed it and now it works well. 

How to set the bundlesize token:

1. go to https://github.com/login/oauth/authorize?scope=repo%3Astatus&client_id=6756cb03a8d6528aca5a
2. copy-paste the token from there to Travis env variables: https://travis-ci.org/sweetalert2/sweetalert2/settings