### PR TITLE
fix(iOS): remove harming .swal2-iosfix styles

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -20,12 +20,6 @@ body {
 }
 
 body {
-  &.swal2-iosfix {
-    position: fixed;
-    right: 0;
-    left: 0;
-  }
-
   &.swal2-no-backdrop {
 
     .swal2-shown {


### PR DESCRIPTION
Hopefully fix #920

Those styles were introduced in https://github.com/sweetalert2/sweetalert2/commit/4a2d36b494fbae879c9a17f92af90cb61f03b4d5 but I tested and it seems that they don't make any difference, just harming.