### PR TITLE
.d.ts: improve type inference for returned Promise<> in swal() calls

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -26,7 +26,7 @@ declare module 'sweetalert2' {
      * @deprecated
      * swal() overload for legacy alerts that use { useRejections: true }.
      */
-    function swal(settings: SweetAlertOptions & { useRejections: true }): Promise<number>;
+    function swal(settings: SweetAlertOptions & { useRejections: true }): Promise<any>;
 
     /**
      * A namespace inside the default function, containing utility function for controlling the currently-displayed

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -6,7 +6,7 @@ declare module 'sweetalert2' {
      *   import swal from 'sweetalert2';
      *   swal('The Internet?', 'That thing is still around?', 'question');
      */
-    function swal(title: string, message?: string, type?: SweetAlertType): Promise<any>;
+    function swal(title: string, message?: string, type?: SweetAlertType): Promise<SweetAlertResult>;
 
     /**
      * Function to display a SweetAlert modal, with an object of options, all being optional.
@@ -20,7 +20,13 @@ declare module 'sweetalert2' {
      *     timer: 2000
      *   })
      */
-    function swal(settings: SweetAlertOptions): Promise<any>;
+    function swal(settings: SweetAlertOptions & { useRejections?: false }): Promise<SweetAlertResult>;
+
+    /**
+     * @deprecated
+     * swal() overload for legacy alerts that use { useRejections: true }.
+     */
+    function swal(settings: SweetAlertOptions & { useRejections: true }): Promise<number>;
 
     /**
      * A namespace inside the default function, containing utility function for controlling the currently-displayed
@@ -230,6 +236,11 @@ declare module 'sweetalert2' {
     }
 
     export type SweetAlertType = 'success' | 'error' | 'warning' | 'info' | 'question';
+
+    export interface SweetAlertResult {
+        value?: any;
+        dismiss?: SweetAlertDismissReason;
+    }
 
     type SyncOrAsync<T> = T | Promise<T>;
 
@@ -683,15 +694,6 @@ declare module 'sweetalert2' {
          * @default null
          */
         onClose?: (modalElement: HTMLElement) => void;
-
-        /**
-         * Determines whether dismissals (outside click, cancel button, close button, Esc key, timer) should
-         * resolve with an object of the format `{ dismiss: SweetAlertDismissReason }` or reject the promise.
-         *
-         * @default false
-         * @deprecated
-         */
-        useRejections?: boolean;
 
         /**
          * Determines whether given `inputValidator` and `preConfirm` functions should be expected to to signal


### PR DESCRIPTION
`swal()` is well-known to return a `Promise<any>` in its TypeScript declaration.

That was true before version 7.0 which resolves by default with an object of form `{ value?: any; dimiss?: SweetAlertDismissReason; }`.

Now we're in the post-`useRejections: true` epoch, and default Swals always return such object, but the signature is still `Promise<any>`. Not very convenient when you don't use `useRejections: true`.

That's why I've introduced `swal()` overloads for both `useRejections: true` and `useRejections: false`:

```ts
function swal(settings: SweetAlertOptions & { useRejections?: false }): Promise<SweetAlertResult>;

function swal(settings: SweetAlertOptions & { useRejections: true }): Promise<any>;

export interface SweetAlertResult {
    value?: any;
    dismiss?: SweetAlertDismissReason;
}
```

Now, when you use `swal()`, TypeScript will select the appropriate overload so you get the most appropriate result type:

 - `swal({ ... })` → `Promise<SweetAlertResult>`
 - `swal({ useRejections: false })` → `Promise<SweetAlertResult>`
 - `swal({ useRejections: true })` → `Promise<any>`

Less concisely:

```ts
import swal, { SweetAlertResult } from 'sweetalert2';

(async () => {
    let result: SweetAlertResult;

    //=> Normal call, this will return a typed Promise result with { value, dismiss }
    result = await swal({});

    //=> Same as this signature
    result = await swal({ useRejections: true });

    //=> Now the result is typed and we can't do shit with it
    // error TS2339: Property 'limonte' does not exist on type 'SweetAlertResult'.
    const val1 = result.limonte;

    // error TS2322: Type 'SweetAlertDismissReason' is not assignable to type 'number'.
    const val2: number = result.dismiss;

    //=> Legacy call, recognized as the alternative swal() signature.
    //   It returns the old 'untyped' Promise<any> as it resolves with any value preConfirm/inputs could return
    const legacyResult = await swal({ useRejections: true }); // legacyResult is of type 'any', not { value, dismiss }
});
```

### Going further

Please note that it would be possible to type that `SweetAlertResult` type so it would look like:

```ts
export interface SweetAlertResult<T> {
    value?: T;
    dismiss?: SweetAlertDismissReason;
}
```

And the type of `T` could be inferred by TypeScript based on your swal options, for example, if you'd use a `preConfirm` that resolves with a `number`, the final swal result would be `{ value?: number, dimiss?: SweetAlertResult }`.

But I don't see a way to implement that without breaking older TypeScript versions that don't support some features that would make this possible (defaults for generic type parameters, TS 2.3, pretty old but maybe not old enough yet).