### PR TITLE
Move animations to SASS variables

### DIFF
--- a/src/animations.scss
+++ b/src/animations.scss
@@ -1,0 +1,143 @@
+// Appearance animation
+@keyframes swal2-show {
+  0% {
+    transform: scale(.7);
+  }
+
+  45% {
+    transform: scale(1.05);
+  }
+
+  80% {
+    transform: scale(.95);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
+// Disppearance animation
+@keyframes swal2-hide {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(.5);
+    opacity: 0;
+  }
+}
+
+// Success icon animations
+@keyframes swal2-animate-success-line-tip {
+  0% {
+    top: 19px;
+    left: 1px;
+    width: 0;
+  }
+
+  54% {
+    top: 17px;
+    left: 2px;
+    width: 0;
+  }
+
+  70% {
+    top: 35px;
+    left: -6px;
+    width: 50px;
+  }
+
+  84% {
+    top: 48px;
+    left: 21px;
+    width: 17px;
+  }
+
+  100% {
+    top: 45px;
+    left: 14px;
+    width: 25px;
+  }
+}
+@keyframes swal2-animate-success-line-long {
+  0% {
+    top: 54px;
+    right: 46px;
+    width: 0;
+  }
+
+  65% {
+    top: 54px;
+    right: 46px;
+    width: 0;
+  }
+
+  84% {
+    top: 35px;
+    right: 0;
+    width: 55px;
+  }
+
+  100% {
+    top: 38px;
+    right: 8px;
+    width: 47px;
+  }
+}
+@keyframes swal2-rotate-success-circular-line {
+  0% {
+    transform: rotate(-45deg);
+  }
+
+  5% {
+    transform: rotate(-45deg);
+  }
+
+  12% {
+    transform: rotate(-405deg);
+  }
+
+  100% {
+    transform: rotate(-405deg);
+  }
+}
+
+// Error icon animations
+@keyframes swal2-animate-error-x-mark {
+  0% {
+    margin-top: 26px;
+    transform: scale(.4);
+    opacity: 0;
+  }
+
+  50% {
+    margin-top: 26px;
+    transform: scale(.4);
+    opacity: 0;
+  }
+
+  80% {
+    margin-top: -6px;
+    transform: scale(1.15);
+  }
+
+  100% {
+    margin-top: 0;
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+@keyframes swal2-animate-error-icon {
+  0% {
+    transform: rotateX(100deg);
+    opacity: 0;
+  }
+
+  100% {
+    transform: rotateX(0deg);
+    opacity: 1;
+  }
+}

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -203,19 +203,7 @@ const setParameters = (params) => {
 
     // Animate icon
     if (params.animation) {
-      switch (params.type) {
-        case 'success':
-          dom.addClass(icon, 'swal2-animate-success-icon')
-          dom.addClass(icon.querySelector('.swal2-success-line-tip'), 'swal2-animate-success-line-tip')
-          dom.addClass(icon.querySelector('.swal2-success-line-long'), 'swal2-animate-success-line-long')
-          break
-        case 'error':
-          dom.addClass(icon, 'swal2-animate-error-icon')
-          dom.addClass(icon.querySelector('.swal2-x-mark'), 'swal2-animate-x-mark')
-          break
-        default:
-          break
-      }
+      dom.addClass(icon, `swal2-animate-${params.type}-icon`)
     }
   }
 

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -2,6 +2,7 @@
 // github.com/sweetalert2/sweetalert2
 
 @import 'variables';
+@import 'animations';
 @import 'mixins';
 
 @import 'toasts';
@@ -326,7 +327,7 @@ body {
           color: transparent;
           cursor: default;
           box-sizing: border-box;
-          animation: rotate-loading 1.5s linear 0s infinite normal;
+          animation: swal2-rotate-loading 1.5s linear 0s infinite normal;
           user-select: none;
         }
 
@@ -348,7 +349,7 @@ body {
             border-right-color: transparent;
             box-shadow: 1px 1px 1px $swal2-white;
             content: '';
-            animation: rotate-loading 1.5s linear 0s infinite normal;
+            animation: swal2-rotate-loading 1.5s linear 0s infinite normal;
           }
         }
       }
@@ -802,39 +803,8 @@ body {
   -webkit-tap-highlight-color: $swal2-transparent;
 }
 
-// Modal animations
-@keyframes showSweetAlert {
-  0% {
-    transform: scale(.7);
-  }
-
-  45% {
-    transform: scale(1.05);
-  }
-
-  80% {
-    transform: scale(.95);
-  }
-
-  100% {
-    transform: scale(1);
-  }
-}
-
-@keyframes hideSweetAlert {
-  0% {
-    transform: scale(1);
-    opacity: 1;
-  }
-
-  100% {
-    transform: scale(.5);
-    opacity: 0;
-  }
-}
-
 .swal2-show {
-  animation: showSweetAlert .3s;
+  animation: $swal2-show-animation;
 
   &.swal2-noanimation {
     animation: none;
@@ -842,7 +812,7 @@ body {
 }
 
 .swal2-hide {
-  animation: hideSweetAlert .15s forwards;
+  animation: $swal2-hide-animation;
 
   &.swal2-noanimation {
     animation: none;
@@ -860,148 +830,30 @@ body {
 
 
 // Success icon animation
-
-@keyframes animate-success-tip {
-  0% {
-    top: 19px;
-    left: 1px;
-    width: 0;
+.swal2-animate-success-icon {
+  .swal2-success-line-tip {
+    animation: $swal2-success-line-tip-animation;
   }
 
-  54% {
-    top: 17px;
-    left: 2px;
-    width: 0;
+  .swal2-success-line-long {
+    animation: $swal2-success-line-long-animation;
   }
 
-  70% {
-    top: 35px;
-    left: -6px;
-    width: 50px;
-  }
-
-  84% {
-    top: 48px;
-    left: 21px;
-    width: 17px;
-  }
-
-  100% {
-    top: 45px;
-    left: 14px;
-    width: 25px;
+  .swal2-success-circular-line-right {
+    animation: $swal2-success-circular-line-animation;
   }
 }
-
-@keyframes animate-success-long {
-  0% {
-    top: 54px;
-    right: 46px;
-    width: 0;
-  }
-
-  65% {
-    top: 54px;
-    right: 46px;
-    width: 0;
-  }
-
-  84% {
-    top: 35px;
-    right: 0;
-    width: 55px;
-  }
-
-  100% {
-    top: 38px;
-    right: 8px;
-    width: 47px;
-  }
-}
-
-@keyframes rotatePlaceholder {
-  0% {
-    transform: rotate(-45deg);
-  }
-
-  5% {
-    transform: rotate(-45deg);
-  }
-
-  12% {
-    transform: rotate(-405deg);
-  }
-
-  100% {
-    transform: rotate(-405deg);
-  }
-}
-
-.swal2-animate-success-line-tip {
-  animation: animate-success-tip .75s;
-}
-
-.swal2-animate-success-line-long {
-  animation: animate-success-long .75s;
-}
-
-.swal2-success {
-  &.swal2-animate-success-icon {
-    .swal2-success-circular-line-right {
-      animation: rotatePlaceholder 4.25s ease-in;
-    }
-  }
-}
-
 
 // Error icon animation
-
-@keyframes animate-error-icon {
-  0% {
-    transform: rotateX(100deg);
-    opacity: 0;
-  }
-
-  100% {
-    transform: rotateX(0deg);
-    opacity: 1;
-  }
-}
-
 .swal2-animate-error-icon {
-  animation: animate-error-icon .5s;
-}
+  animation: $swal2-error-icon-animation;
 
-@keyframes animate-x-mark {
-  0% {
-    margin-top: 26px;
-    transform: scale(.4);
-    opacity: 0;
-  }
-
-  50% {
-    margin-top: 26px;
-    transform: scale(.4);
-    opacity: 0;
-  }
-
-  80% {
-    margin-top: -6px;
-    transform: scale(1.15);
-  }
-
-  100% {
-    margin-top: 0;
-    transform: scale(1);
-    opacity: 1;
+  .swal2-x-mark {
+    animation: $swal2-error-x-mark-animation;
   }
 }
 
-.swal2-animate-x-mark {
-  animation: animate-x-mark .5s;
-}
-
-@keyframes rotate-loading {
+@keyframes swal2-rotate-loading {
   0% {
     transform: rotate(0deg);
   }

--- a/src/toasts.scss
+++ b/src/toasts.scss
@@ -257,12 +257,14 @@ body {
       animation: hideSweetToast .2s forwards;
     }
 
-    .swal2-animate-success-line-tip {
-      animation: animate-toast-success-tip .75s;
-    }
+    .swal2-animate-success-icon {
+      .swal2-success-line-tip {
+        animation: animate-toast-success-tip .75s;
+      }
 
-    .swal2-animate-success-line-long {
-      animation: animate-toast-success-long .75s;
+      .swal2-success-line-long {
+        animation: animate-toast-success-long .75s;
+      }
     }
   }
 }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -60,6 +60,15 @@ $swal2-close-button-size: 2.5em !default;
 
 $swal2-progress-steps-distance: 2.5em !default;
 
+// ANIMATIONS
+$swal2-show-animation: swal2-show .3s !default;
+$swal2-hide-animation: swal2-hide .15s forwards !default;
+$swal2-success-line-tip-animation: swal2-animate-success-line-tip .75s !default;
+$swal2-success-line-long-animation: swal2-animate-success-line-long .75s !default;
+$swal2-success-circular-line-animation: swal2-rotate-success-circular-line 4.25s ease-in !default;
+$swal2-error-icon-animation: swal2-animate-error-icon .5s !default;
+$swal2-error-x-mark-animation: swal2-animate-error-x-mark .5s !default;
+
 // CONFIRM BUTTON
 $swal2-confirm-button-border: 0 !default;
 $swal2-confirm-button-border-radius: .25em !default;


### PR DESCRIPTION
Connected to https://github.com/sweetalert2/sweetalert2/issues/922

This is badly needed for the implementation of the `minimal` theme.

New SASS variables:

- `$swal2-show-animation`
- `$swal2-hide-animation`
- `$swal2-success-line-tip-animation`
- `$swal2-success-line-long-animation`
- `$swal2-success-circular-line-animation`
- `$swal2-error-icon-animation`
- `$swal2-error-x-mark-animation`

The only one left `keyframes` in `sweetalert2.scss` is `swal2-rotate-loading`. I don't like the current implementation of loader, let's keep it as it is for now.