### PR TITLE
Simplify dom.show()

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -1272,7 +1272,7 @@ sweetAlert.showLoading = sweetAlert.enableLoading = () => {
   const cancelButton = dom.getCancelButton()
 
   dom.show(actions)
-  dom.show(confirmButton, 'inline-block')
+  dom.show(confirmButton)
   dom.addClass([popup, actions], swalClasses.loading)
   confirmButton.disabled = true
   cancelButton.disabled = true

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -270,12 +270,9 @@ export const getChildByClass = (elem, className) => {
   }
 }
 
-export const show = (elem, display) => {
-  if (!display) {
-    display = (elem.id === swalClasses.content) ? 'block' : 'flex'
-  }
+export const show = (elem) => {
   elem.style.opacity = ''
-  elem.style.display = display
+  elem.style.display = (elem.id === swalClasses.content) ? 'block' : 'flex'
 }
 
 export const hide = (elem) => {


### PR DESCRIPTION
The second parameter coming from pre-flexbox era, no need in it anymore.