### PR TITLE
Add AppVeyor CI to test against IE

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,36 @@
+# AppVeyor file
+# http://www.appveyor.com/docs/appveyor-yml
+
+# Build version format
+version: "{build}"
+
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
+# Scripts that are called at very beginning, before repo cloning
+init:
+  # Fix line endings on Windows
+  - git config --global core.autocrlf true
+
+# Test against this version of Node.js
+environment:
+  nodejs_version: "8"
+
+build: off
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - npm run build
+  - npm run check:tests:ie
+
+notifications:
+  - provider: Email
+    to:
+      - limon.monte@gmail.com
+    on_build_status_changed: true
+
+# Preserve node_modules between builds
+cache: node_modules -> appveyor.yml,package.json,yarn.lock

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -41,7 +41,8 @@ module.exports = function (config) {
       'karma-spec-reporter',
       'karma-sourcemap-loader',
       'karma-chrome-launcher',
-      'karma-firefox-launcher'
+      'karma-firefox-launcher',
+      'karma-ie-launcher'
     ]
   })
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "karma": "^2.0.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-firefox-launcher": "^1.1.0",
+    "karma-ie-launcher": "^1.0.0",
     "karma-qunit": "^1.2.1",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "^0.0.32",
@@ -94,6 +95,7 @@
     "check": "npm run check:bundlesize && npm run check:tests && npm run check:ts",
     "check:bundlesize": "bundlesize -f dist/sweetalert2.all.min.js -s 15kB",
     "check:tests": "karma start karma.conf.js --single-run --browsers Chrome,Firefox",
+    "check:tests:ie": "karma start karma.conf.js --single-run --browsers IE",
     "check:ts": "tsc sweetalert2.d.ts",
     "release": "node release"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4245,6 +4245,12 @@ karma-firefox-launcher@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz#2c47030452f04531eb7d13d4fc7669630bb93339"
 
+karma-ie-launcher@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/karma-ie-launcher/-/karma-ie-launcher-1.0.0.tgz#497986842c490190346cd89f5494ca9830c6d59c"
+  dependencies:
+    lodash "^4.6.1"
+
 karma-qunit@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/karma-qunit/-/karma-qunit-1.2.1.tgz#88252afd2127bc03b0cc31978ed6882b139f470a"
@@ -4596,7 +4602,7 @@ lodash@^3.10.1, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.1, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 


### PR DESCRIPTION
Closes #947

Travis doesn't provide Windows builds, so let's use AppVeyor

AFAIK it's the default CI option for Windows, e.g. lighthouse is using it https://github.com/GoogleChrome/lighthouse/blob/master/.appveyor.yml

I didn't add the AppVeyor status badge to README yet, let's fix all IE tests and then add the green AppVeyor badge, nobody like red badges :) 