### PR TITLE
fix: resetValidationError() shouldn't fail with the custom content

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -916,7 +916,9 @@ const sweetAlert = (...args) => {
     // Hide block with validation error
     sweetAlert.resetValidationError = () => {
       const validationError = dom.getValidationError()
-      dom.hide(validationError)
+      if (validationError) {
+        dom.hide(validationError)
+      }
 
       const input = getInput()
       if (input) {

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -814,3 +814,20 @@ QUnit.test('animation param evaluates a function', (assert) => {
   })
   assert.notOk($('.swal2-popup').hasClass('swal2-noanimation'))
 })
+
+QUnit.test('Custom content', (assert) => {
+  const done = assert.async()
+  swal({
+    showCancelButton: true,
+    onOpen: () => {
+      swal.getContent().textContent = 'Custom content'
+      swal.clickConfirm()
+    },
+    preConfirm: () => {
+      return 'Some data from custom control'
+    }
+  }).then(result => {
+    assert.ok(result.value)
+    done()
+  })
+})


### PR DESCRIPTION
Fixes #960