### PR TITLE
fix(release-script): install npm deps before running npm tasks

### DIFF
--- a/release.js
+++ b/release.js
@@ -45,6 +45,9 @@ assert.ok(['patch', 'minor', 'major'].includes(semver), 'Must specify the valid 
   log(`Merging from "${branchToPublish}" branch...`)
   await execute(`git merge ${branchToPublish}`)
 
+  log('Installing npm dependencies...')
+  await execute('yarn')
+
   log('Running the build...')
   await execute('npm run build')
 


### PR DESCRIPTION
While publishing the latest release this error occurred to me:

![](https://i.imgur.com/JJK7CAr.png)