### PR TITLE
Consistent properties on `swal` object/function

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -834,16 +834,7 @@ const sweetAlert = (...args) => {
       cancelButton.disabled = false
     }
 
-    sweetAlert.getTitle = () => dom.getTitle()
-    sweetAlert.getContent = () => dom.getContent()
     sweetAlert.getInput = () => getInput()
-    sweetAlert.getImage = () => dom.getImage()
-    sweetAlert.getButtonsWrapper = () => dom.getButtonsWrapper()
-    sweetAlert.getActions = () => dom.getActions()
-    sweetAlert.getConfirmButton = () => dom.getConfirmButton()
-    sweetAlert.getCancelButton = () => dom.getCancelButton()
-    sweetAlert.getFooter = () => dom.getFooter()
-    sweetAlert.isLoading = () => dom.isLoading()
 
     sweetAlert.enableButtons = () => {
       confirmButton.disabled = false
@@ -1334,6 +1325,16 @@ sweetAlert.adaptInputValidator = (legacyValidator) => {
       .then(() => undefined, validationError => validationError)
   }
 }
+
+sweetAlert.getTitle = () => dom.getTitle()
+sweetAlert.getContent = () => dom.getContent()
+sweetAlert.getImage = () => dom.getImage()
+sweetAlert.getButtonsWrapper = () => dom.getButtonsWrapper()
+sweetAlert.getActions = () => dom.getActions()
+sweetAlert.getConfirmButton = () => dom.getConfirmButton()
+sweetAlert.getCancelButton = () => dom.getCancelButton()
+sweetAlert.getFooter = () => dom.getFooter()
+sweetAlert.isLoading = () => dom.isLoading()
 
 sweetAlert.DismissReason = Object.freeze({
   cancel: 'cancel',

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -5,6 +5,7 @@ import * as dom from './utils/dom.js'
 
 let popupParams = Object.assign({}, defaultParams)
 let queue = []
+let currentContext
 
 let previousWindowKeyDown, windowOnkeydownOverridden
 
@@ -416,7 +417,7 @@ const sweetAlert = (...args) => {
     return false
   }
 
-  const context = {}
+  const context = currentContext = {}
 
   const params = context.params = Object.assign({}, popupParams)
 
@@ -507,32 +508,9 @@ const sweetAlert = (...args) => {
       domCache.popup.timeout = setTimeout(() => dismissWith('timer'), params.timer)
     }
 
-    // Get input element by specified type or, if type isn't specified, by params.input
-    const getInput = (inputType) => {
-      inputType = inputType || params.input
-      if (!inputType) {
-        return null
-      }
-      switch (inputType) {
-        case 'select':
-        case 'textarea':
-        case 'file':
-          return dom.getChildByClass(domCache.content, swalClasses[inputType])
-        case 'checkbox':
-          return domCache.popup.querySelector(`.${swalClasses.checkbox} input`)
-        case 'radio':
-          return domCache.popup.querySelector(`.${swalClasses.radio} input:checked`) ||
-            domCache.popup.querySelector(`.${swalClasses.radio} input:first-child`)
-        case 'range':
-          return domCache.popup.querySelector(`.${swalClasses.range} input`)
-        default:
-          return dom.getChildByClass(domCache.content, swalClasses.input)
-      }
-    }
-
     // Get the value of the popup input
     const getInputValue = () => {
-      const input = getInput()
+      const input = sweetAlert.getInput()
       if (!input) {
         return null
       }
@@ -551,7 +529,7 @@ const sweetAlert = (...args) => {
     // input autofocus
     if (params.input) {
       setTimeout(() => {
-        const input = getInput()
+        const input = sweetAlert.getInput()
         if (input) {
           dom.focusInput(input)
         }
@@ -763,7 +741,7 @@ const sweetAlert = (...args) => {
       ]
 
       if (e.key === 'Enter' && !e.isComposing) {
-        if (e.target === getInput()) {
+        if (e.target === sweetAlert.getInput()) {
           if (['textarea', 'file'].includes(params.input)) {
             return // do not submit
           }
@@ -822,123 +800,6 @@ const sweetAlert = (...args) => {
       window.onkeydown = handleKeyDown
     }
 
-    /**
-     * Show spinner instead of Confirm button and disable Cancel button
-     */
-    sweetAlert.hideLoading = sweetAlert.disableLoading = () => {
-      if (!params.showConfirmButton) {
-        dom.hide(domCache.confirmButton)
-        if (!params.showCancelButton) {
-          dom.hide(domCache.actions)
-        }
-      }
-      dom.removeClass([domCache.popup, domCache.actions], swalClasses.loading)
-      domCache.popup.removeAttribute('aria-busy')
-      domCache.popup.removeAttribute('data-loading')
-      domCache.confirmButton.disabled = false
-      domCache.cancelButton.disabled = false
-    }
-
-    sweetAlert.getInput = () => getInput()
-
-    sweetAlert.enableButtons = () => {
-      domCache.confirmButton.disabled = false
-      domCache.cancelButton.disabled = false
-    }
-
-    sweetAlert.disableButtons = () => {
-      domCache.confirmButton.disabled = true
-      domCache.cancelButton.disabled = true
-    }
-
-    sweetAlert.enableConfirmButton = () => {
-      domCache.confirmButton.disabled = false
-    }
-
-    sweetAlert.disableConfirmButton = () => {
-      domCache.confirmButton.disabled = true
-    }
-
-    sweetAlert.enableInput = () => {
-      const input = getInput()
-      if (!input) {
-        return false
-      }
-      if (input.type === 'radio') {
-        const radiosContainer = input.parentNode.parentNode
-        const radios = radiosContainer.querySelectorAll('input')
-        for (let i = 0; i < radios.length; i++) {
-          radios[i].disabled = false
-        }
-      } else {
-        input.disabled = false
-      }
-    }
-
-    sweetAlert.disableInput = () => {
-      const input = getInput()
-      if (!input) {
-        return false
-      }
-      if (input && input.type === 'radio') {
-        const radiosContainer = input.parentNode.parentNode
-        const radios = radiosContainer.querySelectorAll('input')
-        for (let i = 0; i < radios.length; i++) {
-          radios[i].disabled = true
-        }
-      } else {
-        input.disabled = true
-      }
-    }
-
-    // Show block with validation error
-    sweetAlert.showValidationError = (error) => {
-      domCache.validationError.innerHTML = error
-      const popupComputedStyle = window.getComputedStyle(domCache.popup)
-      domCache.validationError.style.marginLeft = `-${popupComputedStyle.getPropertyValue('padding-left')}`
-      domCache.validationError.style.marginRight = `-${popupComputedStyle.getPropertyValue('padding-right')}`
-      dom.show(domCache.validationError)
-
-      const input = getInput()
-      if (input) {
-        input.setAttribute('aria-invalid', true)
-        input.setAttribute('aria-describedBy', swalClasses.validationerror)
-        dom.focusInput(input)
-        dom.addClass(input, swalClasses.inputerror)
-      }
-    }
-
-    // Hide block with validation error
-    sweetAlert.resetValidationError = () => {
-      if (domCache.validationError) {
-        dom.hide(domCache.validationError)
-      }
-
-      const input = getInput()
-      if (input) {
-        input.removeAttribute('aria-invalid')
-        input.removeAttribute('aria-describedBy')
-        dom.removeClass(input, swalClasses.inputerror)
-      }
-    }
-
-    sweetAlert.getProgressSteps = () => {
-      return params.progressSteps
-    }
-
-    sweetAlert.setProgressSteps = (progressSteps) => {
-      params.progressSteps = progressSteps
-      setParameters(params)
-    }
-
-    sweetAlert.showProgressSteps = () => {
-      dom.show(domCache.progressSteps)
-    }
-
-    sweetAlert.hideProgressSteps = () => {
-      dom.hide(domCache.progressSteps)
-    }
-
     sweetAlert.enableButtons()
     sweetAlert.hideLoading()
     sweetAlert.resetValidationError()
@@ -953,7 +814,7 @@ const sweetAlert = (...args) => {
     for (let i = 0; i < inputTypes.length; i++) {
       const inputClass = swalClasses[inputTypes[i]]
       const inputContainer = dom.getChildByClass(domCache.content, inputClass)
-      input = getInput(inputTypes[i])
+      input = sweetAlert.getInput(inputTypes[i])
 
       // set attributes
       if (input) {
@@ -1059,7 +920,7 @@ const sweetAlert = (...args) => {
         break
       case 'checkbox':
         const checkbox = dom.getChildByClass(domCache.content, swalClasses.checkbox)
-        const checkboxInput = getInput('checkbox')
+        const checkboxInput = sweetAlert.getInput('checkbox')
         checkboxInput.type = 'checkbox'
         checkboxInput.value = 1
         checkboxInput.id = swalClasses.checkbox
@@ -1338,6 +1199,184 @@ sweetAlert.getConfirmButton = () => dom.getConfirmButton()
 sweetAlert.getCancelButton = () => dom.getCancelButton()
 sweetAlert.getFooter = () => dom.getFooter()
 sweetAlert.isLoading = () => dom.isLoading()
+
+/**
+ * Show spinner instead of Confirm button and disable Cancel button
+ */
+sweetAlert.hideLoading = sweetAlert.disableLoading = () => {
+  if (currentContext) {
+    const {params, domCache} = currentContext
+    if (!params.showConfirmButton) {
+      dom.hide(domCache.confirmButton)
+      if (!params.showCancelButton) {
+        dom.hide(domCache.actions)
+      }
+    }
+    dom.removeClass([domCache.popup, domCache.actions], swalClasses.loading)
+    domCache.popup.removeAttribute('aria-busy')
+    domCache.popup.removeAttribute('data-loading')
+    domCache.confirmButton.disabled = false
+    domCache.cancelButton.disabled = false
+  }
+}
+
+// Get input element by specified type or, if type isn't specified, by params.input
+sweetAlert.getInput = (inputType) => {
+  if (currentContext) {
+    const {params, domCache} = currentContext
+    inputType = inputType || params.input
+    if (!inputType) {
+      return null
+    }
+    switch (inputType) {
+      case 'select':
+      case 'textarea':
+      case 'file':
+        return dom.getChildByClass(domCache.content, swalClasses[inputType])
+      case 'checkbox':
+        return domCache.popup.querySelector(`.${swalClasses.checkbox} input`)
+      case 'radio':
+        return domCache.popup.querySelector(`.${swalClasses.radio} input:checked`) ||
+          domCache.popup.querySelector(`.${swalClasses.radio} input:first-child`)
+      case 'range':
+        return domCache.popup.querySelector(`.${swalClasses.range} input`)
+      default:
+        return dom.getChildByClass(domCache.content, swalClasses.input)
+    }
+  }
+}
+
+sweetAlert.enableButtons = () => {
+  if (currentContext) {
+    const {domCache} = currentContext
+    domCache.confirmButton.disabled = false
+    domCache.cancelButton.disabled = false
+  }
+}
+
+sweetAlert.disableButtons = () => {
+  if (currentContext) {
+    const {domCache} = currentContext
+    domCache.confirmButton.disabled = true
+    domCache.cancelButton.disabled = true
+  }
+}
+
+sweetAlert.enableConfirmButton = () => {
+  if (currentContext) {
+    const {domCache} = currentContext
+    domCache.confirmButton.disabled = false
+  }
+}
+
+sweetAlert.disableConfirmButton = () => {
+  if (currentContext) {
+    const {domCache} = currentContext
+    domCache.confirmButton.disabled = true
+  }
+}
+
+sweetAlert.enableInput = () => {
+  if (currentContext) {
+    const input = sweetAlert.getInput()
+    if (!input) {
+      return false
+    }
+    if (input.type === 'radio') {
+      const radiosContainer = input.parentNode.parentNode
+      const radios = radiosContainer.querySelectorAll('input')
+      for (let i = 0; i < radios.length; i++) {
+        radios[i].disabled = false
+      }
+    } else {
+      input.disabled = false
+    }
+  }
+}
+
+sweetAlert.disableInput = () => {
+  if (currentContext) {
+    const input = sweetAlert.getInput()
+    if (!input) {
+      return false
+    }
+    if (input && input.type === 'radio') {
+      const radiosContainer = input.parentNode.parentNode
+      const radios = radiosContainer.querySelectorAll('input')
+      for (let i = 0; i < radios.length; i++) {
+        radios[i].disabled = true
+      }
+    } else {
+      input.disabled = true
+    }
+  }
+}
+
+// Show block with validation error
+sweetAlert.showValidationError = (error) => {
+  if (currentContext) {
+    const {domCache} = currentContext
+    domCache.validationError.innerHTML = error
+    const popupComputedStyle = window.getComputedStyle(domCache.popup)
+    domCache.validationError.style.marginLeft = `-${popupComputedStyle.getPropertyValue('padding-left')}`
+    domCache.validationError.style.marginRight = `-${popupComputedStyle.getPropertyValue('padding-right')}`
+    dom.show(domCache.validationError)
+
+    const input = sweetAlert.getInput()
+    if (input) {
+      input.setAttribute('aria-invalid', true)
+      input.setAttribute('aria-describedBy', swalClasses.validationerror)
+      dom.focusInput(input)
+      dom.addClass(input, swalClasses.inputerror)
+    }
+  }
+}
+
+// Hide block with validation error
+sweetAlert.resetValidationError = () => {
+  if (currentContext) {
+    const {domCache} = currentContext
+    if (domCache.validationError) {
+      dom.hide(domCache.validationError)
+    }
+
+    const input = sweetAlert.getInput()
+    if (input) {
+      input.removeAttribute('aria-invalid')
+      input.removeAttribute('aria-describedBy')
+      dom.removeClass(input, swalClasses.inputerror)
+    }
+  }
+}
+
+sweetAlert.getProgressSteps = () => {
+  if (currentContext) {
+    const {params} = currentContext
+    return params.progressSteps
+  }
+}
+
+sweetAlert.setProgressSteps = (progressSteps) => {
+  if (currentContext) {
+    const {params} = currentContext
+    params.progressSteps = progressSteps
+    setParameters(params)
+  }
+}
+
+sweetAlert.showProgressSteps = () => {
+  if (currentContext) {
+    const {domCache} = currentContext
+    dom.show(domCache.progressSteps)
+  }
+}
+
+sweetAlert.hideProgressSteps = () => {
+  if (currentContext) {
+    const {domCache} = currentContext
+    dom.hide(domCache.progressSteps)
+  }
+}
 
 sweetAlert.DismissReason = Object.freeze({
   cancel: 'cancel',

--- a/test/qunit/a11y.js
+++ b/test/qunit/a11y.js
@@ -1,4 +1,5 @@
-/* global QUnit, swal */
+/* global QUnit */
+const {swal} = require('./helpers')
 const $ = require('jquery')
 
 QUnit.test('dialog aria attributes', (assert) => {

--- a/test/qunit/api.js
+++ b/test/qunit/api.js
@@ -1,0 +1,25 @@
+/* global QUnit */
+const {swal, initialSwalPropNames} = require('./helpers')
+
+QUnit.test('properties of `swal` are consistent', async (assert) => {
+  const done = assert.async()
+  const assertConsistent = postfix => {
+    const currentSwalPropNames = Object.keys(swal)
+    const extraPropNames = currentSwalPropNames.filter(key => !initialSwalPropNames.includes(key))
+    assert.deepEqual(extraPropNames.length, 0, `# of extra properties ${postfix}`)
+    assert.deepEqual(extraPropNames.join(','), '', `extra property names ${postfix}`)
+    const missingProps = currentSwalPropNames.filter(key => !currentSwalPropNames.includes(key))
+    assert.deepEqual(missingProps.length, 0, `# of missing properties ${postfix}`)
+    assert.deepEqual(missingProps.join(','), '', `missing property names ${postfix}`)
+  }
+  assertConsistent('before first swal')
+  await swal({
+    title: 'test',
+    onOpen: () => {
+      assertConsistent('after opening first swal')
+      swal.clickConfirm()
+    }
+  })
+  assertConsistent('after closing first swal')
+  done()
+})

--- a/test/qunit/api.js
+++ b/test/qunit/api.js
@@ -1,7 +1,7 @@
 /* global QUnit */
 const {swal, initialSwalPropNames} = require('./helpers')
 
-QUnit.test('properties of `swal` are consistent', async (assert) => {
+QUnit.test('properties of `swal` are consistent', (assert) => {
   const done = assert.async()
   const assertConsistent = postfix => {
     const currentSwalPropNames = Object.keys(swal)
@@ -13,13 +13,14 @@ QUnit.test('properties of `swal` are consistent', async (assert) => {
     assert.deepEqual(missingProps.join(','), '', `missing property names ${postfix}`)
   }
   assertConsistent('before first swal')
-  await swal({
+  swal({
     title: 'test',
     onOpen: () => {
       assertConsistent('after opening first swal')
       swal.clickConfirm()
     }
+  }).then(() => {
+    assertConsistent('after closing first swal')
+    done()
   })
-  assertConsistent('after closing first swal')
-  done()
 })

--- a/test/qunit/deprecated.js
+++ b/test/qunit/deprecated.js
@@ -1,4 +1,5 @@
-/* global QUnit, swal */
+/* global QUnit */
+const {swal} = require('./helpers')
 const $ = require('jquery')
 import { TIMEOUT } from './helpers.js'
 

--- a/test/qunit/helpers.js
+++ b/test/qunit/helpers.js
@@ -1,3 +1,7 @@
 const { detect } = require('detect-browser')
+
 const browser = detect()
 export const TIMEOUT = browser.name === 'ie' ? 100 : 0
+
+export const initialSwalPropNames = Object.keys(global.swal)
+export const swal = global.swal

--- a/test/qunit/helpers.js
+++ b/test/qunit/helpers.js
@@ -3,5 +3,6 @@ const { detect } = require('detect-browser')
 const browser = detect()
 export const TIMEOUT = browser.name === 'ie' ? 100 : 0
 
+// We *only* access `swal` through this module, so that we can be sure `initialSwalPropNames` is set properly
 export const initialSwalPropNames = Object.keys(global.swal)
 export const swal = global.swal

--- a/test/qunit/outside-click.js
+++ b/test/qunit/outside-click.js
@@ -1,4 +1,5 @@
-/* global QUnit, swal */
+/* global QUnit */
+const {swal} = require('./helpers')
 const $ = require('jquery')
 
 const simulateMouseEvent = (x, y, eventType) => {

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -1,5 +1,6 @@
 // TODO: move these files to /test and delete /test/qunit
-/* global QUnit, swal */
+/* global QUnit */
+const {swal} = require('./helpers')
 const $ = require('jquery')
 import { TIMEOUT } from './helpers.js'
 

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -1,4 +1,3 @@
-// TODO: move these files to /test and delete /test/qunit
 /* global QUnit */
 const {swal} = require('./helpers')
 const $ = require('jquery')

--- a/test/qunit/toast.js
+++ b/test/qunit/toast.js
@@ -1,4 +1,5 @@
-/* global QUnit, swal */
+/* global QUnit */
+const {swal} = require('./helpers')
 
 QUnit.test('.swal2-toast-shown', (assert) => {
   swal({toast: true})


### PR DESCRIPTION
As described in the "Enable it" section of the initial comment for issue #968

> For the wrapper pattern to work, the `swal` function/object **must** have a consistent API/shape. Currently a bunch of methods are added after the first swal opens, but they don't exist beforehand. I would assume this is not compatible with our `.d.ts file`. It's a problem because these methods don't exist at initialization, and thus they don't get added to the child swal in the above example of the pattern.

This PR removes that obstacle.

---

Fixes #865