### PR TITLE
chore(d.ts): improve type safety for 'inputValue' attribute

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -599,7 +599,7 @@ declare module 'sweetalert2' {
          *
          * @default ''
          */
-        inputValue?: any;
+        inputValue?: string;
 
         /**
          * If input parameter is set to "select" or "radio", you can provide options.
@@ -643,7 +643,7 @@ declare module 'sweetalert2' {
          *
          * @default null
          */
-        inputValidator?: (inputValue: any) => SyncOrAsync<string | null>;
+        inputValidator?: (inputValue: string) => SyncOrAsync<string | null>;
 
         /**
          * A custom CSS class for the input field.


### PR DESCRIPTION
Closes #957.

cc @toverux.