### PR TITLE
Add travis_retry to prevent karma and saucelabs instabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 
 script:
   # xvfb-run is needed for headless testing with real browsers
-  - xvfb-run yarn test
+  - travis_retry xvfb-run yarn test
 
 after_script:
   - greenkeeper-lockfile-upload


### PR DESCRIPTION
I propose to add a shitty trick which is aimed to compensate karma and SauceLabs instabilities but in practice could make things even worse :hankey: 

Connected to #985 and #986

`travis_retry` docs: https://docs.travis-ci.com/user/common-build-problems/#travis_retry