### PR TITLE
Add link to sweetalert2-parcel-demo (overriding SCSS variables demo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Related projects
 - [ngx-sweetalert2](https://github.com/sweetalert2/ngx-sweetalert2) - Angular 4+ integration
 - [sweetalert2-adonisjs-nuxtjs](https://github.com/sweetalert2/sweetalert2-adonisjs-nuxtjs) - AdonisJS + Nuxt.js demo
 - [sweetalert2-webpack-demo](https://github.com/sweetalert2/sweetalert2-webpack-demo) - webpack demo
+- [sweetalert2-parcel-demo](https://github.com/sweetalert2/sweetalert2-parcel-demo) - overriding SCSS variables demo
 
 
 Related community projects


### PR DESCRIPTION
I made a quick demo to show how to demonstrate overriding SCSS variables: https://github.com/sweetalert2/sweetalert2-parcel-demo