### PR TITLE
Pass control object instead of name property

### DIFF
--- a/src/forms/builder.js
+++ b/src/forms/builder.js
@@ -124,7 +124,7 @@ export const createBaseControl = (tag, controlObject) => {
  * @return {HTMLElement}
  */
 export const createInput = (controlObject) => {
-  let input = createBaseControl('input', controlObject.name)
+  let input = createBaseControl('input', controlObject)
 
   if (controlObject.placeholder) {
     input.placeholder = controlObject.placeholder


### PR DESCRIPTION
This pertains to #824.

Looks like you forgot to pass `controlObject` at: https://github.com/sweetalert2/sweetalert2/blob/06143789ebbda33a585a726c5acc156eb9cc5949/src/forms/builder.js#L127

Btw, the `validator` property for the input doesn't seem to be implemented as yet, so I'd like to. Should it go in `src/sweetalert2.js` or somewhere in the `src/forms` folder?