### PR TITLE
Feature/expose shorthand mapping logic

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -107,7 +107,6 @@ const sweetAlert = (...args) => {
     case 'object':
       showWarningsForParams(args[0])
       Object.assign(params, args[0])
-      params.extraParams = args[0].extraParams
       break
 
     default:

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -97,23 +97,7 @@ const sweetAlert = (...args) => {
 
   const context = currentContext = {}
 
-  const params = context.params = Object.assign({}, popupParams)
-
-  switch (typeof args[0]) {
-    case 'string':
-      [params.title, params.html, params.type] = args
-      break
-
-    case 'object':
-      showWarningsForParams(args[0])
-      Object.assign(params, args[0])
-      break
-
-    default:
-      error('Unexpected type of argument! Expected "string" or "object", got ' + typeof args[0])
-      return false
-  }
-
+  const params = context.params = Object.assign({}, popupParams, sweetAlert.argsToParams(args))
   setParameters(params)
 
   const domCache = context.domCache = {
@@ -1024,6 +1008,25 @@ sweetAlert.hideProgressSteps = () => {
     const {domCache} = currentContext
     dom.hide(domCache.progressSteps)
   }
+}
+
+sweetAlert.argsToParams = (args) => {
+  const params = {}
+  switch (typeof args[0]) {
+    case 'string':
+      [params.title, params.html, params.type] = args
+      break
+
+    case 'object':
+      showWarningsForParams(args[0])
+      Object.assign(params, args[0])
+      break
+
+    default:
+      error('Unexpected type of argument! Expected "string" or "object", got ' + typeof args[0])
+      return false
+  }
+  return params
 }
 
 sweetAlert.DismissReason = DismissReason

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -108,35 +108,6 @@ const sweetAlert = (...args) => {
       showWarningsForParams(args[0])
       Object.assign(params, args[0])
       params.extraParams = args[0].extraParams
-
-      if (params.input === 'email' && params.inputValidator === null) {
-        const inputValidator = (email) => {
-          return new Promise((resolve, reject) => {
-            const emailRegex = /^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9-]{2,24}$/
-            if (emailRegex.test(email)) {
-              resolve()
-            } else {
-              reject('Invalid email address')
-            }
-          })
-        }
-        params.inputValidator = params.expectRejections ? inputValidator : sweetAlert.adaptInputValidator(inputValidator)
-      }
-
-      if (params.input === 'url' && params.inputValidator === null) {
-        const inputValidator = (url) => {
-          return new Promise((resolve, reject) => {
-            // taken from https://stackoverflow.com/a/3809435/1331425
-            const urlRegex = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/
-            if (urlRegex.test(url)) {
-              resolve()
-            } else {
-              reject('Invalid URL')
-            }
-          })
-        }
-        params.inputValidator = params.expectRejections ? inputValidator : sweetAlert.adaptInputValidator(inputValidator)
-      }
       break
 
     default:

--- a/src/utils/defaultInputValidators.js
+++ b/src/utils/defaultInputValidators.js
@@ -1,0 +1,13 @@
+export default {
+  email: (string) => {
+    return /^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9-]{2,24}$/.test(string)
+      ? Promise.resolve()
+      : Promise.reject('Invalid email address')
+  },
+  url: (string) => {
+    // taken from https://stackoverflow.com/a/3809435/1331425
+    return /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/.test(string)
+      ? Promise.resolve()
+      : Promise.reject('Invalid URL')
+  }
+}

--- a/src/utils/setParameters.js
+++ b/src/utils/setParameters.js
@@ -10,6 +10,25 @@ import sweetAlert from '../sweetalert2'
  * @returns {boolean}
  */
 export default function setParameters (params) {
+  // Set default `inputValidator` for input types 'email' and 'url' if not defined
+  if (params.input === 'email' && params.inputValidator === null) {
+    const inputValidator = (email) => {
+      return /^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9-]{2,24}$/.test(email)
+        ? Promise.resolve()
+        : Promise.reject('Invalid email address')
+    }
+    params.inputValidator = params.expectRejections ? inputValidator : sweetAlert.adaptInputValidator(inputValidator)
+  }
+  if (params.input === 'url' && params.inputValidator === null) {
+    const inputValidator = (url) => {
+      // taken from https://stackoverflow.com/a/3809435/1331425
+      return /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/.test(url)
+        ? Promise.resolve()
+        : Promise.reject('Invalid URL')
+    }
+    params.inputValidator = params.expectRejections ? inputValidator : sweetAlert.adaptInputValidator(inputValidator)
+  }
+
   // Determine if the custom target element is valid
   if (
     !params.target ||

--- a/src/utils/setParameters.js
+++ b/src/utils/setParameters.js
@@ -2,6 +2,7 @@ import { swalClasses, iconTypes } from './classes.js'
 import { warn, error } from './utils.js'
 import * as dom from './dom/index'
 import sweetAlert from '../sweetalert2'
+import defaultInputValidators from './defaultInputValidators'
 
 /**
  * Set type, text and actions on popup
@@ -10,23 +11,13 @@ import sweetAlert from '../sweetalert2'
  * @returns {boolean}
  */
 export default function setParameters (params) {
-  // Set default `inputValidator` for input types 'email' and 'url' if not defined
-  if (params.input === 'email' && params.inputValidator === null) {
-    const inputValidator = (email) => {
-      return /^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9-]{2,24}$/.test(email)
-        ? Promise.resolve()
-        : Promise.reject('Invalid email address')
-    }
-    params.inputValidator = params.expectRejections ? inputValidator : sweetAlert.adaptInputValidator(inputValidator)
-  }
-  if (params.input === 'url' && params.inputValidator === null) {
-    const inputValidator = (url) => {
-      // taken from https://stackoverflow.com/a/3809435/1331425
-      return /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/.test(url)
-        ? Promise.resolve()
-        : Promise.reject('Invalid URL')
-    }
-    params.inputValidator = params.expectRejections ? inputValidator : sweetAlert.adaptInputValidator(inputValidator)
+  // Use default `inputValidator` for supported input types if not provided
+  if (!params.inputValidator) {
+    Object.keys(defaultInputValidators).forEach((key) => {
+      if (params.input === key) {
+        params.inputValidator = params.expectRejections ? defaultInputValidators[key] : sweetAlert.adaptInputValidator(defaultInputValidators[key])
+      }
+    })
   }
 
   // Determine if the custom target element is valid


### PR DESCRIPTION
Resolves #979, adding a new `swal.argsToParams` method

Also made a fix here https://github.com/sweetalert2/sweetalert2/commit/b1e3a31be7860674ec4bccd0e180dc31d3118192 for default `inputValidator`s for "email" and "url" input types to still apply when using shorthand.