### PR TITLE
Fix/require in node env

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ install:
 
 test_script:
   - yarn run build
-  - yarn run check:tests
+  - yarn run check:qunit
 
 notifications:
   - provider: Email

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,9 +75,13 @@ gulp.task('build:styles', () => {
  * Warning: This task depends on dist/sweetalert2.js & dist/sweetalert2.css
  */
 gulp.task('build:standalone', () => {
+  const css2jsOptions = {
+    prefix: 'if (typeof document !== "undefined"){' + $.css2js.defaultOptions.prefix,
+    suffix: $.css2js.defaultOptions.suffix + '}'
+  }
   const prettyJs = gulp.src('dist/sweetalert2.js')
   const prettyCssAsJs = gulp.src('dist/sweetalert2.css')
-    .pipe($.css2js())
+    .pipe($.css2js(css2jsOptions))
   const prettyStandalone = merge(prettyJs, prettyCssAsJs)
     .pipe($.concat('sweetalert2.all.js'))
     .pipe(gulp.dest('dist'))
@@ -86,7 +90,7 @@ gulp.task('build:standalone', () => {
   } else {
     const uglyJs = gulp.src('dist/sweetalert2.min.js')
     const uglyCssAsJs = gulp.src('dist/sweetalert2.min.css')
-      .pipe($.css2js())
+      .pipe($.css2js(css2jsOptions))
     const uglyStandalone = merge(uglyJs, uglyCssAsJs)
       .pipe($.concat('sweetalert2.all.min.js'))
       .pipe(gulp.dest('dist'))

--- a/package.json
+++ b/package.json
@@ -100,11 +100,11 @@
     "fix:lint": "standard --fix",
     "test": "npm run build && npm run check",
     "build": "gulp build",
-    "check": "npm run check:linting && npm run check:bundlesize && npm run check:require-in-node && npm run check:tests && npm run check:ts",
+    "check": "npm run check:linting && npm run check:bundlesize && npm run check:require-in-node && npm run check:qunit && npm run check:ts",
     "check:linting": "gulp lint",
     "check:bundlesize": "bundlesize -f dist/sweetalert2.all.min.js -s 15kB",
     "check:require-in-node": "node test/require-in-node",
-    "check:tests": "karma start karma.conf.js --single-run  --captureTimeout 240000 --browserNoActivityTimeout 240000",
+    "check:qunit": "karma start karma.conf.js --single-run  --captureTimeout 240000 --browserNoActivityTimeout 240000",
     "check:ts": "tsc sweetalert2.d.ts",
     "release": "node release"
   },

--- a/package.json
+++ b/package.json
@@ -100,9 +100,10 @@
     "fix:lint": "standard --fix",
     "test": "npm run build && npm run check",
     "build": "gulp build",
-    "check": "npm run check:linting && npm run check:bundlesize && npm run check:tests && npm run check:ts",
+    "check": "npm run check:linting && npm run check:bundlesize && npm run check:require-in-node && npm run check:tests && npm run check:ts",
     "check:linting": "gulp lint",
     "check:bundlesize": "bundlesize -f dist/sweetalert2.all.min.js -s 15kB",
+    "check:require-in-node": "node test/require-in-node",
     "check:tests": "karma start karma.conf.js --single-run  --captureTimeout 240000 --browserNoActivityTimeout 240000",
     "check:ts": "tsc sweetalert2.d.ts",
     "release": "node release"

--- a/test/require-in-node.js
+++ b/test/require-in-node.js
@@ -1,0 +1,2 @@
+require('../dist/sweetalert2')
+require('../dist/sweetalert2.all')


### PR DESCRIPTION
Related to #996

This branch just adds a (currently failing) check to the `npm test` script to ensure you can `require('sweetalert2')` without crashing. (And fixes the semantics of our npm script for qunit tests.)

Once tests-always-included/gulp-css2js#6 is merged we just have to rerun the build from the Travis site and it should pass (assuming the change is published as a minor or patch release).

Then we can merge and make a patch release to close #996