### PR TITLE
Feature/plugin and mixin methods

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -1030,10 +1030,30 @@ sweetAlert.argsToParams = (args) => {
       break
 
     default:
-      error('Unexpected type of argument! Expected "string" or "object", got ' + typeof args[0])
-      return false
+      throw new TypeError('Unexpected type of argument! Expected "string" or "object", got ' + typeof args[0])
   }
   return params
+}
+
+sweetAlert.plugin = function (plugin) {
+  const parentSwal = this
+  const pluginResult = plugin(parentSwal)
+  const [fn, members] = typeof pluginResult === 'function' ? [pluginResult, {}] : pluginResult
+  const childSwal = (...args) => {
+    const argsToParams = members.argsToParams || parentSwal.argsToParams
+    const params = argsToParams(args)
+    return fn(params)
+  }
+  return Object.assign(childSwal, parentSwal, members)
+}
+
+sweetAlert.mixin = function (mixin) {
+  const parentSwal = this
+  const childSwal = (...args) => {
+    const params = Object.assign({}, mixin, parentSwal.argsToParams(args))
+    return parentSwal(params)
+  }
+  return Object.assign(childSwal, parentSwal)
 }
 
 sweetAlert.DismissReason = DismissReason

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -97,7 +97,9 @@ const sweetAlert = (...args) => {
 
   const context = currentContext = {}
 
-  const params = context.params = Object.assign({}, popupParams, sweetAlert.argsToParams(args))
+  const userParams = sweetAlert.argsToParams(args)
+  showWarningsForParams(userParams)
+  const params = context.params = Object.assign({}, popupParams, userParams)
   setParameters(params)
 
   const domCache = context.domCache = {
@@ -1025,7 +1027,6 @@ sweetAlert.argsToParams = (args) => {
       break
 
     case 'object':
-      showWarningsForParams(args[0])
       Object.assign(params, args[0])
       break
 

--- a/test/qunit/api/api.js
+++ b/test/qunit/api/api.js
@@ -1,5 +1,5 @@
 /* global QUnit */
-const {swal, initialSwalPropNames} = require('./helpers')
+const {swal, initialSwalPropNames} = require('../helpers')
 
 QUnit.test('properties of `swal` are consistent', (assert) => {
   const done = assert.async()

--- a/test/qunit/api/mixins.js
+++ b/test/qunit/api/mixins.js
@@ -1,0 +1,27 @@
+/* global QUnit */
+const { swal } = require('../helpers')
+
+QUnit.test('basic mixin', (assert) => {
+  const done = assert.async()
+  const mySwal = swal.mixin({
+    input: 'text',
+    inputValue: 'inputValue'
+  })
+  assert.deepEqual(Object.assign({}, mySwal), Object.assign({}, swal))
+  mySwal({ onOpen: () => mySwal.clickConfirm() })
+    .then((result) => {
+      assert.equal(result.value, 'inputValue')
+      done()
+    })
+})
+
+QUnit.test('mixins and shorthand calls', (assert) => {
+  const done = assert.async()
+  const mySwal = swal
+    .plugin(swal => params => {
+      assert.deepEqual(params, { title: 'title', html: 'html', type: 'info', footer: 'footer' })
+      done()
+    })
+    .mixin({ title: 'no effect', html: 'no effect', type: 'error', footer: 'footer' })
+  mySwal('title', 'html', 'info')
+})

--- a/test/qunit/api/plugins.js
+++ b/test/qunit/api/plugins.js
@@ -1,0 +1,65 @@
+/* global QUnit */
+const { swal } = require('../helpers')
+
+QUnit.test('basic plugin', (assert) => {
+  const originalSwal = swal
+  const mySwal = swal.plugin(swal => {
+    assert.equal(swal, originalSwal)
+    return params => {
+      assert.deepEqual(params, { title: 'title' })
+      // normally here we would call `swal` and return the result, while working in the plugin's magic
+      // but there's really no need to use `swal` here since we know `swal === originalSwal` and it should behave as such
+      // whatever we return here should be the return value of `mySwal()`, so lets just return a simple sync value
+      return { value: 'value' }
+    }
+  })
+  assert.deepEqual(Object.assign({}, mySwal), Object.assign({}, swal))
+  const result = mySwal({ title: 'title' })
+  assert.deepEqual(result, { value: 'value' })
+})
+
+QUnit.test('plugins and shorthand calls', (assert) => {
+  const done = assert.async()
+  const mySwal = swal.plugin(swal => params => {
+    assert.deepEqual(params, { title: 'title', html: 'html', type: 'info' })
+    done()
+  })
+  mySwal('title', 'html', 'info')
+})
+
+QUnit.test('plugins with static properties & methods', (assert) => {
+  const staticMembers = {
+    property: 'property',
+    method: () => 'method'
+  }
+  const mySwal = swal.plugin(swal => [
+    params => params, // `swal()` result will just be `params` (non-Promise)
+    staticMembers
+  ])
+  assert.deepEqual(Object.assign({}, mySwal), Object.assign({}, swal, staticMembers))
+  assert.deepEqual(mySwal('title'), { title: 'title' })
+})
+
+QUnit.test('extending argsToParams works while layering on more plugins/mixins', (assert) => {
+  const done = assert.async()
+  const promptPlugin = swal => [
+    params => swal(Object.assign({input: 'text'}, params)),
+    {
+      argsToParams: args => typeof args[1] === 'string'
+        ? {title: args[0], inputValue: args[1]}
+        : swal.argsToParams(args)
+    }
+  ]
+
+  const copyrightFooterMixin = { footer: 'Copyright' }
+  const capitalizeTitlePlugin = swal => params => swal(Object.assign({}, params, {title: params.title.toUpperCase()}))
+  const mySwal = swal
+    .plugin(swal => params => {
+      assert.deepEqual(params, {input: 'text', footer: 'Copyright', title: 'TITLE', inputValue: 'inputValue'})
+      done()
+    })
+    .plugin(promptPlugin)
+    .mixin(copyrightFooterMixin)
+    .plugin(capitalizeTitlePlugin)
+  mySwal('title', 'inputValue')
+})


### PR DESCRIPTION
This is the convenience method that I mentioned at the very end of this comment https://github.com/sweetalert2/sweetalert2/issues/968#issue-301215886

There I'm calling them "wrappers", I've also referred to them as "decorators" and I think "extensions". Most recently it's "mixins". We're currently discussing what this kind of extensions should be called in https://github.com/sweetalert2/sweetalert2-react-content/pull/14#issuecomment-371767918

It would be great if we could just call it a "sweetalert2 plugin"!

---

These code changes add two really handy new methods: `plugin` and `mixin`.  

---

# plugin

`plugin` takes care of some boilerplate that's irritating when implementing the "wrapper"/"decorator"/"React HOC" pattern manually...

## before

example from #968 but now not breaking shorthand (`swal('title', 'html', 'info')`) calls, thanks to new argsToParams method

```js
const withCopyrightInFooter = swal => {
  const fn = (...args) => {
    const params = swal.argsToParams(args)
    return swal({
      ...params,
      footer: (params.footer ? params.footer + '<br/>' : '') + 'Copyright Rick Sanchez'
    })
  }
  return Object.assign(fn, swal)
}
const mySwal = withCopyrightInFooter(swal)
```

## after

- don't worry about using argsToParams here; we are always given options in normalized "params" form
- don't worry about assigning the `swal` methods to your new instance

```js
const withCopyrightInFooter = swal => params => swal({
  ...params,
  footer: (params.footer ? params.footer + '<br/>' : '') + 'Copyright Rick Sanchez'
})
const mySwal = swal.plugin(withCopyrightInFooter)
```

## advanced

In some cases you may even want to define new static methods, or even override/extend static methods like `swal.argsToParams`, as I have needed to in sweetalert2-react-content so we can `swal(<p>foo</p>)`. That's still easy with the new API:

```js
const titleArrayPlugin = swal => [
  params => swal({ ...params, ...myExtraParams }),
  { argsToParams: args => args[0] instanceof Array ? { title: args[0].join(' & ') } : swal.argsToParams(args) }
]
const mySwal = swal.plugin(titleArrayPlugin)
mySwal(['a', 'b', 'c'] // swal displays "a' & b' & c"
```

---

# mixin
`mixin` is more similar to a React mixin. Mixins are leaky abstractions and plugins are preferred (as I've talked about in #815 and #968 ), but in some isolated one-off instances i think they will be good, especially for users that find that API less confusing. 

## before

- Without object spread syntax (which we don't have here atm for some reason agh) it becomes a lot more code with all the `Object.assign({}, ...`

```js
const textPromptOptions = { input: 'text', showCancelButton: true }
const {value: firstName} = await swal({ ...textPromptOptions, text: 'What is your first name?' })
const {value: lastName} = await myPromptSwal({ ...myPromptOptions, text: 'What is your last name?' })
```

## after

```js
const myTextPrompt = swal.mixin({ input: 'text', showCancelButton: true })
const {value: firstName} = await myTextPrompt('What is your first name?')
const {value: lastName} = await myTextPrompt('What is your last name?')
```

---

After this, next step should be to extract the logic of certain features that are currently core into plugins: toasts, forms, etc., and in the next major: setDefaults/resetDefaults, queue). Not necessarily [extract it] into separate repos, but definitely different `.js` modules. **This would be a win for our internal code quality also, by separating concerns into different layers.**