### PR TITLE
Feature/mixin method

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -1037,6 +1037,31 @@ sweetAlert.argsToParams = (args) => {
   return params
 }
 
+/**
+ * Returns a wrapped instance of `swal` containing `params` as defaults.
+ * Useful for reusing swal configuration.
+ *
+ * For example:
+ *
+ * Before:
+ * const textPromptOptions = { input: 'text', showCancelButton: true }
+ * const {value: firstName} = await swal({ ...textPromptOptions, title: 'What is your first name?' })
+ * const {value: lastName} = await swal({ ...textPromptOptions, title: 'What is your last name?' })
+ *
+ * After:
+ * const myTextPrompt = swal.mixin({ input: 'text', showCancelButton: true })
+ * const {value: firstName} = await myTextPrompt('What is your first name?')
+ * const {value: lastName} = await myTextPrompt('What is your last name?')
+ *
+ * @param params
+ */
+sweetAlert.mixin = function (params) {
+  const parentSwal = this
+  const childSwal = (...args) =>
+    parentSwal(Object.assign({}, params, parentSwal.argsToParams(args)))
+  return Object.assign(childSwal, parentSwal)
+}
+
 sweetAlert.DismissReason = DismissReason
 
 sweetAlert.noop = () => { }

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -97,7 +97,9 @@ const sweetAlert = (...args) => {
 
   const context = currentContext = {}
 
-  const params = context.params = Object.assign({}, popupParams, sweetAlert.argsToParams(args))
+  const userParams = sweetAlert.argsToParams(args)
+  showWarningsForParams(userParams)
+  const params = context.params = Object.assign({}, popupParams, userParams)
   setParameters(params)
 
   const domCache = context.domCache = {
@@ -1025,7 +1027,6 @@ sweetAlert.argsToParams = (args) => {
       break
 
     case 'object':
-      showWarningsForParams(args[0])
       Object.assign(params, args[0])
       break
 

--- a/test/qunit/api/api.js
+++ b/test/qunit/api/api.js
@@ -1,5 +1,5 @@
 /* global QUnit */
-const {swal, initialSwalPropNames} = require('./helpers')
+const {swal, initialSwalPropNames} = require('../helpers')
 
 QUnit.test('properties of `swal` are consistent', (assert) => {
   const done = assert.async()

--- a/test/qunit/api/mixins.js
+++ b/test/qunit/api/mixins.js
@@ -1,0 +1,36 @@
+/* global QUnit */
+const { swal } = require('../helpers')
+
+QUnit.test('basic mixin', (assert) => {
+  const done = assert.async()
+  const mySwal = swal.mixin({ title: '1_title' })
+  mySwal({
+    onOpen: () => {
+      assert.equal(mySwal.getTitle().textContent, '1_title')
+      mySwal.clickConfirm()
+    }
+  }).then((result) => {
+    assert.deepEqual(result, { value: true })
+    done()
+  })
+})
+
+QUnit.test('mixins and static properties/methods', (assert) => {
+  const mySwal = swal.mixin({})
+  assert.deepEqual(Object.assign({}, mySwal), Object.assign({}, swal))
+})
+
+QUnit.test('mixins and shorthand calls', (assert) => {
+  const done = assert.async()
+  const mySwal = swal.mixin({
+    title: 'no effect',
+    html: 'no effect',
+    onOpen: () => {
+      assert.equal(mySwal.getTitle().textContent, '2_title')
+      assert.equal(mySwal.getContent().textContent, '2_html')
+      mySwal.clickConfirm()
+      done()
+    }
+  })
+  mySwal('2_title', '2_html')
+})


### PR DESCRIPTION
Just the `swal.mixin` method from #1008, commented

About the `swal.plugin` method: We should first explore adapting this library to a proper OO and thus extensible interface (see #1007), before adding the complexity (and probably typescript-breaking) of that method which should not be needed in the first place.

About the warning on `setDefaults`, we definitely should have one, but I want to defer adding it until we can suggest using a `global-defaults` plugin for those that don't want to update their old code.
