### PR TITLE
Travis: google-chrome: latest -> chrome: stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 
 addons:
   firefox: latest
-  google-chrome: latest
+  chrome: stable
 
 before_install:
   - yarn global add greenkeeper-lockfile@1


### PR DESCRIPTION
It looks like for some weird reason `google-chrome: latest` is stuck on 62:

![](https://i.imgur.com/83PSY4l.png)

`chrome: stable` works as expected and installs Chrome 65:

![](https://i.imgur.com/UUkIpfu.png)

~Maybe this could help with #986 :pray:~

Nope 

![](https://i.imgur.com/no6nhXB.png)