### PR TITLE
Fix/karma babel use es2015 preset

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+require('babel-polyfill')
 const isCi = require('is-ci')
 
 const noLaunch = process.argv.includes('--no-launch')
@@ -61,6 +62,7 @@ module.exports = function (config) {
     },
     files: [
       'node_modules/promise-polyfill/dist/polyfill.min.js',
+      'node_modules/babel-polyfill/dist/polyfill.js',
       'dist/sweetalert2.css',
       'dist/sweetalert2.js',
       'test/qunit/**/*.js'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -61,7 +61,6 @@ module.exports = function (config) {
       ]
     },
     files: [
-      'node_modules/promise-polyfill/dist/polyfill.min.js',
       'node_modules/babel-polyfill/dist/polyfill.js',
       'dist/sweetalert2.css',
       'dist/sweetalert2.js',

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "merge2": "^1.2.1",
     "mkdirp": "^0.5.1",
     "pify": "^3.0.0",
-    "promise-polyfill": "^7.1.0",
     "qunit": "^2.5.1",
     "rimraf": "^2.6.2",
     "rollup": "^0.57.1",

--- a/test/sandbox.html
+++ b/test/sandbox.html
@@ -1,5 +1,5 @@
 <!-- IE11 compatibility -->
-<script src="/node_modules/promise-polyfill/dist/polyfill.min.js"></script>
+<script src="/node_modules/babel-polyfill/dist/polyfill.min.js"></script>
 
 <script src="../dist/sweetalert2.js"></script>
 <link rel="stylesheet" href="../dist/sweetalert2.css">

--- a/yarn.lock
+++ b/yarn.lock
@@ -6176,10 +6176,6 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
-promise-polyfill@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-7.1.0.tgz#4d749485b44577c14137591c6f36e5d7e2dd3378"
-
 property-is-enumerable-x@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz#7ca48917476cd0914b37809bfd05776a0d942f6f"


### PR DESCRIPTION
Get rid of `promise-polyfill` devDependency, use `babel-polyfill` to fix currently failing build in AppVeyor (IE11):

```
  × inputValue as a Promise
	Died on test #1    at Anonymous function (webpack:///test/qunit/tests.js:858:0 <- test/qunit/tests.js:1:110983)
	   at n (webpack:///webpack/bootstrap:25:0 <- test/qunit/tests.js:1:98)
	   at Anonymous function (webpack:///webpack/bootstrap:68:0 <- test/qunit/tests.js:1:580)
	   at Global code (test/qunit/tests.js:1:2): 'Symbol' is undefined
	ReferenceError: 'Symbol' is undefined
	   at Anonymous function (webpack:///test/qunit/tests.js:865:2 <- test/qunit/tests.js:1:111442)
	   at runTest (node_modules/qunit/qunit/qunit.js:1478:6)
	   at run (node_modules/qunit/qunit/qunit.js:1464:6)
	   at Anonymous function (node_modules/qunit/qunit/qunit.js:1676:7)
	   at advance (node_modules/qunit/qunit/qunit.js:1116:6)
	   at begin (node_modules/qunit/qunit/qunit.js:3065:4)
	   at Anonymous function (node_modules/qunit/qunit/qunit.js:2063:6)
```

https://ci.appveyor.com/project/limonte/sweetalert2/build/272

---

Connected to #1025