### PR TITLE
fix(release-script): add --strategy-option=theirs to git merge master

### DIFF
--- a/release.js
+++ b/release.js
@@ -43,7 +43,7 @@ assert.ok(['patch', 'minor', 'major'].includes(semver), 'Must specify the valid 
   await execute('git pull origin')
 
   log(`Merging from "${branchToPublish}" branch...`)
-  await execute(`git merge ${branchToPublish}`)
+  await execute(`git merge --strategy-option=theirs ${branchToPublish}`)
 
   log('Installing npm dependencies...')
   await execute('yarn')


### PR DESCRIPTION
I had the git conflict executing the `git merge master` step and release script stopped.

Let's use `--strategy-option=theirs` for merging with the master branch.

Docs: https://git-scm.com/docs/merge-strategies

 