### PR TITLE
feat: pass extraParams to default validators

### DIFF
--- a/src/utils/defaultInputValidators.js
+++ b/src/utils/defaultInputValidators.js
@@ -1,13 +1,13 @@
 export default {
-  email: (string) => {
+  email: (string, extraParams) => {
     return /^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9-]{2,24}$/.test(string)
       ? Promise.resolve()
-      : Promise.reject('Invalid email address')
+      : Promise.reject(extraParams.validationMessage || 'Invalid email address')
   },
-  url: (string) => {
+  url: (string, extraParams) => {
     // taken from https://stackoverflow.com/a/3809435/1331425
     return /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/.test(string)
       ? Promise.resolve()
-      : Promise.reject('Invalid URL')
+      : Promise.reject(extraParams.validationMessage || 'Invalid URL')
   }
 }

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -159,6 +159,25 @@ QUnit.test('input text', (assert) => {
   Swal.clickConfirm()
 })
 
+QUnit.test('validation message', (assert) => {
+  const done = assert.async()
+  Swal({
+    input: 'email',
+    extraParams: {
+      validationMessage: 'Adresse e-mail invalide'
+    }
+  })
+
+  $('.swal2-input').val('invalid-email')
+  Swal.clickConfirm()
+
+  setTimeout(() => {
+    assert.ok($('.swal2-validationerror').is(':visible'))
+    assert.equal($('.swal2-validationerror').text(), 'Adresse e-mail invalide')
+    done()
+  }, TIMEOUT)
+})
+
 QUnit.test('validation error', (assert) => {
   const done = assert.async()
   const inputValidator = (value) => Promise.resolve(!value && 'no falsy values')


### PR DESCRIPTION
Closes #1081 

Undocumented `extraParams` parameter is passed as the second argument to validators.

Use `extraParams.validationMessage` (naming to be in sync with https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation#Constraint_validation_API_properties)

The l10n of validation message for default validators (email, url) will look like: 

```js
Swal({
  input: 'email',
  extraParams: {
    validationMessage: 'Adresse e-mail invalide'
  }
})
```