### PR TITLE
fix: add IE11 workaround for oninput event handler

### DIFF
--- a/src/utils/dom/init.js
+++ b/src/utils/dom/init.js
@@ -103,8 +103,12 @@ export const init = (params) => {
     popup.setAttribute('aria-modal', 'true')
   }
 
-  const resetValidationError = () => {
-    sweetAlert.isVisible() && sweetAlert.resetValidationError()
+  let oldInputVal // IE11 workaround, see #1109 for details
+  const resetValidationError = (e) => {
+    if (sweetAlert.isVisible() && oldInputVal !== e.target.value) {
+      sweetAlert.resetValidationError()
+    }
+    oldInputVal = e.target.value
   }
 
   input.oninput = resetValidationError


### PR DESCRIPTION
Fixes #1050

There's a known issue in IE11 https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101220/

IE11 is firing `input` event without any actual input in case there's placeholder set.

From https://github.com/vuejs/vue/issues/7138#issuecomment-347211193

> the last comment from MS: no fix