### PR TITLE
fix: unset previousActiveElement in restoreFocusTimeout, not before

### DIFF
--- a/src/globalState.js
+++ b/src/globalState.js
@@ -5,12 +5,11 @@ export default globalState
 // Restore previous active (focused) element
 export const restoreActiveElement = () => {
   if (globalState.previousActiveElement && globalState.previousActiveElement.focus) {
-    const previousActiveElement = globalState.previousActiveElement
-    globalState.previousActiveElement = null
     const x = window.scrollX
     const y = window.scrollY
     globalState.restoreFocusTimeout = setTimeout(() => {
-      previousActiveElement.focus && previousActiveElement.focus()
+      globalState.previousActiveElement.focus()
+      globalState.previousActiveElement = null
     }, 100) // issues/900
     if (typeof x !== 'undefined' && typeof y !== 'undefined') { // IE doesn't have scrollX/scrollY support
       window.scrollTo(x, y)


### PR DESCRIPTION
Follow-up for #1124 

Fixes #1122 