### PR TITLE
feat(params): add stopKeyDownPropagation param

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -301,7 +301,9 @@ export function _main (userParams) {
     }
 
     const keydownHandler = (e, innerParams) => {
-      e.stopPropagation()
+      if (innerParams.stopKeydownPropagation) {
+        e.stopPropagation()
+      }
 
       const arrowKeys = [
         'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -16,6 +16,7 @@ const defaultParams = {
   allowOutsideClick: true,
   allowEscapeKey: true,
   allowEnterKey: true,
+  stopKeydownPropagation: true,
   showConfirmButton: true,
   showCancelButton: false,
   preConfirm: null,

--- a/test/qunit/params/stopKeydownPropagation.js
+++ b/test/qunit/params/stopKeydownPropagation.js
@@ -1,0 +1,17 @@
+/* global QUnit */
+import { triggerEscape, SwalWithoutAnimation } from '../helpers.js'
+
+QUnit.test('stopKeydownPropagation', (assert) => {
+  const done = assert.async()
+
+  document.body.addEventListener('keydown', (e) => {
+    assert.equal(e.key, 'Escape')
+    done()
+  })
+
+  SwalWithoutAnimation({
+    title: 'Esc me and I will propagate keydown',
+    onOpen: triggerEscape,
+    stopKeydownPropagation: false
+  })
+})


### PR DESCRIPTION
Closes #1130

`e.stopPropagation()` in the `keydown` handler `capture` mode was introduced in #1105 for the compatibility with Bootstrap. 

This PR adds ability not to stop `keydown` events by introducing the `stopKeyDownPropagation` boolean param. Because generally it's a good idea not to propagate `keydown` events (e.g. <kbd>Esc</kbd>) to the document, default value will be `true`, which means no breaking changes.