### PR TITLE
Add `keydownListenerCapture` param

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -360,13 +360,15 @@ export function _main (userParams) {
     }
 
     if (globalState.keydownHandlerAdded) {
-      window.removeEventListener('keydown', globalState.keydownHandler, {capture: true})
+      globalState.keydownTarget.removeEventListener('keydown', globalState.keydownHandler, {capture: globalState.keydownListenerCapture})
       globalState.keydownHandlerAdded = false
     }
 
     if (!innerParams.toast) {
       globalState.keydownHandler = (e) => keydownHandler(e, innerParams)
-      window.addEventListener('keydown', globalState.keydownHandler, {capture: true})
+      globalState.keydownTarget = innerParams.keydownListenerCapture ? window : domCache.popup
+      globalState.keydownListenerCapture = innerParams.keydownListenerCapture
+      globalState.keydownTarget.addEventListener('keydown', globalState.keydownHandler, {capture: globalState.keydownListenerCapture})
       globalState.keydownHandlerAdded = true
     }
 

--- a/src/staticMethods/close.js
+++ b/src/staticMethods/close.js
@@ -24,7 +24,7 @@ const close = (onClose, onAfterClose) => {
   const removePopupAndResetState = () => {
     if (!dom.isToast()) {
       restoreActiveElement()
-      window.removeEventListener('keydown', globalState.keydownHandler, {capture: true})
+      globalState.keydownTarget.removeEventListener('keydown', globalState.keydownHandler, {capture: globalState.keydownListenerCapture})
       globalState.keydownHandlerAdded = false
     }
 

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -17,6 +17,7 @@ const defaultParams = {
   allowEscapeKey: true,
   allowEnterKey: true,
   stopKeydownPropagation: true,
+  keydownListenerCapture: false,
   showConfirmButton: true,
   showCancelButton: false,
   preConfirm: null,

--- a/test/qunit/helpers.js
+++ b/test/qunit/helpers.js
@@ -18,6 +18,10 @@ export const SwalWithoutAnimation = Swal.mixin({animation: false})
 export const triggerEscape = () => {
   const e = document.createEvent('HTMLEvents')
   e.key = 'Escape'
-  e.initEvent('keydown', false, true)
+  e.initEvent(
+    'keydown',
+    true, // bubbles
+    true  // cancelable
+  )
   Swal.getPopup().dispatchEvent(e)
 }

--- a/test/qunit/helpers.js
+++ b/test/qunit/helpers.js
@@ -19,5 +19,5 @@ export const triggerEscape = () => {
   const e = document.createEvent('HTMLEvents')
   e.key = 'Escape'
   e.initEvent('keydown', false, true)
-  document.body.dispatchEvent(e)
+  Swal.getPopup().dispatchEvent(e)
 }

--- a/test/qunit/outside-click.js
+++ b/test/qunit/outside-click.js
@@ -1,5 +1,5 @@
 /* global QUnit */
-const {Swal, SwalWithoutAnimation} = require('./helpers')
+const {Swal, SwalWithoutAnimation, TIMEOUT} = require('./helpers')
 const $ = require('jquery')
 
 const simulateMouseEvent = (x, y, eventType) => {
@@ -83,5 +83,5 @@ QUnit.test('allowOutsideClick: () => !swal.isLoading()', (assert) => {
     assert.ok(Swal.isVisible())
     Swal.hideLoading()
     $('.swal2-container').click()
-  })
+  }, TIMEOUT)
 })

--- a/test/qunit/toast.js
+++ b/test/qunit/toast.js
@@ -19,11 +19,6 @@ QUnit.test('.swal2-has-input', (assert) => {
   })
 })
 
-QUnit.test('should not overrie window.onkeydown', (assert) => {
-  Swal({toast: true})
-  assert.equal(null, window.onkeydown)
-})
-
 QUnit.test('toast click closes when no buttons or input are specified', (assert) => {
   const done = assert.async()
 


### PR DESCRIPTION
Fixed #1130 

#1105 was my fuck-up. By doing `e.stopPropagation()` inside the `keydown` handler with the `capture` mode on `window`, I disabled all custom inputs inside a modal which are trying to catch `keydown` events (e.g. #1130).

The `capture` mode is needed for the compatibility with the shitty implementation of Bootstrap modals, therefore I will leave it as a possibility for those developers who decided to use both Bootstrap modals and SweetAlert2 at the same time.