### PR TITLE
fix(polyfill): Do not monkey patch Symbol and WeakMap polyfills onto global object

### DIFF
--- a/src/privateProps.js
+++ b/src/privateProps.js
@@ -8,40 +8,7 @@
  *   then we can use that language feature.
  */
 
-// WeakMap polyfill, needed for Android 4.4
-// Related issue: https://github.com/sweetalert2/sweetalert2/issues/1071
-if (typeof window !== 'undefined' && typeof window.WeakMap !== 'function') {
-  // https://github.com/Riim/symbol-polyfill/blob/master/index.js
-  if (!window.Symbol) {
-    let idCounter = 0
-    window.Symbol = function Symbol (key) {
-      return '__' + key + '_' + Math.floor(Math.random() * 1e9) + '_' + (++idCounter) + '__'
-    }
-    window.Symbol.iterator = window.Symbol('Symbol.iterator')
-  }
-
-  // http://webreflection.blogspot.fi/2015/04/a-weakmap-polyfill-in-20-lines-of-code.html
-  window.WeakMap = (function (s, dP, hOP) {
-    function WeakMap () {
-      dP(this, s, {value: Symbol('WeakMap')})
-    }
-    WeakMap.prototype = {
-      'delete': function del (o) {
-        delete o[this[s]]
-      },
-      get: function get (o) {
-        return o[this[s]]
-      },
-      has: function has (o) {
-        return hOP.call(o, this[s])
-      },
-      set: function set (o, v) {
-        dP(o, this[s], {configurable: true, value: v})
-      }
-    }
-    return WeakMap
-  }(Symbol('WeakMap'), Object.defineProperty, {}.hasOwnProperty))
-}
+import WeakMap from './utils/WeakMap'
 
 export default {
   promise: new WeakMap(),

--- a/src/utils/Symbol.js
+++ b/src/utils/Symbol.js
@@ -1,0 +1,10 @@
+// https://github.com/Riim/symbol-polyfill/blob/master/index.js
+
+export default typeof Symbol === 'function' ? Symbol : (() => {
+  let idCounter = 0
+  function Symbol (key) {
+    return '__' + key + '_' + Math.floor(Math.random() * 1e9) + '_' + (++idCounter) + '__'
+  }
+  Symbol.iterator = Symbol('Symbol.iterator')
+  return Symbol
+})()

--- a/src/utils/WeakMap.js
+++ b/src/utils/WeakMap.js
@@ -1,0 +1,26 @@
+// WeakMap polyfill, needed for Android 4.4
+// Related issue: https://github.com/sweetalert2/sweetalert2/issues/1071
+// http://webreflection.blogspot.fi/2015/04/a-weakmap-polyfill-in-20-lines-of-code.html
+
+import Symbol from './Symbol'
+
+export default typeof WeakMap === 'function' ? WeakMap : ((s, dP, hOP) => {
+  function WeakMap () {
+    dP(this, s, {value: Symbol('WeakMap')})
+  }
+  WeakMap.prototype = {
+    'delete': function del (o) {
+      delete o[this[s]]
+    },
+    get: function get (o) {
+      return o[this[s]]
+    },
+    has: function has (o) {
+      return hOP.call(o, this[s])
+    },
+    set: function set (o, v) {
+      dP(o, this[s], {configurable: true, value: v})
+    }
+  }
+  return WeakMap
+})(Symbol('WeakMap'), Object.defineProperty, {}.hasOwnProperty)


### PR DESCRIPTION
As titled: Do not monkey patch Symbol and WeakMap polyfills onto global object