### PR TITLE
Move from unreliable unpkg.com to jsdelivr.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or:
 bower install --save sweetalert2
 ```
 
-Or download from CDN: [unpkg.com/sweetalert2](https://unpkg.com/sweetalert2) | [jsdelivr.net/npm/sweetalert2](https://cdn.jsdelivr.net/npm/sweetalert2)
+Or download from CDN: [jsdelivr.net/npm/sweetalert2](https://cdn.jsdelivr.net/npm/sweetalert2)
 
 
 Usage
@@ -58,7 +58,7 @@ Usage
 <script src="sweetalert2/dist/sweetalert2.all.min.js"></script>
 
 <!-- Include a polyfill for ES6 Promises (optional) for IE11, UC Browser and Android browser support -->
-<script src="https://unpkg.com/promise-polyfill"></script>
+<script src="https://cdn.jsdelivr.net/npm/promise-polyfill"></script>
 ```
 
 You can also include the stylesheet separately if desired:

--- a/release.js
+++ b/release.js
@@ -85,5 +85,8 @@ assert.ok(['patch', 'minor', 'major'].includes(semver), 'Must specify the valid 
   log(`Switching back to "${branchToPublish}" (so you can continue to work)...`)
   await execute(`git checkout "${branchToPublish}"`)
 
+  log(`Purge jsdelivr cache...`)
+  await execute(`curl https://purge.jsdelivr.net/npm/sweetalert2`)
+
   log('OK!')
 })().catch(console.error)


### PR DESCRIPTION
Reason: 

- https://github.com/unpkg/unpkg.com/issues/115
- https://github.com/unpkg/unpkg.com/issues/117

As @MartinKolarik suggested in https://github.com/sweetalert2/sweetalert2.github.io/commit/63b376024bb586682423dccf296d08f974ca26bf also added the "jsdelivr purge cache" step to the release script.