### PR TITLE
feat(tests): add third-party checks to cron CI cuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ script:
     fi;
 
   - if [[ "$TRAVIS_EVENT_TYPE" = "cron"  ]]; then
-      travis_retry yarn test:sauce;
+      travis_retry yarn test:sauce &&
+      yarn check:third-party;
     fi;
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -111,6 +111,10 @@
     "check:qunit:sauce": "karma start karma.conf.js --single-run --sauce",
     "check:qunit:minified:sauce": "karma start karma.conf.js --single-run --minified --sauce",
     "check:ts": "tsc --lib dom,es6 sweetalert2.d.ts",
+    "check:third-party": "npm run check:unpkg && npm run check:jsdelivr",
+    "check:wappalyzer": "curl 'https://api.wappalyzer.com/lookup-basic/v1/?url=https%3A%2F%2Fsweetalert2.github.io' 2>&1 | grep --quiet 'SweetAlert2'",
+    "check:unpkg": "curl --location 'https://unpkg.com/sweetalert2' 2>&1 | grep --quiet 'window.Swal'",
+    "check:jsdelivr": "curl --location 'https://cdn.jsdelivr.net/npm/sweetalert2' 2>&1 | grep --quiet 'window.Swal'",
     "release": "node release"
   },
   "bugs": "https://github.com/sweetalert2/sweetalert2/issues",


### PR DESCRIPTION
The front-end ecosystem is unreliable, everything we're depending on should be tested by us.

In order to know issues like https://github.com/unpkg/unpkg.com/issues/115 and https://github.com/unpkg/unpkg.com/issues/117 ASAP let's ensure on our side on a daily basis that both most popular CDNs are fine.

TODO(@limonte): add `check:wappalyzer` to `check:third-party` once https://github.com/AliasIO/Wappalyzer/pull/2363 is done (#1147)