### PR TITLE
You don't need jQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-preset-env": "^1.6.1",
     "browser-sync": "^2.23.3",
     "bundlesize": "^0.17.0",
+    "custom-event-polyfill": "^0.3.0",
     "detect-browser": "^2.1.0",
     "event-stream": "^3.3.4",
     "execa": "^0.10.0",

--- a/src/utils/dom/getters.js
+++ b/src/utils/dom/getters.js
@@ -1,5 +1,5 @@
 import { swalClasses } from '../classes'
-import { uniqueArray, warnOnce } from '../utils'
+import { uniqueArray, warnOnce, toArray } from '../utils'
 
 export const getContainer = () => document.body.querySelector('.' + swalClasses.container)
 
@@ -12,7 +12,7 @@ export const getPopup = () => elementByClass(swalClasses.popup)
 
 export const getIcons = () => {
   const popup = getPopup()
-  return Array.prototype.slice.call(popup.querySelectorAll('.' + swalClasses.icon))
+  return toArray(popup.querySelectorAll('.' + swalClasses.icon))
 }
 
 export const getTitle = () => elementByClass(swalClasses.title)
@@ -41,7 +41,7 @@ export const getFooter = () => elementByClass(swalClasses.footer)
 export const getCloseButton = () => elementByClass(swalClasses.close)
 
 export const getFocusableElements = () => {
-  const focusableElementsWithTabindex = Array.prototype.slice.call(
+  const focusableElementsWithTabindex = toArray(
     getPopup().querySelectorAll('[tabindex]:not([tabindex="-1"]):not([tabindex="0"])')
   )
   // sort according to tabindex
@@ -57,7 +57,7 @@ export const getFocusableElements = () => {
     })
 
   // https://github.com/jkup/focusable/blob/master/index.js
-  const otherFocusableElements = Array.prototype.slice.call(
+  const otherFocusableElements = toArray(
     getPopup().querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable], audio[controls], video[controls]')
   )
 

--- a/src/utils/setParameters.js
+++ b/src/utils/setParameters.js
@@ -73,7 +73,10 @@ export default function setParameters (params) {
   if (params.titleText) {
     title.innerText = params.titleText
   } else if (params.title) {
-    title.innerHTML = params.title.split('\n').join('<br />')
+    if (typeof params.title === 'string') {
+      params.title = params.title.split('\n').join('<br />')
+    }
+    dom.parseHtmlToContainer(params.title, title)
   }
 
   if (typeof params.backdrop === 'string') {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -15,6 +15,12 @@ export const uniqueArray = (arr) => {
 }
 
 /**
+ * Convert NodeList to Array
+ * @param nodeList
+ */
+export const toArray = (nodeList) => Array.prototype.slice.call(nodeList)
+
+  /**
  * Converts `inputOptions` into an array of `[value, label]`s
  * @param inputOptions
  */

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -597,7 +597,10 @@ declare module 'sweetalert2' {
          *      '<input id="swal-input1" class="swal2-input">' +
          *      '<input id="swal-input2" class="swal2-input">',
          *    focusConfirm: false,
-         *    preConfirm: () => [$('#swal-input1').val(), $('#swal-input2').val()]
+         *    preConfirm: () => [
+         *      document.querySelector('#swal-input1').value,
+         *      document.querySelector('#swal-input2').value
+         *    ]
          *  }).then(result => swal(JSON.stringify(result));
          *
          * @default null

--- a/test/qunit/a11y.js
+++ b/test/qunit/a11y.js
@@ -1,7 +1,6 @@
 /* global QUnit */
-const {Swal, SwalWithoutAnimation} = require('./helpers')
+const {$, Swal, SwalWithoutAnimation} = require('./helpers')
 const {RESTORE_FOCUS_TIMEOUT} = require('../../src/constants')
-const $ = require('jquery')
 
 QUnit.test('previous active element', (assert) => {
   const done = assert.async()
@@ -24,14 +23,14 @@ QUnit.test('previous active element', (assert) => {
 
 QUnit.test('dialog aria attributes', (assert) => {
   Swal('Modal dialog')
-  assert.equal($('.swal2-modal').attr('role'), 'dialog')
-  assert.equal($('.swal2-modal').attr('aria-live'), 'assertive')
-  assert.equal($('.swal2-modal').attr('aria-modal'), 'true')
+  assert.equal($('.swal2-modal').getAttribute('role'), 'dialog')
+  assert.equal($('.swal2-modal').getAttribute('aria-live'), 'assertive')
+  assert.equal($('.swal2-modal').getAttribute('aria-modal'), 'true')
 })
 
 QUnit.test('toast aria attributes', (assert) => {
   Swal({title: 'Toast', toast: true})
-  assert.equal($('.swal2-toast').attr('role'), 'alert')
-  assert.equal($('.swal2-toast').attr('aria-live'), 'polite')
-  assert.notOk($('.swal2-toast').attr('aria-modal'))
+  assert.equal($('.swal2-toast').getAttribute('role'), 'alert')
+  assert.equal($('.swal2-toast').getAttribute('aria-live'), 'polite')
+  assert.notOk($('.swal2-toast').getAttribute('aria-modal'))
 })

--- a/test/qunit/deprecated.js
+++ b/test/qunit/deprecated.js
@@ -1,7 +1,5 @@
 /* global QUnit */
-const {Swal, SwalWithoutAnimation} = require('./helpers')
-const $ = require('jquery')
-import { triggerEscape } from './helpers.js'
+const {$, Swal, SwalWithoutAnimation, triggerEscape, isVisible} = require('./helpers')
 
 QUnit.test('confirm button /w useRejections: true', (assert) => {
   const done = assert.async()
@@ -99,9 +97,9 @@ QUnit.test('close button /w useRejections: true', (assert) => {
     }
   )
 
-  const $closeButton = $('.swal2-close')
-  assert.ok($closeButton.is(':visible'))
-  $closeButton.click()
+  const closeButton = $('.swal2-close')
+  assert.ok(isVisible(closeButton))
+  closeButton.click()
 })
 
 QUnit.test('input text /w useRejections: true', (assert) => {
@@ -116,7 +114,7 @@ QUnit.test('input text /w useRejections: true', (assert) => {
     done()
   })
 
-  $('.swal2-input').val(string)
+  $('.swal2-input').value = string
   Swal.clickConfirm()
 })
 
@@ -132,7 +130,7 @@ QUnit.test('built-in email validation /w useRejections: true', (assert) => {
     done()
   })
 
-  $('.swal2-input').val(validEmailAddress)
+  $('.swal2-input').value = validEmailAddress
   Swal.clickConfirm()
 })
 
@@ -149,7 +147,7 @@ QUnit.test('input select /w useRejections: true', (assert) => {
     done()
   })
 
-  $('.swal2-select').val(selected)
+  $('.swal2-select').value = selected
   Swal.clickConfirm()
 })
 
@@ -163,12 +161,12 @@ QUnit.test('input checkbox /w useRejections: true', (assert) => {
     },
     useRejections: true
   }).then((result) => {
-    assert.equal(checkbox.attr('name'), 'test-checkbox')
+    assert.equal(checkbox.getAttribute('name'), 'test-checkbox')
     assert.equal(result, '1')
     done()
   })
 
   const checkbox = $('.swal2-checkbox input')
-  checkbox.prop('checked', true)
+  checkbox.checked = true
   Swal.clickConfirm()
 })

--- a/test/qunit/focus.js
+++ b/test/qunit/focus.js
@@ -1,6 +1,5 @@
 /* global QUnit */
-const {Swal, SwalWithoutAnimation} = require('./helpers')
-const $ = require('jquery')
+const {$, Swal, SwalWithoutAnimation} = require('./helpers')
 
 QUnit.test('default focus', (assert) => {
   const done = assert.async()
@@ -34,15 +33,17 @@ QUnit.test('focusConfirm', (assert) => {
   Swal({
     showCancelButton: true
   })
-  assert.equal(document.activeElement, $('.swal2-confirm')[0])
+  assert.equal(document.activeElement, $('.swal2-confirm'))
 
-  const anchor = $('<a href>link</a>')
+  const anchor = document.createElement('a')
+  anchor.innerText = 'link'
+  anchor.href = ''
   Swal({
     html: anchor,
     showCancelButton: true,
     focusConfirm: false
   })
-  assert.equal(document.activeElement.outerHTML, anchor[0].outerHTML)
+  assert.equal(document.activeElement.outerHTML, anchor.outerHTML)
 })
 
 QUnit.test('focusCancel', (assert) => {
@@ -51,7 +52,7 @@ QUnit.test('focusCancel', (assert) => {
     showCancelButton: true,
     focusCancel: true
   })
-  assert.equal(document.activeElement, $('.swal2-cancel')[0])
+  assert.equal(document.activeElement, $('.swal2-cancel'))
 })
 
 // TODO(@limonte): this test needs to be revisited

--- a/test/qunit/helpers.js
+++ b/test/qunit/helpers.js
@@ -1,6 +1,13 @@
+/* global CustomEvent */
+require('custom-event-polyfill') // for IE11
 const { detect } = require('detect-browser')
 
 const browser = detect()
+
+export const $ = document.querySelector.bind(document)
+
+export const isVisible = (elem) => elem && (elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)
+export const isHidden = (elem) => !isVisible(elem)
 
 export let TIMEOUT = 1
 
@@ -14,6 +21,11 @@ if (browser.name === 'ie') {
 export const initialSwalPropNames = Object.keys(global.Swal)
 export const Swal = global.Swal
 export const SwalWithoutAnimation = Swal.mixin({animation: false})
+
+export const dispatchCustomEvent = (elem, eventName, eventDetail = {}) => {
+  var event = new CustomEvent(eventName, {bubbles: true, cancelable: true, detail: eventDetail})
+  elem.dispatchEvent(event)
+}
 
 export const triggerEscape = () => {
   const e = document.createEvent('HTMLEvents')

--- a/test/qunit/jquery.js
+++ b/test/qunit/jquery.js
@@ -1,0 +1,14 @@
+/* global QUnit */
+const {$, Swal} = require('./helpers')
+const jQuery = require('jquery')
+
+QUnit.test('jQuery elements as params', (assert) => {
+  Swal({
+    title: jQuery('<h1>jQuery title</h1>'),
+    html: jQuery('<p>jQuery content</p>'),
+    footer: jQuery('<footer>jQuery footer</footer>')
+  })
+  assert.equal($('.swal2-title').innerHTML, '<h1>jQuery title</h1>')
+  assert.equal($('#swal2-content').innerHTML, '<p>jQuery content</p>')
+  assert.equal($('.swal2-footer').innerHTML, '<footer>jQuery footer</footer>')
+})

--- a/test/qunit/outside-click.js
+++ b/test/qunit/outside-click.js
@@ -1,12 +1,12 @@
 /* global QUnit */
-const {Swal, SwalWithoutAnimation, TIMEOUT} = require('./helpers')
-const $ = require('jquery')
+const {$, Swal, SwalWithoutAnimation, dispatchCustomEvent, TIMEOUT} = require('./helpers')
 
 const simulateMouseEvent = (x, y, eventType) => {
-  var event = $.Event(eventType)
-  event.clientX = x
-  event.clientY = y
-  $(document.elementFromPoint(x, y)).trigger(event)
+  dispatchCustomEvent(
+    document.elementFromPoint(x, y),
+    eventType,
+    {clientX: x, clientY: y}
+  )
 }
 
 QUnit.test('backdrop click', (assert) => {

--- a/test/qunit/toast.js
+++ b/test/qunit/toast.js
@@ -1,6 +1,5 @@
 /* global QUnit */
-const {Swal, SwalWithoutAnimation} = require('./helpers')
-const $ = require('jquery')
+const {$, Swal, SwalWithoutAnimation} = require('./helpers')
 
 QUnit.test('.swal2-toast-shown', (assert) => {
   Swal({toast: true})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2004,6 +2004,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+custom-event-polyfill@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-0.3.0.tgz#99807839be62edb446b645832e0d80ead6fa1888"
+
 custom-event@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"


### PR DESCRIPTION
The reasoning of this PR is to improve maintainability of the SweetAlert2 codebase. In 2018 it's not obligatory to know jQuery, so let's not use it :) The platform is grown up enough already.
 
Thanks to these two resources:

- https://github.com/nefe/You-Dont-Need-jQuery
- http://youmightnotneedjquery.com/

I got rid of jQuery everywhere except tests which are testing the built-in compatibility with it. (`test/qunit/jquery.js`)