### PR TITLE
Appveyor: add tests in Chrome and Firefox

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,12 @@ init:
 
 # Test against this version of Node.js
 environment:
-  nodejs_version: "8"
+  nodejs_version: "8.11"
+  SAUCE_USERNAME:
+    secure: urRYP9EQoRpDVcREo1HoNA==
+  SAUCE_ACCESS_KEY:
+    secure: 34SrDTIXrCWkakMDBCSyEGCWUStBJcbimW0gGnWF7I3zMXRwbetSZO9bHTmT98H2
+  COVERALLS_REPO_TOKEN: "VC97qTfg9RO9TCP7Gqyq8oTlDjvBG8RIC"
 
 build: off
 
@@ -22,9 +27,20 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - yarn
 
+before_test:
+
 test_script:
-  - yarn run build
-  - yarn run check:qunit
+  - if "%APPVEYOR_SCHEDULED_BUILD%" == "True" (
+      yarn test:sauce &&
+      yarn check:third-party
+    ) else (
+      yarn test
+    )
+
+on_success:
+  - yarn coveralls
+  - 7z a -tzip coverage.zip coverage
+  - curl --silent --upload-file coverage.zip https://transfer.sh/coverage.zip
 
 notifications:
   - provider: Email
@@ -35,4 +51,4 @@ notifications:
     on_build_status_changed: true
 
 # Preserve node_modules between builds
-cache: node_modules -> appveyor.yml,package.json,yarn.lock
+cache: node_modules -> yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,3 @@ script:
 notifications:
   email:
     on_success: never
-
-after_success:
-  - cat ./coverage/lcov.info | coveralls
-  - zip -r coverage.zip coverage
-  - curl --upload-file ./coverage.zip https://transfer.sh/coverage.zip

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -70,7 +70,7 @@ module.exports = function (config) {
     } else if (isCi) {
       // AppVeyor
       if (isWindows) {
-        browsers = ['IE']
+        browsers = ['IE', 'ChromeHeadless', 'Firefox']
       // Travis
       } else {
         browsers = ['ChromeHeadless', 'Firefox']

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -71,12 +71,12 @@ module.exports = function (config) {
       // AppVeyor
       if (isWindows) {
         browsers = ['IE', 'ChromeHeadless', 'Firefox']
-      // Travis
-      } else {
-        browsers = ['ChromeHeadless', 'Firefox']
         if (!testMinified) {
           reporters.push('coverage')
         }
+      // Travis
+      } else {
+        browsers = ['ChromeHeadless', 'Firefox']
       }
     } else {
       // Local development

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "check:wappalyzer": "curl 'https://api.wappalyzer.com/lookup-basic/v1/?url=https%3A%2F%2Fsweetalert2.github.io' 2>&1 | grep --quiet 'SweetAlert2'",
     "check:unpkg": "curl --location 'https://unpkg.com/sweetalert2' 2>&1 | grep --quiet 'window.Swal'",
     "check:jsdelivr": "curl --location 'https://cdn.jsdelivr.net/npm/sweetalert2' 2>&1 | grep --quiet 'window.Swal'",
+    "coveralls": "cat coverage/lcov.info | coveralls",
     "release": "node release"
   },
   "bugs": "https://github.com/sweetalert2/sweetalert2/issues",


### PR DESCRIPTION
Appveyor is quite similar in its features to Travis. The nice bonus is IE11.

I guess the next step will be getting rid of Travis and sticking to Appveyor only.

Another bonus is the flexibility of scheduled builds - they could be triggered more than once daily. 