### PR TITLE
chore: get rid of array destructuring in function parameters, save 1kB

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -451,7 +451,9 @@ export function _main (userParams) {
           select.appendChild(placeholder)
         }
         populateInputOptions = (inputOptions) => {
-          inputOptions.forEach(([optionValue, optionLabel]) => {
+          inputOptions.forEach(inputOption => {
+            const optionValue = inputOption[0]
+            const optionLabel = inputOption[1]
             const option = document.createElement('option')
             option.value = optionValue
             option.innerHTML = optionLabel
@@ -469,7 +471,9 @@ export function _main (userParams) {
         const radio = dom.getChildByClass(domCache.content, swalClasses.radio)
         radio.innerHTML = ''
         populateInputOptions = (inputOptions) => {
-          inputOptions.forEach(([radioValue, radioLabel]) => {
+          inputOptions.forEach(inputOption => {
+            const radioValue = inputOption[0]
+            const radioLabel = inputOption[1]
             const radioInput = document.createElement('input')
             const radioLabelElement = document.createElement('label')
             radioInput.type = 'radio'


### PR DESCRIPTION
Currently, babel adds this code to bundle:

![image](https://user-images.githubusercontent.com/6059356/43256293-ffb38af4-90d4-11e8-8209-0efedf83192e.png)

Let's be less cool and get rid of array destructuring in function parameters for the sake of the smaller bundle.

`dist/sweetalert2.js`:

- before: `76713 B`
- after: `75822 B`