### PR TITLE
Add update() method

### DIFF
--- a/src/instanceMethods.js
+++ b/src/instanceMethods.js
@@ -5,4 +5,4 @@ export * from './instanceMethods/enable-disable-elements.js'
 export * from './instanceMethods/show-reset-validation-error.js'
 export * from './instanceMethods/progress-steps.js'
 export * from './instanceMethods/_main.js'
-
+export * from './instanceMethods/update.js'

--- a/src/instanceMethods/update.js
+++ b/src/instanceMethods/update.js
@@ -1,0 +1,44 @@
+import * as dom from '../../src/utils/dom/index'
+import { warn } from '../../src/utils/utils'
+import sweetAlert from '../sweetalert2'
+import privateProps from '../privateProps'
+
+/**
+ * Updates popup options.
+ */
+export function update (params) {
+  const validUpdatableParams = {}
+
+  // assign valid params from `params` to `defaults`
+  Object.keys(params).forEach(param => {
+    if (sweetAlert.isUpdatableParameter(param)) {
+      validUpdatableParams[param] = params[param]
+    } else {
+      warn(`Invalid parameter to update: "${param}". Updatable params are listed here: TODO (@limonte) add link`)
+    }
+  })
+
+  const innerParams = privateProps.innerParams.get(this)
+  const updatedParams = Object.assign({}, innerParams, validUpdatableParams)
+
+  // Actions
+  dom.renderActions(updatedParams)
+
+  // Content
+  dom.renderContent(updatedParams)
+
+  // Icon
+  dom.renderIcon(updatedParams)
+
+  // Image
+  dom.renderImage(updatedParams)
+
+  // Progress steps
+  dom.renderProgressSteps(updatedParams)
+
+  // Title
+  dom.renderTitle(updatedParams)
+
+
+  privateProps.innerParams.set(this, updatedParams)
+}

--- a/src/staticMethods.js
+++ b/src/staticMethods.js
@@ -7,5 +7,6 @@ export * from './staticMethods/showLoading.js'
 export * from './staticMethods/timer.js'
 export {
   isValidParameter,
+  isUpdatableParameter,
   isDeprecatedParameter
 } from './utils/params.js'

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -87,6 +87,39 @@ export const isValidParameter = (paramName) => {
 }
 
 /**
+ * Is valid parameter for Swal.update() method
+ * @param {String} paramName
+ */
+export const isUpdatableParameter = (paramName) => {
+  return [
+    'title',
+    'titleText',
+    'text',
+    'html',
+    'type',
+    'showConfirmButton',
+    'showCancelButton',
+    'confirmButtonText',
+    'confirmButtonAriaLabel',
+    'confirmButtonColor',
+    'confirmButtonClass',
+    'cancelButtonText',
+    'cancelButtonAriaLabel',
+    'cancelButtonColor',
+    'cancelButtonClass',
+    'buttonsStyling',
+    'reverseButtons',
+    'imageUrl',
+    'imageWidth',
+    'imageHeigth',
+    'imageAlt',
+    'imageClass',
+    'progressSteps',
+    'currentProgressStep'
+  ].indexOf(paramName) !== -1
+}
+
+/**
  * Is deprecated parameter
  * @param {String} paramName
  */

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -50,6 +50,17 @@ declare module 'sweetalert2' {
         function isVisible(): boolean;
 
         /**
+         * Updates popup options.
+         * See the SweetAlertOptions interface for the list of accepted fields and values.
+         *
+         * ex.
+         *   swal.update({
+         *     type: 'error'
+         *   })
+         */
+        function update(newSettings: SweetAlertOptions): void;
+
+        /**
          * Closes the currently open SweetAlert2 modal programmatically.
          *
          * @param onComplete An optional callback to be called when the alert has finished closing.
@@ -279,6 +290,13 @@ declare module 'sweetalert2' {
          * @param paramName The parameter to check
          */
         function isValidParameter(paramName: string): boolean;
+
+        /**
+         * Determines if a given parameter name is valid for Swal.update() method.
+         *
+         * @param paramName The parameter to check
+         */
+        function isUpdatableParameter(paramName: string): boolean;
 
         /**
          * Normalizes the arguments you can give to Swal.fire() in an object of type SweetAlertOptions.

--- a/test/qunit/methods/update.js
+++ b/test/qunit/methods/update.js
@@ -1,0 +1,32 @@
+const { Swal, SwalWithoutAnimation, isVisible } = require('../helpers')
+
+QUnit.test('update() method', (assert) => {
+  SwalWithoutAnimation.fire()
+
+  Swal.update({
+    title: 'New title',
+    html: 'New content',
+    type: 'success',
+    showConfirmButton: false,
+    showCancelButton: true,
+    cancelButtonText: 'New cancel button text',
+    imageUrl: '/assets/swal2-logo.png'
+  })
+
+  assert.equal(Swal.getTitle().textContent, 'New title')
+  assert.equal(Swal.getContent().textContent, 'New content')
+
+  assert.ok(isVisible(Swal.getIcons().filter(icon => icon.classList.contains('swal2-success'))[0]))
+
+  assert.ok(isVisible(Swal.getImage()))
+  assert.ok(Swal.getImage().src.indexOf('/assets/swal2-logo.png') > 0)
+
+  assert.notOk(isVisible(Swal.getConfirmButton()))
+  assert.ok(isVisible(Swal.getCancelButton()))
+  assert.equal(Swal.getCancelButton().textContent, 'New cancel button text')
+})
+
+QUnit.test('isUpdatableParameter() method', (assert) => {
+  assert.ok(Swal.isUpdatableParameter('title'))
+  assert.notOk(Swal.isUpdatableParameter('preConfirm'))
+})


### PR DESCRIPTION
I believe this is much better than #1152

Renderers were introduced recently, there are currently 2 renderers: https://github.com/sweetalert2/sweetalert2/tree/master/src/utils/dom/renderers

Renderers allow to re-render particular parts of a popup without re-initialization:

![peek 2018-07-27 10-18](https://user-images.githubusercontent.com/6059356/43308279-bf70a1d8-9189-11e8-8aa2-b216b8967d00.gif)

I'm quite happy with this implementation. What do you think @zenflow? 