### PR TITLE
fix(focus): fallback focus to body for IE11

### DIFF
--- a/src/globalState.js
+++ b/src/globalState.js
@@ -12,6 +12,8 @@ export const restoreActiveElement = () => {
     if (globalState.previousActiveElement && globalState.previousActiveElement.focus) {
       globalState.previousActiveElement.focus()
       globalState.previousActiveElement = null
+    } else if (document.body) {
+      document.body.focus()
     }
   }, RESTORE_FOCUS_TIMEOUT) // issues/900
   if (typeof x !== 'undefined' && typeof y !== 'undefined') { // IE doesn't have scrollX/scrollY support

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -135,9 +135,8 @@ export function _main (userParams) {
     }
 
     // Mouse interactions
-    const onButtonEvent = (event) => {
-      const e = event || window.event
-      const target = e.target || e.srcElement
+    const onButtonEvent = (e) => {
+      const target = e.target
       const {confirmButton, cancelButton} = domCache
       const targetedConfirm = confirmButton && (confirmButton === target || confirmButton.contains(target))
       const targetedCancel = cancelButton && (cancelButton === target || cancelButton.contains(target))
@@ -317,7 +316,7 @@ export function _main (userParams) {
 
         // TAB
       } else if (e.key === 'Tab') {
-        const targetElement = e.target || e.srcElement
+        const targetElement = e.target
 
         const focusableElements = dom.getFocusableElements(innerParams.focusCancel)
         let btnIndex = -1


### PR DESCRIPTION
From https://developer.paciellogroup.com/blog/2018/06/the-current-state-of-modal-dialog-accessibility/

> When a modal dialog is closed, focus should return to the control that initially activated the dialog. This will allow keyboard and screen reader users to continue to parse the document from where they left off. If a modal dialog was not initiated by a purposeful user action (boo), or the element that had activated the dialog is no longer in the DOM, then closing the dialog should place the user’s focus in a logical location. e.g. if a dialog was opened on page load, then focus could be placed on either the body or main element. 