### PR TITLE
Set aria-hidden="true" to all body children when modal is sshown

### DIFF
--- a/src/staticMethods/close.js
+++ b/src/staticMethods/close.js
@@ -1,5 +1,6 @@
 import { undoScrollbar } from '../utils/scrollbarFix'
 import { undoIOSfix } from '../utils/iosFix'
+import { unsetAriaHidden } from '../utils/aria'
 import * as dom from '../utils/dom/index'
 import { swalClasses } from '../utils/classes.js'
 import globalState, { restoreActiveElement } from '../globalState'
@@ -45,6 +46,7 @@ const close = (onClose, onAfterClose) => {
     if (dom.isModal()) {
       undoScrollbar()
       undoIOSfix()
+      unsetAriaHidden()
     }
 
     if (onAfterClose !== null && typeof onAfterClose === 'function') {

--- a/src/utils/aria.js
+++ b/src/utils/aria.js
@@ -1,0 +1,28 @@
+import { toArray } from './utils'
+
+// From https://developer.paciellogroup.com/blog/2018/06/the-current-state-of-modal-dialog-accessibility/
+// Adding aria-hidden="true" to elements outside of the active modal dialog ensures that
+// elements not within the active modal dialog will not be surfaced if a user opens a screen
+// reader’s list of elements (headings, form controls, landmarks, etc.) in the document.
+
+export const setAriaHidden = () => {
+  const bodyChildren = toArray(document.body.children)
+  bodyChildren.forEach(el => {
+    if (el.hasAttribute('aria-hidden') ) {
+      el.setAttribute('data-previous-aria-hidden', el.getAttribute('aria-hidden'))
+    }
+    el.setAttribute('aria-hidden', 'true')
+  })
+}
+
+export const unsetAriaHidden = () => {
+  const bodyChildren = toArray(document.body.children)
+  bodyChildren.forEach(el => {
+    if (el.hasAttribute('data-previous-aria-hidden') ) {
+      el.setAttribute('aria-hidden', el.getAttribute('data-previous-aria-hidden'))
+      el.removeAttribute('data-previous-aria-hidden')
+    } else {
+      el.removeAttribute('aria-hidden')
+    }
+  })
+}

--- a/src/utils/dom/getters.js
+++ b/src/utils/dom/getters.js
@@ -68,7 +68,7 @@ export const getFocusableElements = () => {
 }
 
 export const isModal = () => {
-  return !document.body.classList.contains(swalClasses['toast-shown'])
+  return !isToast() && !document.body.classList.contains(swalClasses['no-backdrop'])
 }
 
 export const isToast = () => {

--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -2,6 +2,7 @@ import * as dom from './dom/index'
 import { swalClasses } from './classes'
 import { fixScrollbar } from './scrollbarFix'
 import { iOSfix } from './iosFix'
+import { setAriaHidden } from './aria'
 import globalState from '../globalState'
 
 /**
@@ -45,6 +46,7 @@ export const openPopup = (params) => {
   if (dom.isModal()) {
     fixScrollbar()
     iOSfix()
+    setAriaHidden()
   }
   if (!dom.isToast() && !globalState.previousActiveElement) {
     globalState.previousActiveElement = document.activeElement

--- a/test/qunit/a11y.js
+++ b/test/qunit/a11y.js
@@ -32,6 +32,42 @@ QUnit.test('should focus body in there is not previuos active element', (assert)
   }, RESTORE_FOCUS_TIMEOUT)
 })
 
+QUnit.test('should set aria-hidden="true" to all body children if modal', (assert) => {
+  const div = document.createElement('div')
+  const divAriaHiddenFalse = document.createElement('div')
+  divAriaHiddenFalse.setAttribute('aria-hidden', 'false')
+  document.body.appendChild(div)
+  document.body.appendChild(divAriaHiddenFalse)
+
+  SwalWithoutAnimation({})
+  assert.equal(div.getAttribute('aria-hidden'), 'true')
+  assert.equal(divAriaHiddenFalse.getAttribute('aria-hidden'), 'true')
+
+  Swal.close()
+  assert.notOk(div.hasAttribute('aria-hidden'))
+  assert.equal(divAriaHiddenFalse.getAttribute('aria-hidden'), 'false')
+})
+
+QUnit.test('should not set aria-hidden="true" when `backdrop: false`', (assert) => {
+  const div = document.createElement('div')
+  document.body.appendChild(div)
+
+  SwalWithoutAnimation({
+    backdrop: false
+  })
+  assert.notOk(div.hasAttribute('aria-hidden'))
+})
+
+QUnit.test('should not set aria-hidden="true" when `toast: true`', (assert) => {
+  const div = document.createElement('div')
+  document.body.appendChild(div)
+
+  SwalWithoutAnimation({
+    toast: true
+  })
+  assert.notOk(div.hasAttribute('aria-hidden'))
+})
+
 QUnit.test('dialog aria attributes', (assert) => {
   Swal('Modal dialog')
   assert.equal($('.swal2-modal').getAttribute('role'), 'dialog')


### PR DESCRIPTION
Connected to #564 
Connected to #980 
Connected to #1010

From https://developer.paciellogroup.com/blog/2018/06/the-current-state-of-modal-dialog-accessibility/

> Adding `aria-hidden="true"` to elements outside of the active modal dialog ensures that elements not within the active modal dialog will not be surfaced if a user opens a screen reader’s list of elements (headings, form controls, landmarks, etc.) in the document.
