### PR TITLE
fix(arguments): allow undefined args

### DIFF
--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -19,7 +19,7 @@ function SweetAlert (...args) {
     error('This package requires a Promise library, please include a shim to enable it in this browser (See: https://github.com/sweetalert2/sweetalert2/wiki/Migration-from-SweetAlert-to-SweetAlert2#1-ie-support)')
   }
 
-  if (typeof args[0] === 'undefined') {
+  if (args.length === 0) {
     error('At least 1 argument is expected!')
     return false
   }

--- a/src/staticMethods/argsToParams.js
+++ b/src/staticMethods/argsToParams.js
@@ -3,7 +3,11 @@ import { error } from '../utils/utils.js'
 export const argsToParams = (args) => {
   const params = {}
   switch (typeof args[0]) {
-    case 'string':
+    case 'object':
+      Object.assign(params, args[0])
+      break
+
+    default:
       ['title', 'html', 'type'].forEach((name, index) => {
         switch (typeof args[index]) {
           case 'string':
@@ -15,14 +19,6 @@ export const argsToParams = (args) => {
             error(`Unexpected type of ${name}! Expected "string", got ${typeof args[index]}`)
         }
       })
-      break
-
-    case 'object':
-      Object.assign(params, args[0])
-      break
-
-    default:
-      error(`Unexpected type of argument! Expected "string" or "object", got "${typeof args[0]}"`)
   }
   return params
 }

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -12,14 +12,6 @@ QUnit.test('modal shows up', (assert) => {
   assert.ok(Swal.isVisible())
 })
 
-QUnit.test('should throw console error about invalid argument', (assert) => {
-  const _consoleError = console.error
-  const spy = sinon.spy(console, 'error')
-  Swal(10)
-  console.error = _consoleError
-  assert.ok(spy.calledWith('SweetAlert2: Unexpected type of argument! Expected "string" or "object", got "number"'))
-})
-
 QUnit.test('should throw console error about missing arguments', (assert) => {
   const _consoleError = console.error
   const spy = sinon.spy(console, 'error')
@@ -42,6 +34,14 @@ QUnit.test('should throw console error about unexpected params', (assert) => {
   Swal('Hello world!', { type: 'success' })
   console.error = _consoleError
   assert.ok(spy.calledWith('SweetAlert2: Unexpected type of html! Expected "string", got object'))
+})
+
+QUnit.test('should not throw console error about undefined params and treat them as empty strings', (assert) => {
+  const _consoleError = console.error
+  const spy = sinon.spy(console, 'error')
+  Swal(undefined, 'Hello world!', undefined)
+  console.error = _consoleError
+  assert.ok(spy.notCalled)
 })
 
 QUnit.test('should show the popup with OK button in case of empty object passed as an argument', (assert) => {


### PR DESCRIPTION
`swal(undefined, 'hello world')`  should work like `swal('', 'hello world')`