### PR TITLE
fix(release): purge jsdelivr before switching to master

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -23,11 +23,11 @@ module.exports = {
     '@semantic-release/github',
     {
       'path': '@semantic-release/exec',
-      'cmd': 'node tools/cherry-pick-release-to-master'
+      'cmd': 'node tools/purge-jsdelivr'
     },
     {
       'path': '@semantic-release/exec',
-      'cmd': 'node tools/purge-jsdelivr'
+      'cmd': 'node tools/cherry-pick-release-to-master'
     },
   ]
 }


### PR DESCRIPTION
The script needs the `dist` folder which isn't presented in `master` branch.