### PR TITLE
Set align-items for swal container to flex-start

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -100,7 +100,7 @@ body {
   bottom: 0;
   left: 0;
   flex-direction: row;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   padding: 10px;
 
@@ -130,7 +130,7 @@ body {
   }
 
   &.swal2-center {
-    align-items: center;
+    align-items: flex-start;
   }
 
   &.swal2-center-start,


### PR DESCRIPTION
Fix #933 changing the `align-items` property for `swal-container` and
`swal-center` classes to `flex-start`