### PR TITLE
Deprecate extraParams, expose getValidationMessage()

### DIFF
--- a/src/enhancers/withNoNewKeyword.js
+++ b/src/enhancers/withNoNewKeyword.js
@@ -19,6 +19,7 @@ export function withNoNewKeyword (ParentSwal) {
     Object.setPrototypeOf(NoNewKeywordSwal, ParentSwal)
   } else {
     // Android 4.4
+    /* istanbul ignore next */
     // eslint-disable-next-line
     NoNewKeywordSwal.__proto__ = ParentSwal
   }

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -33,7 +33,7 @@ export function _main (userParams) {
     confirmButton: dom.getConfirmButton(),
     cancelButton: dom.getCancelButton(),
     closeButton: dom.getCloseButton(),
-    validationError: dom.getValidationError(),
+    validationMessage: dom.getValidationMessage(),
     progressSteps: dom.getProgressSteps()
   }
   privateProps.domCache.set(this, domCache)
@@ -105,22 +105,22 @@ export function _main (userParams) {
       }
 
       if (innerParams.preConfirm) {
-        this.resetValidationError()
+        this.resetValidationMessage()
         const preConfirmPromise = Promise.resolve().then(() => innerParams.preConfirm(value, innerParams.extraParams))
         if (innerParams.expectRejections) {
           preConfirmPromise.then(
             (preConfirmValue) => succeedWith(preConfirmValue || value),
-            (validationError) => {
+            (validationMessage) => {
               this.hideLoading()
-              if (validationError) {
-                this.showValidationError(validationError)
+              if (validationMessage) {
+                this.showValidationMessage(validationMessage)
               }
             }
           )
         } else {
           preConfirmPromise.then(
             (preConfirmValue) => {
-              if (dom.isVisible(domCache.validationError) || preConfirmValue === false) {
+              if (dom.isVisible(domCache.validationMessage) || preConfirmValue === false) {
                 this.hideLoading()
               } else {
                 succeedWith(preConfirmValue || value)
@@ -159,21 +159,21 @@ export function _main (userParams) {
                       this.enableInput()
                       confirm(inputValue)
                     },
-                    (validationError) => {
+                    (validationMessage) => {
                       this.enableButtons()
                       this.enableInput()
-                      if (validationError) {
-                        this.showValidationError(validationError)
+                      if (validationMessage) {
+                        this.showValidationMessage(validationMessage)
                       }
                     }
                   )
                 } else {
                   validationPromise.then(
-                    (validationError) => {
+                    (validationMessage) => {
                       this.enableButtons()
                       this.enableInput()
-                      if (validationError) {
-                        this.showValidationError(validationError)
+                      if (validationMessage) {
+                        this.showValidationMessage(validationMessage)
                       } else {
                         confirm(inputValue)
                       }
@@ -368,7 +368,7 @@ export function _main (userParams) {
 
     this.enableButtons()
     this.hideLoading()
-    this.resetValidationError()
+    this.resetValidationMessage()
 
     if (innerParams.toast && (innerParams.input || innerParams.footer || innerParams.showCloseButton)) {
       dom.addClass(document.body, swalClasses['toast-column'])

--- a/src/instanceMethods/show-reset-validation-error.js
+++ b/src/instanceMethods/show-reset-validation-error.js
@@ -1,30 +1,31 @@
 import * as dom from '../utils/dom/index'
+import { warnOnce } from '../utils/utils'
 import { swalClasses } from '../utils/classes'
 import privateProps from '../privateProps'
 
-// Show block with validation error
-export function showValidationError (error) {
+// Show block with validation message
+export function showValidationMessage (error) {
   const domCache = privateProps.domCache.get(this)
-  domCache.validationError.innerHTML = error
+  domCache.validationMessage.innerHTML = error
   const popupComputedStyle = window.getComputedStyle(domCache.popup)
-  domCache.validationError.style.marginLeft = `-${popupComputedStyle.getPropertyValue('padding-left')}`
-  domCache.validationError.style.marginRight = `-${popupComputedStyle.getPropertyValue('padding-right')}`
-  dom.show(domCache.validationError)
+  domCache.validationMessage.style.marginLeft = `-${popupComputedStyle.getPropertyValue('padding-left')}`
+  domCache.validationMessage.style.marginRight = `-${popupComputedStyle.getPropertyValue('padding-right')}`
+  dom.show(domCache.validationMessage)
 
   const input = this.getInput()
   if (input) {
     input.setAttribute('aria-invalid', true)
-    input.setAttribute('aria-describedBy', swalClasses.validationerror)
+    input.setAttribute('aria-describedBy', swalClasses['validation-message'])
     dom.focusInput(input)
     dom.addClass(input, swalClasses.inputerror)
   }
 }
 
-// Hide block with validation error
-export function resetValidationError () {
+// Hide block with validation message
+export function resetValidationMessage () {
   const domCache = privateProps.domCache.get(this)
-  if (domCache.validationError) {
-    dom.hide(domCache.validationError)
+  if (domCache.validationMessage) {
+    dom.hide(domCache.validationMessage)
   }
 
   const input = this.getInput()
@@ -33,4 +34,16 @@ export function resetValidationError () {
     input.removeAttribute('aria-describedBy')
     dom.removeClass(input, swalClasses.inputerror)
   }
+}
+
+// @deprecated
+export function resetValidationError() {
+  warnOnce(`Swal.resetValidationError() is deprecated and will be removed in the next major release, use Swal.resetValidationMessage() instead`)
+  resetValidationMessage.bind(this)()
+}
+
+// @deprecated
+export function showValidationError(error) {
+  warnOnce(`Swal.showValidationError() is deprecated and will be removed in the next major release, use Swal.showValidationMessage() instead`)
+  showValidationMessage.bind(this)(error)
 }

--- a/src/staticMethods/adaptInputValidator.js
+++ b/src/staticMethods/adaptInputValidator.js
@@ -4,6 +4,6 @@
 export const adaptInputValidator = (legacyValidator) => {
   return function adaptedInputValidator (inputValue, extraParams) {
     return legacyValidator.call(this, inputValue, extraParams)
-      .then(() => undefined, validationError => validationError)
+      .then(() => undefined, validationMessage => validationMessage)
   }
 }

--- a/src/staticMethods/dom.js
+++ b/src/staticMethods/dom.js
@@ -14,6 +14,7 @@ export {
   getCancelButton,
   getFooter,
   getFocusableElements,
+  getValidationMessage,
   isLoading
 } from '../utils/dom/index'
 

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -557,15 +557,15 @@ body {
     }
   }
 
-  .swal2-validationerror {
+  .swal2-validation-message {
     display: none;
     align-items: center;
-    justify-content: $swal2-validationerror-justify-content;
-    padding: $swal2-validationerror-padding;
-    background: $swal2-validationerror-background;
-    color: $swal2-validationerror-color;
-    font-size: $swal2-validationerror-font-size;
-    font-weight: $swal2-validationerror-font-weight;
+    justify-content: $swal2-validation-message-justify-content;
+    padding: $swal2-validation-message-padding;
+    background: $swal2-validation-message-background;
+    color: $swal2-validation-message-color;
+    font-size: $swal2-validation-message-font-size;
+    font-weight: $swal2-validation-message-font-weight;
     overflow: hidden;
 
     &::before {
@@ -575,13 +575,13 @@ body {
       height: 1.5em;
       margin: 0 .625em;
       border-radius: 50%;
-      background-color: $swal2-validationerror-icon-background;
-      color: $swal2-validationerror-icon-color;
+      background-color: $swal2-validation-message-icon-background;
+      color: $swal2-validation-message-icon-color;
       font-weight: 600;
       line-height: 1.5em;
       text-align: center;
       content: '!';
-      zoom: $swal2-validationerror-icon-zoom;
+      zoom: $swal2-validation-message-icon-zoom;
     }
   }
 }

--- a/src/toasts.scss
+++ b/src/toasts.scss
@@ -106,7 +106,7 @@ body {
         font-size: $swal2-toast-input-font-size;
       }
 
-      .swal2-validationerror {
+      .swal2-validation-message {
         font-size: $swal2-toast-validation-font-size;
       }
     }

--- a/src/utils/classes.js
+++ b/src/utils/classes.js
@@ -43,7 +43,7 @@ export const swalClasses = prefix([
   'label',
   'textarea',
   'inputerror',
-  'validationerror',
+  'validation-message',
   'progresssteps',
   'activeprogressstep',
   'progresscircle',

--- a/src/utils/dom/animationEndEvent.js
+++ b/src/utils/dom/animationEndEvent.js
@@ -2,6 +2,7 @@ import { isNodeEnv } from '../isNodeEnv'
 
 export const animationEndEvent = (() => {
   // Prevent run in Node env
+  /* istanbul ignore if */
   if (isNodeEnv()) {
     return false
   }

--- a/src/utils/dom/getters.js
+++ b/src/utils/dom/getters.js
@@ -24,7 +24,7 @@ export const getImage = () => elementByClass(swalClasses.image)
 
 export const getProgressSteps = () => elementByClass(swalClasses.progresssteps)
 
-export const getValidationError = () => elementByClass(swalClasses.validationerror)
+export const getValidationMessage = () => elementByClass(swalClasses['validation-message'])
 
 export const getConfirmButton = () => elementByClass(swalClasses.confirm)
 

--- a/src/utils/dom/init.js
+++ b/src/utils/dom/init.js
@@ -46,7 +46,7 @@ const sweetHTML = `
        <span class="${swalClasses.label}"></span>
      </label>
      <textarea class="${swalClasses.textarea}"></textarea>
-     <div class="${swalClasses.validationerror}" id="${swalClasses.validationerror}"></div>
+     <div class="${swalClasses['validation-message']}" id="${swalClasses['validation-message']}"></div>
    </div>
    <div class="${swalClasses.actions}">
      <button type="button" class="${swalClasses.confirm}">OK</button>
@@ -106,26 +106,26 @@ export const init = (params) => {
   }
 
   let oldInputVal // IE11 workaround, see #1109 for details
-  const resetValidationError = (e) => {
+  const resetValidationMessage = (e) => {
     if (sweetAlert.isVisible() && oldInputVal !== e.target.value) {
-      sweetAlert.resetValidationError()
+      sweetAlert.resetValidationMessage()
     }
     oldInputVal = e.target.value
   }
 
-  input.oninput = resetValidationError
-  file.onchange = resetValidationError
-  select.onchange = resetValidationError
-  checkbox.onchange = resetValidationError
-  textarea.oninput = resetValidationError
+  input.oninput = resetValidationMessage
+  file.onchange = resetValidationMessage
+  select.onchange = resetValidationMessage
+  checkbox.onchange = resetValidationMessage
+  textarea.oninput = resetValidationMessage
 
   range.oninput = (e) => {
-    resetValidationError(e)
+    resetValidationMessage(e)
     rangeOutput.value = range.value
   }
 
   range.onchange = (e) => {
-    resetValidationError(e)
+    resetValidationMessage(e)
     range.nextSibling.value = range.value
   }
 

--- a/src/utils/dom/init.js
+++ b/src/utils/dom/init.js
@@ -75,6 +75,7 @@ export const init = (params) => {
     )
   }
 
+  /* istanbul ignore if */
   if (isNodeEnv()) {
     error('SweetAlert2 requires document to initialize')
     return

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -53,6 +53,7 @@ const defaultParams = {
   inputClass: null,
   inputAttributes: {},
   inputValidator: null,
+  validationMessage: null,
   grow: false,
   position: 'center',
   progressSteps: [],

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -68,7 +68,8 @@ const defaultParams = {
 
 export const deprecatedParams = [
   'useRejections',
-  'expectRejections'
+  'expectRejections',
+  'extraParams'
 ]
 
 const toastIncompatibleParams = [

--- a/src/utils/setParameters.js
+++ b/src/utils/setParameters.js
@@ -20,6 +20,14 @@ export default function setParameters (params) {
     })
   }
 
+  // params.extraParams is @deprecated
+  if (params.validationMessage) {
+    if (typeof params.extraParams !== 'object') {
+      params.extraParams = {}
+    }
+    params.extraParams.validationMessage = params.validationMessage
+  }
+
   // Determine if the custom target element is valid
   if (
     !params.target ||

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -55,16 +55,16 @@ $swal2-input-font-size: 1.125em !default;
 $swal2-textarea-height: 6.75em !default;
 $swal2-textarea-padding: .75em !default;
 
-// VALIDATION ERROR
-$swal2-validationerror-justify-content: center !default;
-$swal2-validationerror-padding: .625em !default;
-$swal2-validationerror-background: lighten($swal2-black, 94) !default;
-$swal2-validationerror-color: lighten($swal2-black, 40) !default;
-$swal2-validationerror-font-size: 1em !default;
-$swal2-validationerror-font-weight: 300 !default;
-$swal2-validationerror-icon-background: $swal2-error !default;
-$swal2-validationerror-icon-color: $swal2-white !default;
-$swal2-validationerror-icon-zoom: normal !default;
+// VALIDATION MESSAGE
+$swal2-validation-message-justify-content: center !default;
+$swal2-validation-message-padding: .625em !default;
+$swal2-validation-message-background: lighten($swal2-black, 94) !default;
+$swal2-validation-message-color: lighten($swal2-black, 40) !default;
+$swal2-validation-message-font-size: 1em !default;
+$swal2-validation-message-font-weight: 300 !default;
+$swal2-validation-message-icon-background: $swal2-error !default;
+$swal2-validation-message-icon-color: $swal2-white !default;
+$swal2-validation-message-icon-zoom: normal !default;
 
 // PROGRESS STEPS
 $swal2-progress-steps-margin: 0 0 1.25em !default;

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -734,6 +734,19 @@ declare module 'sweetalert2' {
         inputValidator?: (inputValue: string) => SyncOrAsync<string | null>;
 
         /**
+         * A custom validation message for default validators (email, url).
+         *
+         * ex.
+         *   swal({
+         *     input: 'email',
+         *     validationMesage: 'Adresse e-mail invalide'
+         *   })
+         *
+         * @default null
+         */
+        validationMesage?: string;
+
+        /**
          * A custom CSS class for the input field.
          *
          * @default null

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -182,13 +182,28 @@ declare module 'sweetalert2' {
          * Shows a validation error message.
          *
          * @param error The error message.
+         * @deprecated
          */
         function showValidationError(error: string): void;
 
         /**
          * Hides validation error message.
+         *
+         * @deprecated
          */
         function resetValidationError(): void;
+
+        /**
+         * Shows a validation message.
+         *
+         * @param validationMessage The validation message.
+         */
+        function showValidationMessage(validationMessage: string): void;
+
+        /**
+         * Hides validation message.
+         */
+        function resetValidationMessage(): void;
 
         /**
          * Gets the input DOM node, this method works with input parameter.
@@ -204,6 +219,11 @@ declare module 'sweetalert2' {
          * Enables the modal input.
          */
         function enableInput(): void;
+
+        /**
+         * Gets the validation message container.
+         */
+        function getValidationMessage(): HTMLElement;
 
         /**
          * If `timer` parameter is set, returns number os milliseconds of timer remained.
@@ -804,7 +824,7 @@ declare module 'sweetalert2' {
 
         /**
          * Determines whether given `inputValidator` and `preConfirm` functions should be expected to to signal
-         * validation errors by rejecting, or by their respective means (see documentation for each option).
+         * validation message by rejecting, or by their respective means (see documentation for each option).
          *
          * @default false
          * @deprecated

--- a/test/qunit/params/input.js
+++ b/test/qunit/params/input.js
@@ -60,8 +60,8 @@ QUnit.test('input email + built-in email validation', (assert) => {
   Swal.getInput().value = invalidEmailAddress
   Swal.clickConfirm()
   setTimeout(() => {
-    assert.ok(isVisible(Swal.getValidationError()))
-    assert.ok(Swal.getValidationError().textContent.indexOf('Invalid email address') !== -1)
+    assert.ok(isVisible(Swal.getValidationMessage()))
+    assert.ok(Swal.getValidationMessage().textContent.indexOf('Invalid email address') !== -1)
 
     Swal.getInput().value = validEmailAddress
     triggerKeydownEvent(Swal.getInput(), 'Enter')
@@ -81,8 +81,8 @@ QUnit.test('input url + built-in url validation', (assert) => {
   Swal.getInput().value = invalidUrl
   Swal.clickConfirm()
   setTimeout(() => {
-    assert.ok(isVisible(Swal.getValidationError()))
-    assert.ok(Swal.getValidationError().textContent.indexOf('Invalid URL') !== -1)
+    assert.ok(isVisible(Swal.getValidationMessage()))
+    assert.ok(Swal.getValidationMessage().textContent.indexOf('Invalid URL') !== -1)
 
     Swal.getInput().value = validUrl
     triggerKeydownEvent(Swal.getInput(), 'Enter')

--- a/test/qunit/params/input.js
+++ b/test/qunit/params/input.js
@@ -60,8 +60,8 @@ QUnit.test('input email + built-in email validation', (assert) => {
   Swal.getInput().value = invalidEmailAddress
   Swal.clickConfirm()
   setTimeout(() => {
-    assert.ok(isVisible($('.swal2-validationerror')))
-    assert.ok($('.swal2-validationerror').textContent.indexOf('Invalid email address') !== -1)
+    assert.ok(isVisible(Swal.getValidationError()))
+    assert.ok(Swal.getValidationError().textContent.indexOf('Invalid email address') !== -1)
 
     Swal.getInput().value = validEmailAddress
     triggerKeydownEvent(Swal.getInput(), 'Enter')
@@ -81,8 +81,8 @@ QUnit.test('input url + built-in url validation', (assert) => {
   Swal.getInput().value = invalidUrl
   Swal.clickConfirm()
   setTimeout(() => {
-    assert.ok(isVisible($('.swal2-validationerror')))
-    assert.ok($('.swal2-validationerror').textContent.indexOf('Invalid URL') !== -1)
+    assert.ok(isVisible(Swal.getValidationError()))
+    assert.ok(Swal.getValidationError().textContent.indexOf('Invalid URL') !== -1)
 
     Swal.getInput().value = validUrl
     triggerKeydownEvent(Swal.getInput(), 'Enter')

--- a/test/qunit/params/validationMessage.js
+++ b/test/qunit/params/validationMessage.js
@@ -1,25 +1,31 @@
 const { Swal, SwalWithoutAnimation, isVisible, TIMEOUT } = require('../helpers')
 
 QUnit.test('input: email + validationMessage', (assert) => {
+  const done = assert.async()
+
   SwalWithoutAnimation({
     input: 'email',
     validationMessage: 'custom email validation message'
   })
   Swal.clickConfirm()
   setTimeout(() => {
-    assert.ok(isVisible(Swal.getValidationError()))
-    assert.equal(Swal.getValidationError().textContent, 'custom email validation message')
+    assert.ok(isVisible(Swal.getValidationMessage()))
+    assert.equal(Swal.getValidationMessage().textContent, 'custom email validation message')
+    done()
   }, TIMEOUT)
 })
 
 QUnit.test('input: url + validationMessage', (assert) => {
+  const done = assert.async()
+
   SwalWithoutAnimation({
     input: 'url',
     validationMessage: 'custom url validation message'
   })
   Swal.clickConfirm()
   setTimeout(() => {
-    assert.ok(isVisible(Swal.getValidationError()))
-    assert.equal(Swal.getValidationError().textContent, 'custom url validation message')
+    assert.ok(isVisible(Swal.getValidationMessage()))
+    assert.equal(Swal.getValidationMessage().textContent, 'custom url validation message')
+    done()
   }, TIMEOUT)
 })

--- a/test/qunit/params/validationMessage.js
+++ b/test/qunit/params/validationMessage.js
@@ -1,0 +1,25 @@
+const { Swal, SwalWithoutAnimation, isVisible, TIMEOUT } = require('../helpers')
+
+QUnit.test('input: email + validationMessage', (assert) => {
+  SwalWithoutAnimation({
+    input: 'email',
+    validationMessage: 'custom email validation message'
+  })
+  Swal.clickConfirm()
+  setTimeout(() => {
+    assert.ok(isVisible(Swal.getValidationError()))
+    assert.equal(Swal.getValidationError().textContent, 'custom email validation message')
+  }, TIMEOUT)
+})
+
+QUnit.test('input: url + validationMessage', (assert) => {
+  SwalWithoutAnimation({
+    input: 'url',
+    validationMessage: 'custom url validation message'
+  })
+  Swal.clickConfirm()
+  setTimeout(() => {
+    assert.ok(isVisible(Swal.getValidationError()))
+    assert.equal(Swal.getValidationError().textContent, 'custom url validation message')
+  }, TIMEOUT)
+})

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -209,14 +209,14 @@ QUnit.test('validation error', (assert) => {
   const inputValidator = (value) => Promise.resolve(!value && 'no falsy values')
 
   SwalWithoutAnimation({ input: 'text', inputValidator })
-  assert.ok(isHidden($('.swal2-validationerror')))
+  assert.ok(isHidden(Swal.getValidationError()))
   setTimeout(() => {
     const initialModalHeight = $('.swal2-modal').offsetHeight
 
     Swal.clickConfirm()
     setTimeout(() => {
-      assert.ok(isVisible($('.swal2-validationerror')))
-      assert.equal($('.swal2-validationerror').textContent, 'no falsy values')
+      assert.ok(isVisible(Swal.getValidationError()))
+      assert.equal(Swal.getValidationError().textContent, 'no falsy values')
       assert.ok($('.swal2-input').getAttribute('aria-invalid'))
       assert.ok($('.swal2-modal').offsetHeight > initialModalHeight)
 
@@ -228,7 +228,7 @@ QUnit.test('validation error', (assert) => {
       event.initEvent('input', true, true)
       $('.swal2-input').dispatchEvent(event)
 
-      assert.ok(isHidden($('.swal2-validationerror')))
+      assert.ok(isHidden(Swal.getValidationError()))
       assert.notOk($('.swal2-input').getAttribute('aria-invalid'))
       assert.ok($('.swal2-modal').offsetHeight === initialModalHeight)
       done()

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -204,19 +204,19 @@ QUnit.test('set and reset defaults', (assert) => {
   Swal.clickCancel()
 })
 
-QUnit.test('validation error', (assert) => {
+QUnit.test('validation message', (assert) => {
   const done = assert.async()
   const inputValidator = (value) => Promise.resolve(!value && 'no falsy values')
 
   SwalWithoutAnimation({ input: 'text', inputValidator })
-  assert.ok(isHidden(Swal.getValidationError()))
+  assert.ok(isHidden(Swal.getValidationMessage()))
   setTimeout(() => {
     const initialModalHeight = $('.swal2-modal').offsetHeight
 
     Swal.clickConfirm()
     setTimeout(() => {
-      assert.ok(isVisible(Swal.getValidationError()))
-      assert.equal(Swal.getValidationError().textContent, 'no falsy values')
+      assert.ok(isVisible(Swal.getValidationMessage()))
+      assert.equal(Swal.getValidationMessage().textContent, 'no falsy values')
       assert.ok($('.swal2-input').getAttribute('aria-invalid'))
       assert.ok($('.swal2-modal').offsetHeight > initialModalHeight)
 
@@ -228,7 +228,7 @@ QUnit.test('validation error', (assert) => {
       event.initEvent('input', true, true)
       $('.swal2-input').dispatchEvent(event)
 
-      assert.ok(isHidden(Swal.getValidationError()))
+      assert.ok(isHidden(Swal.getValidationMessage()))
       assert.notOk($('.swal2-input').getAttribute('aria-invalid'))
       assert.ok($('.swal2-modal').offsetHeight === initialModalHeight)
       done()

--- a/test/sandbox.html
+++ b/test/sandbox.html
@@ -22,7 +22,7 @@
     showCancelButton: true,
     preConfirm: function (value) {
       if (!value) {
-        Swal.showValidationError('Should not be empty!')
+        Swal.getValidationMessage('Should not be empty!')
       }
     },
     onOpen: function (modal) {


### PR DESCRIPTION
Clean-up for the upcoming (in 2-3 months) major release.

- deprecate `extraParams`, it's the completely unnecessary complexity brought by me 2.5 years ago which was never documented.
- add `validationMessage` param (docs: https://github.com/sweetalert2/sweetalert2.github.io/issues/37)
- expose `getValidationMessage()` getter (docs: https://github.com/sweetalert2/sweetalert2.github.io/issues/38)
- deprecate `showValidationError()` and `resetValidationError()` in favor of `showValidationMessage()` and `resetValidationMessage()`