### PR TITLE
Warn about invalid inputValue

### DIFF
--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -10,11 +10,13 @@ let currentInstance
 // SweetAlert constructor
 function SweetAlert (...args) {
   // Prevent run in Node env
+  /* istanbul ignore if */
   if (typeof window === 'undefined') {
     return
   }
 
   // Check for the existence of Promise
+  /* istanbul ignore if */
   if (typeof Promise === 'undefined') {
     error('This package requires a Promise library, please include a shim to enable it in this browser (See: https://github.com/sweetalert2/sweetalert2/wiki/Migration-from-SweetAlert-to-SweetAlert2#1-ie-support)')
   }
@@ -71,6 +73,7 @@ Object.keys(instanceMethods).forEach(key => {
 
 SweetAlert.DismissReason = DismissReason
 
+/* istanbul ignore next */
 SweetAlert.noop = () => { }
 
 SweetAlert.version = version

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -2,7 +2,7 @@ import defaultParams, { showWarningsForParams } from '../utils/params'
 import * as dom from '../utils/dom/index'
 import { swalClasses } from '../utils/classes'
 import Timer from '../utils/Timer'
-import { formatInputOptions, error, callIfFunction, isThenable } from '../utils/utils'
+import { formatInputOptions, error, warn, callIfFunction, isThenable } from '../utils/utils'
 import setParameters from '../utils/setParameters'
 import globalState from '../globalState'
 import { openPopup } from '../utils/openPopup'
@@ -417,7 +417,11 @@ export function _main (userParams) {
       case 'tel':
       case 'url': {
         input = dom.getChildByClass(domCache.content, swalClasses.input)
-        input.value = innerParams.inputValue
+        if (typeof innerParams.inputValue === 'string' || typeof innerParams.inputValue === 'number') {
+          input.value = innerParams.inputValue
+        } else {
+          warn(`Unexpected type of inputValue! Expected "string" or "number", got "${typeof innerParams.inputValue}"`)
+        }
         input.placeholder = innerParams.inputPlaceholder
         input.type = innerParams.input
         dom.show(input)

--- a/src/instanceMethods/show-reset-validation-error.js
+++ b/src/instanceMethods/show-reset-validation-error.js
@@ -37,12 +37,14 @@ export function resetValidationMessage () {
 }
 
 // @deprecated
+/* istanbul ignore next */
 export function resetValidationError() {
   warnOnce(`Swal.resetValidationError() is deprecated and will be removed in the next major release, use Swal.resetValidationMessage() instead`)
   resetValidationMessage.bind(this)()
 }
 
 // @deprecated
+/* istanbul ignore next */
 export function showValidationError(error) {
   warnOnce(`Swal.showValidationError() is deprecated and will be removed in the next major release, use Swal.showValidationMessage() instead`)
   showValidationMessage.bind(this)(error)

--- a/src/utils/dom/domUtils.js
+++ b/src/utils/dom/domUtils.js
@@ -68,11 +68,3 @@ export const hide = (elem) => {
 
 // borrowed from jquery $(elem).is(':visible') implementation
 export const isVisible = (elem) => elem && (elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)
-
-export const removeStyleProperty = (elem, property) => {
-  if (elem.style.removeProperty) {
-    elem.style.removeProperty(property)
-  } else {
-    elem.style.removeAttribute(property)
-  }
-}

--- a/src/utils/dom/renderers/renderActions.js
+++ b/src/utils/dom/renderers/renderActions.js
@@ -22,7 +22,7 @@ export const renderActions = (params) => {
 
   // Confirm button
   if (params.showConfirmButton) {
-    dom.removeStyleProperty(confirmButton, 'display')
+    confirmButton.style.removeProperty('display')
   } else {
     dom.hide(confirmButton)
   }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -79,4 +79,4 @@ export const warnOnce = (message) => {
  */
 export const callIfFunction = (arg) => typeof arg === 'function' ? arg() : arg
 
-export const isThenable = (arg) => typeof arg === 'object' && typeof arg.then === 'function'
+export const isThenable = (arg) => arg && typeof arg === 'object' && typeof arg.then === 'function'

--- a/test/qunit/params/inputValue.js
+++ b/test/qunit/params/inputValue.js
@@ -1,0 +1,37 @@
+const { Swal, SwalWithoutAnimation, TIMEOUT } = require('../helpers')
+const sinon = require('sinon/pkg/sinon')
+
+QUnit.test('inputValue number', (assert) => {
+  Swal({ input: 'text', inputValue: 333 })
+  assert.ok(Swal.getInput().value, '333')
+})
+
+QUnit.test('inputValue as a Promise', (assert) => {
+  const inputTypes = ['text', 'email', 'number', 'tel', 'textarea']
+  const done = assert.async(inputTypes.length)
+  const value = '1.1 input value'
+  const inputValue = new Promise((resolve) => {
+    resolve('1.1 input value')
+  })
+  inputTypes.forEach(input => {
+    SwalWithoutAnimation({
+      input,
+      inputValue,
+      onOpen: (modal) => {
+        setTimeout(() => {
+          const inputEl = input === 'textarea' ? modal.querySelector('.swal2-textarea') : modal.querySelector('.swal2-input')
+          assert.equal(inputEl.value, input === 'number' ? parseFloat(value) : value)
+          done()
+        }, TIMEOUT)
+      }
+    })
+  })
+})
+
+QUnit.test('should throw console warning about unexpected type of inputValue', (assert) => {
+  const _consoleWarn = console.warn
+  const spy = sinon.spy(console, 'warn')
+  Swal({ input: 'text', inputValue: undefined })
+  console.warn = _consoleWarn
+  assert.ok(spy.calledWith('SweetAlert2: Unexpected type of inputValue! Expected "string" or "number", got "undefined"'))
+})

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -790,25 +790,3 @@ QUnit.test('Custom content', (assert) => {
     done()
   })
 })
-
-QUnit.test('inputValue as a Promise', (assert) => {
-  const inputTypes = ['text', 'email', 'number', 'tel', 'textarea']
-  const done = assert.async(inputTypes.length)
-  const value = '1.1 input value'
-  const inputValue = new Promise((resolve) => {
-    resolve('1.1 input value')
-  })
-  inputTypes.forEach(input => {
-    SwalWithoutAnimation({
-      input,
-      inputValue,
-      onOpen: (modal) => {
-        setTimeout(() => {
-          const inputEl = input === 'textarea' ? modal.querySelector('.swal2-textarea') : modal.querySelector('.swal2-input')
-          assert.equal(inputEl.value, input === 'number' ? parseFloat(value) : value)
-          done()
-        }, TIMEOUT)
-      }
-    })
-  })
-})


### PR DESCRIPTION
Previously, `inputValue: null` and `inputValue: undefined` were behaving incorrectly