### PR TITLE
Revert breaking changes in SASS variables

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -560,12 +560,12 @@ body {
   .swal2-validation-message {
     display: none;
     align-items: center;
-    justify-content: $swal2-validation-message-justify-content;
-    padding: $swal2-validation-message-padding;
-    background: $swal2-validation-message-background;
-    color: $swal2-validation-message-color;
-    font-size: $swal2-validation-message-font-size;
-    font-weight: $swal2-validation-message-font-weight;
+    justify-content: $swal2-validationerror-justify-content;
+    padding: $swal2-validationerror-padding;
+    background: $swal2-validationerror-background;
+    color: $swal2-validationerror-color;
+    font-size: $swal2-validationerror-font-size;
+    font-weight: $swal2-validationerror-font-weight;
     overflow: hidden;
 
     &::before {
@@ -575,13 +575,13 @@ body {
       height: 1.5em;
       margin: 0 .625em;
       border-radius: 50%;
-      background-color: $swal2-validation-message-icon-background;
-      color: $swal2-validation-message-icon-color;
+      background-color: $swal2-validationerror-icon-background;
+      color: $swal2-validationerror-icon-color;
       font-weight: 600;
       line-height: 1.5em;
       text-align: center;
       content: '!';
-      zoom: $swal2-validation-message-icon-zoom;
+      zoom: $swal2-validationerror-icon-zoom;
     }
   }
 }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -56,15 +56,15 @@ $swal2-textarea-height: 6.75em !default;
 $swal2-textarea-padding: .75em !default;
 
 // VALIDATION MESSAGE
-$swal2-validation-message-justify-content: center !default;
-$swal2-validation-message-padding: .625em !default;
-$swal2-validation-message-background: lighten($swal2-black, 94) !default;
-$swal2-validation-message-color: lighten($swal2-black, 40) !default;
-$swal2-validation-message-font-size: 1em !default;
-$swal2-validation-message-font-weight: 300 !default;
-$swal2-validation-message-icon-background: $swal2-error !default;
-$swal2-validation-message-icon-color: $swal2-white !default;
-$swal2-validation-message-icon-zoom: normal !default;
+$swal2-validationerror-justify-content: center !default;
+$swal2-validationerror-padding: .625em !default;
+$swal2-validationerror-background: lighten($swal2-black, 94) !default;
+$swal2-validationerror-color: lighten($swal2-black, 40) !default;
+$swal2-validationerror-font-size: 1em !default;
+$swal2-validationerror-font-weight: 300 !default;
+$swal2-validationerror-icon-background: $swal2-error !default;
+$swal2-validationerror-icon-color: $swal2-white !default;
+$swal2-validationerror-icon-zoom: normal !default;
 
 // PROGRESS STEPS
 $swal2-progress-steps-margin: 0 0 1.25em !default;


### PR DESCRIPTION
Revert renaming SASS variables from https://github.com/sweetalert2/sweetalert2/pull/1227

SASS variables names are the part of public API and should not be changed in patch or minor releases.

Respect semver @limonte and keep your users happy.