### PR TITLE
Trigger onAfterClose after prevActiveElement got focus

### DIFF
--- a/src/globalState.js
+++ b/src/globalState.js
@@ -6,17 +6,20 @@ export default globalState
 
 // Restore previous active (focused) element
 export const restoreActiveElement = () => {
-  const x = window.scrollX
-  const y = window.scrollY
-  globalState.restoreFocusTimeout = setTimeout(() => {
-    if (globalState.previousActiveElement && globalState.previousActiveElement.focus) {
-      globalState.previousActiveElement.focus()
-      globalState.previousActiveElement = null
-    } else if (document.body) {
-      document.body.focus()
+  return new Promise(resolve => {
+    const x = window.scrollX
+    const y = window.scrollY
+    globalState.restoreFocusTimeout = setTimeout(() => {
+      if (globalState.previousActiveElement && globalState.previousActiveElement.focus) {
+        globalState.previousActiveElement.focus()
+        globalState.previousActiveElement = null
+      } else if (document.body) {
+        document.body.focus()
+      }
+      resolve()
+    }, RESTORE_FOCUS_TIMEOUT) // issues/900
+    if (typeof x !== 'undefined' && typeof y !== 'undefined') { // IE doesn't have scrollX/scrollY support
+      window.scrollTo(x, y)
     }
-  }, RESTORE_FOCUS_TIMEOUT) // issues/900
-  if (typeof x !== 'undefined' && typeof y !== 'undefined') { // IE doesn't have scrollX/scrollY support
-    window.scrollTo(x, y)
-  }
+  })
 }

--- a/src/staticMethods/close.js
+++ b/src/staticMethods/close.js
@@ -24,9 +24,11 @@ const close = (onClose, onAfterClose) => {
 
   const removePopupAndResetState = () => {
     if (!dom.isToast()) {
-      restoreActiveElement()
+      restoreActiveElement().then(() => triggerOnAfterClose(onAfterClose))
       globalState.keydownTarget.removeEventListener('keydown', globalState.keydownHandler, { capture: globalState.keydownListenerCapture })
       globalState.keydownHandlerAdded = false
+    } else {
+      triggerOnAfterClose(onAfterClose)
     }
 
     if (container.parentNode) {
@@ -48,12 +50,6 @@ const close = (onClose, onAfterClose) => {
       undoIOSfix()
       unsetAriaHidden()
     }
-
-    if (onAfterClose !== null && typeof onAfterClose === 'function') {
-      setTimeout(() => {
-        onAfterClose()
-      })
-    }
   }
 
   // If animation is supported, animate
@@ -69,6 +65,15 @@ const close = (onClose, onAfterClose) => {
     removePopupAndResetState()
   }
 }
+
+const triggerOnAfterClose = (onAfterClose) => {
+  if (onAfterClose !== null && typeof onAfterClose === 'function') {
+    setTimeout(() => {
+      onAfterClose()
+    })
+  }
+}
+
 export {
   close,
   close as closePopup,

--- a/test/qunit/focus.js
+++ b/test/qunit/focus.js
@@ -86,10 +86,8 @@ QUnit.test('focusCancel', (assert) => {
 //       text: 'I should trap focus inside myself and restore previousActiveElement when I\'m closed',
 //       timer: 1,
 //       onAfterClose: () => {
-//         setTimeout(() => {
-//           assert.equal(document.activeElement, buttonModal)
-//           done()
-//         }, RESTORE_FOCUS_TIMEOUT)
+//         assert.equal(document.activeElement, buttonModal)
+//         done()
 //       }
 //     })
 //   })


### PR DESCRIPTION
Connected to https://github.com/sweetalert2/sweetalert2/issues/751#issuecomment-425275007

There's `RESTORE_FOCUS_TIMEOUT` constant which was introduced in order to fix #900 

Currently, if a developer wants to scroll his document he need to do this:

```js
onAfterClose: () => setTimeout(() => window.scrollTo(0,0), 100) // RESTORE_FOCUS_TIMEOUT is 100
```

this is completely unexpected and undocumented, which leads to poor DX.

After this change the same could be achieved with 

```js
onAfterClose: () => window.scrollTo(0,0)
```
