### PR TITLE
fix(styles): body 'overflow-y: hidden' -> 'overflow: hidden'

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -12,7 +12,7 @@ body {
       '.swal2-no-backdrop',
       '.swal2-toast-shown'
     ) {
-      overflow-y: hidden;
+      overflow: hidden; // not overflow-y because of Sarari, #1253
     }
   }
 

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -81,7 +81,7 @@ QUnit.test('the vertical scrollbar should be hidden and the according padding-ri
   const bodyStyles = window.getComputedStyle(document.body);
 
   assert.equal(bodyStyles.paddingRight, (scrollbarWidth + 30) + 'px')
-  assert.equal(bodyStyles.overflowY, 'hidden')
+  assert.equal(bodyStyles.overflow, 'hidden')
 
   document.body.removeChild(talltDiv)
 })


### PR DESCRIPTION
Fixes #1246 

I don't have an explanation why Safari behaves this way.