### PR TITLE
Proposed fix for long content on ie11

### DIFF
--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -26,6 +26,7 @@ export const openPopup = (params) => {
     dom.removeClass(popup, swalClasses.fade)
   }
   dom.show(popup)
+  if (popup.offsetTop < 0 ) { popup.parentElement.style.alignItems = 'flex-start' }
 
   // scrolling is 'hidden' until animation is done, after that 'auto'
   container.style.overflowY = 'hidden'


### PR DESCRIPTION
As soon as the pop-up is shown, we check for offsetTop, and if negative
set the align-items of the container to flex-start
Proposed fix for #933