### PR TITLE
Added preventDefault() in esc key handling

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -349,6 +349,7 @@ export function _main (userParams) {
 
         // ESC
       } else if ((e.key === 'Escape' || e.key === 'Esc') && callIfFunction(innerParams.allowEscapeKey) === true) {
+        e.preventDefault()
         dismissWith(constructor.DismissReason.esc)
       }
     }


### PR DESCRIPTION
Fix for #1261. 

When the esc key is pressed, preventDefault() is called
to avoid side effects such as browser exiting full screen