### PR TITLE
use `.min.css` to prevent the strig concationation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,7 +87,7 @@ gulp.task('build:styles', () => {
  */
 gulp.task('build:standalone', () => {
   const prettyJs = gulp.src('dist/sweetalert2.js')
-  const prettyCssAsJs = gulp.src('dist/sweetalert2.css')
+  const prettyCssAsJs = gulp.src('dist/sweetalert2.min.css')
     .pipe($.css2js())
   const prettyStandalone = merge(prettyJs, prettyCssAsJs)
     .pipe($.concat('sweetalert2.all.js'))


### PR DESCRIPTION
Fixes #1266
Fixes #1101

As discussed in the previous PR, chenge to useing the `.min.css` file, and stay with css2js with default options.
