### PR TITLE
Support for CSS direction property

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -409,6 +409,11 @@ export function _main (userParams) {
       dom.hide(inputContainer)
     }
 
+    // RTL
+    if (window.getComputedStyle(document.body).direction === 'rtl') {
+      dom.addClass(dom.getContainer(), swalClasses['rtl'])
+    }
+
     let populateInputOptions
     switch (innerParams.input) {
       case 'text':

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -835,13 +835,12 @@ body {
 
 
 // Right-to-left support
-[dir='rtl'] {
+.swal2-rtl {
   .swal2-close {
-    right: auto;
-    left: $swal2-close-button-gap;
+     right: auto;
+     left: $swal2-close-button-gap;
   }
 }
-
 
 // Success icon animation
 .swal2-animate-success-icon {

--- a/src/utils/classes.js
+++ b/src/utils/classes.js
@@ -67,7 +67,8 @@ export const swalClasses = prefix([
   'bottom-right',
   'grow-row',
   'grow-column',
-  'grow-fullscreen'
+  'grow-fullscreen',
+  'rtl'
 ])
 
 export const iconTypes = prefix([


### PR DESCRIPTION
Added handling of page direction (`rtl `or `ltr`) through `window.getComputedStyle(targetElement).direction` instead of relying on specific tag properties / style. This implementation will support for example both `<body/div/whatnot dir="rtl">` and `<body/div/whatnot style="direction: rtl">`. 

In order to achieve that a new CSS class `swal2-rtl `has been introduced. 

Fix #1262 
