### PR TITLE
feat(input): add .checkValidity() support

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -181,6 +181,9 @@ export function _main (userParams) {
                     error => errorWith(error)
                   )
                 }
+              } else if (!this.getInput().checkValidity()) {
+                this.enableButtons()
+                this.showValidationMessage(innerParams.validationMessage)
               } else {
                 confirm(inputValue)
               }

--- a/test/qunit/validation.js
+++ b/test/qunit/validation.js
@@ -1,0 +1,26 @@
+const { Swal, isVisible, TIMEOUT } = require('./helpers')
+
+QUnit.test('input.checkValidity()', (assert) => {
+  const done = assert.async()
+
+  Swal({
+    input: 'tel',
+    inputAttributes: {
+      pattern: '[0-9]{3}-[0-9]{3}-[0-9]{4}'
+    },
+    validationMessage: 'Invalid phone number'
+  }).then(result => {
+    assert.equal(result.value, '123-456-7890')
+    done()
+  })
+
+  Swal.getInput().value = 'blah-blah'
+  Swal.clickConfirm()
+  setTimeout(() => {
+    assert.ok(isVisible(Swal.getValidationMessage()))
+    assert.equal(Swal.getValidationMessage().textContent, 'Invalid phone number')
+
+    Swal.getInput().value = '123-456-7890'
+    Swal.clickConfirm()
+  }, TIMEOUT)
+})


### PR DESCRIPTION
Allow this use-case:

```js
Swal({
  input: 'tel',
  inputAttributes: {
    pattern: '[0-9]{3}-[0-9]{3}-[0-9]{4}'
  },
  validationMessage: 'Invalid phone number'
})
```