### PR TITLE
Check if document.activeElement.blur is defined before using it

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -573,7 +573,7 @@ export function _main (userParams) {
 
     if (!innerParams.toast) {
       if (!callIfFunction(innerParams.allowEnterKey)) {
-        if (document.activeElement) {
+        if (document.activeElement && typeof document.activeElement.blur === 'function') {
           document.activeElement.blur()
         }
       } else if (innerParams.focusCancel && dom.isVisible(domCache.cancelButton)) {


### PR DESCRIPTION
IE11 warns about document.activeElement.blur is undefined when running tests.