### PR TITLE
Fix for Edge crash with setting placeholder attribute

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -404,7 +404,12 @@ export function _main (userParams) {
           }
         }
         for (let attr in innerParams.inputAttributes) {
-          if (['range'].includes(inputTypes[i]) && attr === 'placeholder') { break }
+          // Do not set a placeholder for <input type="range">
+          // it'll crash Edge, #1298
+          if (inputTypes[i] === 'range' && attr === 'placeholder') {
+            continue
+          }
+
           input.setAttribute(attr, innerParams.inputAttributes[attr])
         }
       }

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -404,6 +404,7 @@ export function _main (userParams) {
           }
         }
         for (let attr in innerParams.inputAttributes) {
+          if (['range'].includes(inputTypes[i]) && attr === 'placeholder') { break }
           input.setAttribute(attr, innerParams.inputAttributes[attr])
         }
       }


### PR DESCRIPTION
Setting `placeholder` attribute to a `range` input crashes Edge. (https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8696129/)
