### PR TITLE
Pin dependency on event-stream to the exact version used when it was introduced

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "custom-event-polyfill": "^1.0.6",
     "detect-browser": "^3.0.0",
     "eslint": "^5.9.0",
-    "event-stream": "^4.0.1",
+    "event-stream": "3.3.4",
     "execa": "^1.0.0",
     "git-state": "^4.0.0",
     "gulp": "^4.0.0",


### PR DESCRIPTION
This should remove any urgency on issue #1301