### PR TITLE
Control the number of devDeps in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ install:
   - yarn global add bundlesize@^0.17.0
   - bundlesize -f dist/sweetalert2.all.min.js -s 16kB
 
+  # prevent adding devDependencies with a shitload of subdependencies
+  - if [ `yarn list | wc -l` -gt 4000 ]; then
+      exit 1;
+    fi
+
 script:
   - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then
       yarn run check;


### PR DESCRIPTION
In the JS ecosystem, we believe that it's okay to have thousands of dev-dependencies. 

SweetAlert2 has around 3500, and that's quite average. 

We should aim for the minimal number of devDeps as well as carefully checking every dependency we're adding.

![image](https://user-images.githubusercontent.com/6059356/47900780-ce203000-de86-11e8-97d1-74e829b1b935.png)
