### PR TITLE
feat(api): add .resumeTimer(), .toggleTimer(), .increaseTimer()

### DIFF
--- a/src/staticMethods/timer.js
+++ b/src/staticMethods/timer.js
@@ -1,7 +1,7 @@
 import globalState from '../globalState'
 
 /**
- * If `timer` parameter is set, returns number os milliseconds of timer remained.
+ * If `timer` parameter is set, returns number of milliseconds of timer remained.
  * Otherwise, returns undefined.
  */
 export const getTimerLeft = () => {
@@ -9,9 +9,34 @@ export const getTimerLeft = () => {
 }
 
 /**
- * Stop timer manually. Returns number os milliseconds of timer remained.
- * Otherwise, returns undefined.
+ * Stop timer. Returns number of milliseconds of timer remained.
+ * If `timer` parameter isn't set, returns undefined.
  */
 export const stopTimer = () => {
   return globalState.timeout && globalState.timeout.stop()
+}
+
+/**
+ * Resume timer. Returns number of milliseconds of timer remained.
+ * If `timer` parameter isn't set, returns undefined.
+ */
+export const resumeTimer = () => {
+  return globalState.timeout && globalState.timeout.start()
+}
+
+/**
+ * Resume timer. Returns number of milliseconds of timer remained.
+ * If `timer` parameter isn't set, returns undefined.
+ */
+export const toggleTimer = () => {
+  const timer = globalState.timeout
+  return timer && (timer.running ? timer.stop() : timer.start())
+}
+
+/**
+ * Increase timer. Returns number of milliseconds of an updated timer.
+ * If `timer` parameter isn't set, returns undefined.
+ */
+export const increaseTimer = (n) => {
+  return globalState.timeout && globalState.timeout.increase(n)
 }

--- a/src/utils/Timer.js
+++ b/src/utils/Timer.js
@@ -1,25 +1,36 @@
 export default class Timer {
   constructor (callback, delay) {
-    let id, started, running
-    let remaining = delay
+    let id, started, remaining = delay
+    this.running = false
+
     this.start = function () {
-      running = true
+      this.running = true
       started = new Date()
       id = setTimeout(callback, remaining)
+      return remaining
     }
+
     this.stop = function () {
-      running = false
+      this.running = false
       clearTimeout(id)
       remaining -= new Date() - started
       return remaining
     }
+
+    this.increase = function (n) {
+      this.stop()
+      remaining += n
+      return this.start()
+    }
+
     this.getTimerLeft = function () {
-      if (running) {
+      if (this.running) {
         this.stop()
         this.start()
       }
       return remaining
     }
+
     this.start()
   }
 }

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -226,16 +226,36 @@ declare module 'sweetalert2' {
         function getValidationMessage(): HTMLElement;
 
         /**
-         * If `timer` parameter is set, returns number os milliseconds of timer remained.
+         * If `timer` parameter is set, returns number of milliseconds of timer remained.
          * Otherwise, returns undefined.
          */
         function getTimerLeft(): number | undefined;
 
         /**
-         * Stop timer manually. Returns number os milliseconds of timer remained.
-         * Otherwise, returns undefined.
+         * Stop timer. Returns number of milliseconds of timer remained.
+         * If `timer` parameter isn't set, returns undefined.
          */
         function stopTimer(): number | undefined;
+
+        /**
+         * Resume timer. Returns number of milliseconds of timer remained.
+         * If `timer` parameter isn't set, returns undefined.
+         */
+        function resumeTimer(): number | undefined;
+
+        /**
+         * Toggle timer. Returns number of milliseconds of timer remained.
+         * If `timer` parameter isn't set, returns undefined.
+         */
+        function toggleTimer(): number | undefined;
+
+        /**
+         * Increase timer. Returns number of milliseconds of an updated timer.
+         * If `timer` parameter isn't set, returns undefined.
+         *
+         * @param n The number of milliseconds to add to the currect timer
+         */
+        function increaseTimer(n: number): number | undefined;
 
         /**
          * Provide an array of SweetAlert2 parameters to show multiple modals, one modal after another.

--- a/test/qunit/helpers.js
+++ b/test/qunit/helpers.js
@@ -9,7 +9,7 @@ export const $ = document.querySelector.bind(document)
 export const isVisible = (elem) => elem && (elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)
 export const isHidden = (elem) => !isVisible(elem)
 
-export let TIMEOUT = 1
+export let TIMEOUT = 50
 
 if (browser.name === 'ie') {
   TIMEOUT = 100

--- a/test/qunit/methods/increaseTimer.js
+++ b/test/qunit/methods/increaseTimer.js
@@ -1,19 +1,21 @@
 import { Swal, SwalWithoutAnimation, TIMEOUT } from '../helpers.js'
 
-QUnit.test('stopTimer() method', (assert) => {
+QUnit.test('increaseTimer() method', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation({
     timer: 5 * TIMEOUT
   })
 
-  setTimeout(() => {
-    assert.ok(Swal.stopTimer() > 0)
-  }, 3 * TIMEOUT)
+  assert.ok(Swal.increaseTimer(4 * TIMEOUT) > 0)
 
   setTimeout(() => {
     assert.ok(Swal.isVisible())
-    done()
   }, 7 * TIMEOUT)
+
+  setTimeout(() => {
+    assert.notOk(Swal.isVisible())
+    done()
+  }, 10 * TIMEOUT)
 })
 

--- a/test/qunit/methods/resumeTimer.js
+++ b/test/qunit/methods/resumeTimer.js
@@ -1,19 +1,22 @@
 import { Swal, SwalWithoutAnimation, TIMEOUT } from '../helpers.js'
 
-QUnit.test('stopTimer() method', (assert) => {
+QUnit.test('resumeTimer() method', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation({
     timer: 5 * TIMEOUT
   })
 
-  setTimeout(() => {
-    assert.ok(Swal.stopTimer() > 0)
-  }, 3 * TIMEOUT)
+  Swal.stopTimer()
 
   setTimeout(() => {
     assert.ok(Swal.isVisible())
-    done()
+    Swal.resumeTimer()
   }, 7 * TIMEOUT)
+
+  setTimeout(() => {
+    assert.notOk(Swal.isVisible())
+    done()
+  }, 15 * TIMEOUT)
 })
 

--- a/test/qunit/methods/toggleTimer.js
+++ b/test/qunit/methods/toggleTimer.js
@@ -1,19 +1,22 @@
 import { Swal, SwalWithoutAnimation, TIMEOUT } from '../helpers.js'
 
-QUnit.test('stopTimer() method', (assert) => {
+QUnit.test('toggleTimer() method', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation({
     timer: 5 * TIMEOUT
   })
 
-  setTimeout(() => {
-    assert.ok(Swal.stopTimer() > 0)
-  }, 3 * TIMEOUT)
+  Swal.toggleTimer()
 
   setTimeout(() => {
     assert.ok(Swal.isVisible())
-    done()
+    Swal.toggleTimer()
   }, 7 * TIMEOUT)
+
+  setTimeout(() => {
+    assert.notOk(Swal.isVisible())
+    done()
+  }, 15 * TIMEOUT)
 })
 


### PR DESCRIPTION
Closes #1321 

This PR adds new API methods for controlling `timer`:

- `resumeTimer()`
- `toggleTimer()`
- `increaseTimer(n)`
