### PR TITLE
Use fixed timeouts in timer tests

### DIFF
--- a/test/qunit/helpers.js
+++ b/test/qunit/helpers.js
@@ -9,7 +9,7 @@ export const $ = document.querySelector.bind(document)
 export const isVisible = (elem) => elem && (elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)
 export const isHidden = (elem) => !isVisible(elem)
 
-export let TIMEOUT = 50
+export let TIMEOUT = 1
 
 if (browser.name === 'ie' || browser.name === 'firefox') {
   TIMEOUT = 100

--- a/test/qunit/methods/increaseTimer.js
+++ b/test/qunit/methods/increaseTimer.js
@@ -1,29 +1,29 @@
-import { Swal, SwalWithoutAnimation, TIMEOUT } from '../helpers.js'
+import { Swal, SwalWithoutAnimation } from '../helpers.js'
 
 QUnit.test('increaseTimer() method', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation({
-    timer: 5 * TIMEOUT
+    timer: 500
   })
 
-  assert.ok(Swal.increaseTimer(4 * TIMEOUT) > 0)
+  assert.ok(Swal.increaseTimer(400) > 0)
 
   setTimeout(() => {
     assert.ok(Swal.isVisible())
-  }, 7 * TIMEOUT)
+  }, 700)
 
   setTimeout(() => {
     assert.notOk(Swal.isVisible())
     done()
-  }, 10 * TIMEOUT)
+  }, 1000)
 })
 
 QUnit.test('increaseTimer() after stopTimer()', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation({
-    timer: 5 * TIMEOUT
+    timer: 500
   })
 
   const remainingTime = Swal.stopTimer()
@@ -33,6 +33,6 @@ QUnit.test('increaseTimer() after stopTimer()', (assert) => {
   setTimeout(() => {
     assert.equal(Swal.getTimerLeft(), remainingTime + 10)
     done()
-  }, 1 * TIMEOUT)
+  }, 100)
 })
 

--- a/test/qunit/methods/isTimerRunning.js
+++ b/test/qunit/methods/isTimerRunning.js
@@ -1,10 +1,10 @@
-import { Swal, SwalWithoutAnimation, TIMEOUT } from '../helpers.js'
+import { Swal, SwalWithoutAnimation } from '../helpers.js'
 
 QUnit.test('isTimerRunning() method', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation({
-    timer: 2 * TIMEOUT
+    timer: 200
   })
 
   setTimeout(() => {
@@ -12,5 +12,5 @@ QUnit.test('isTimerRunning() method', (assert) => {
     Swal.stopTimer()
     assert.ok(!Swal.isTimerRunning())
     done()
-  }, 1 * TIMEOUT)
+  }, 100)
 })

--- a/test/qunit/methods/resumeTimer.js
+++ b/test/qunit/methods/resumeTimer.js
@@ -1,10 +1,10 @@
-import { Swal, SwalWithoutAnimation, TIMEOUT } from '../helpers.js'
+import { Swal, SwalWithoutAnimation } from '../helpers.js'
 
 QUnit.test('resumeTimer() method', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation({
-    timer: 5 * TIMEOUT
+    timer: 500
   })
 
   Swal.stopTimer()
@@ -12,19 +12,19 @@ QUnit.test('resumeTimer() method', (assert) => {
   setTimeout(() => {
     assert.ok(Swal.isVisible())
     Swal.resumeTimer()
-  }, 6 * TIMEOUT)
+  }, 600)
 
   setTimeout(() => {
     assert.notOk(Swal.isVisible())
     done()
-  }, 15 * TIMEOUT)
+  }, 1500)
 })
 
 QUnit.test('resumeTimer() method called twice', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation({
-    timer: 5 * TIMEOUT
+    timer: 500
   })
 
   Swal.resumeTimer()
@@ -35,5 +35,5 @@ QUnit.test('resumeTimer() method called twice', (assert) => {
   setTimeout(() => {
     assert.ok(Swal.isVisible())
     done()
-  }, 10 * TIMEOUT)
+  }, 1000)
 })

--- a/test/qunit/methods/stopTimer.js
+++ b/test/qunit/methods/stopTimer.js
@@ -1,20 +1,20 @@
-import { Swal, SwalWithoutAnimation, TIMEOUT } from '../helpers.js'
+import { Swal, SwalWithoutAnimation } from '../helpers.js'
 
 QUnit.test('stopTimer() method', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation({
-    timer: 5 * TIMEOUT
+    timer: 500
   })
 
   setTimeout(() => {
     assert.ok(Swal.stopTimer() > 0)
-  }, 3 * TIMEOUT)
+  }, 300)
 
   setTimeout(() => {
     assert.ok(Swal.isVisible())
     done()
-  }, 7 * TIMEOUT)
+  }, 700)
 })
 
 QUnit.test('stopTimer() method called twice', (assert) => {
@@ -29,6 +29,6 @@ QUnit.test('stopTimer() method called twice', (assert) => {
   setTimeout(() => {
     assert.equal(Swal.stopTimer(), remainingTime)
     done()
-  }, 1 * TIMEOUT)
+  }, 100)
 })
 

--- a/test/qunit/methods/toggleTimer.js
+++ b/test/qunit/methods/toggleTimer.js
@@ -1,10 +1,10 @@
-import { Swal, SwalWithoutAnimation, TIMEOUT } from '../helpers.js'
+import { Swal, SwalWithoutAnimation } from '../helpers.js'
 
 QUnit.test('toggleTimer() method', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation({
-    timer: 5 * TIMEOUT
+    timer: 500
   })
 
   Swal.toggleTimer()
@@ -12,11 +12,11 @@ QUnit.test('toggleTimer() method', (assert) => {
   setTimeout(() => {
     assert.ok(Swal.isVisible())
     Swal.toggleTimer()
-  }, 7 * TIMEOUT)
+  }, 700)
 
   setTimeout(() => {
     assert.notOk(Swal.isVisible())
     done()
-  }, 20 * TIMEOUT)
+  }, 2000)
 })
 


### PR DESCRIPTION
This was my mistake, by using `TIMEOUT` I made tests less readable.