### PR TITLE
fix: do not throw warnings when inputValue is a promise

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -2,7 +2,7 @@ import defaultParams, { showWarningsForParams } from '../utils/params'
 import * as dom from '../utils/dom/index'
 import { swalClasses } from '../utils/classes'
 import Timer from '../utils/Timer'
-import { formatInputOptions, error, warn, callIfFunction, isThenable } from '../utils/utils'
+import { formatInputOptions, error, warn, callIfFunction, isPromise } from '../utils/utils'
 import setParameters from '../utils/setParameters'
 import globalState from '../globalState'
 import { openPopup } from '../utils/openPopup'
@@ -434,8 +434,8 @@ export function _main (userParams) {
         input = dom.getChildByClass(domCache.content, swalClasses.input)
         if (typeof innerParams.inputValue === 'string' || typeof innerParams.inputValue === 'number') {
           input.value = innerParams.inputValue
-        } else {
-          warn(`Unexpected type of inputValue! Expected "string" or "number", got "${typeof innerParams.inputValue}"`)
+        } else if (!isPromise(innerParams.inputValue)) {
+          warn(`Unexpected type of inputValue! Expected "string", "number" or "Promise", got "${typeof innerParams.inputValue}"`)
         }
         setInputPlaceholder(input)
         input.type = innerParams.input
@@ -546,7 +546,7 @@ export function _main (userParams) {
 
     if (innerParams.input === 'select' || innerParams.input === 'radio') {
       const processInputOptions = inputOptions => populateInputOptions(formatInputOptions(inputOptions))
-      if (isThenable(innerParams.inputOptions)) {
+      if (isPromise(innerParams.inputOptions)) {
         constructor.showLoading()
         innerParams.inputOptions.then((inputOptions) => {
           this.hideLoading()
@@ -557,7 +557,7 @@ export function _main (userParams) {
       } else {
         error(`Unexpected type of inputOptions! Expected object, Map or Promise, got ${typeof innerParams.inputOptions}`)
       }
-    } else if (['text', 'email', 'number', 'tel', 'textarea'].includes(innerParams.input) && isThenable(innerParams.inputValue)) {
+    } else if (['text', 'email', 'number', 'tel', 'textarea'].includes(innerParams.input) && isPromise(innerParams.inputValue)) {
       constructor.showLoading()
       dom.hide(input)
       innerParams.inputValue.then((inputValue) => {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -79,4 +79,4 @@ export const warnOnce = (message) => {
  */
 export const callIfFunction = (arg) => typeof arg === 'function' ? arg() : arg
 
-export const isThenable = (arg) => arg && typeof arg === 'object' && typeof arg.then === 'function'
+export const isPromise = (arg) => arg && Promise.resolve(arg) === arg

--- a/test/qunit/params/inputValue.js
+++ b/test/qunit/params/inputValue.js
@@ -7,6 +7,9 @@ QUnit.test('inputValue number', (assert) => {
 })
 
 QUnit.test('inputValue as a Promise', (assert) => {
+  const _consoleWarn = console.warn
+  const spy = sinon.spy(console, 'warn')
+
   const inputTypes = ['text', 'email', 'number', 'tel', 'textarea']
   const done = assert.async(inputTypes.length)
   const value = '1.1 input value'
@@ -26,6 +29,9 @@ QUnit.test('inputValue as a Promise', (assert) => {
       }
     })
   })
+
+  console.warn = _consoleWarn
+  assert.ok(spy.notCalled)
 })
 
 QUnit.test('should throw console warning about unexpected type of inputValue', (assert) => {
@@ -33,5 +39,5 @@ QUnit.test('should throw console warning about unexpected type of inputValue', (
   const spy = sinon.spy(console, 'warn')
   Swal({ input: 'text', inputValue: undefined })
   console.warn = _consoleWarn
-  assert.ok(spy.calledWith('SweetAlert2: Unexpected type of inputValue! Expected "string" or "number", got "undefined"'))
+  assert.ok(spy.calledWith('SweetAlert2: Unexpected type of inputValue! Expected "string", "number" or "Promise", got "undefined"'))
 })


### PR DESCRIPTION
Currently, this code is throwing a warning:

```js
const inputValue = new Promise((resolve) => {
  resolve('input value')
})

Swal({
  input: 'text',
  inputValue
})
```