### PR TITLE
Remove excessive args check

### DIFF
--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -20,11 +20,6 @@ function SweetAlert (...args) {
     error('This package requires a Promise library, please include a shim to enable it in this browser (See: https://github.com/sweetalert2/sweetalert2/wiki/Migration-from-SweetAlert-to-SweetAlert2#1-ie-support)')
   }
 
-  if (args.length === 0) {
-    error('At least 1 argument is expected!')
-    return false
-  }
-
   currentInstance = this
 
   const outerParams = Object.freeze(this.constructor.argsToParams(args))

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -27,14 +27,6 @@ QUnit.test('modal scrolled to top on open', (assert) => {
   })
 })
 
-QUnit.test('should throw console error about missing arguments', (assert) => {
-  const _consoleError = console.error
-  const spy = sinon.spy(console, 'error')
-  Swal()
-  console.error = _consoleError
-  assert.ok(spy.calledWith('SweetAlert2: At least 1 argument is expected!'))
-})
-
 QUnit.test('should throw console warning about invalid params', (assert) => {
   const _consoleWarn = console.warn
   const spy = sinon.spy(console, 'warn')


### PR DESCRIPTION
`swal()` (without arguments) should just work, it's absolutely fine to show the empty modal.

But, the main use-case is mixins, users might want to define a mixin once and use it without arguments, e.g.

```js
const oopsError = swal.mixin({
  type: 'error',
  title: 'Oops, error',
  html: 'Please try again later'
})

oopsError()
```