### PR TITLE
New feature for specifying custom container class

### DIFF
--- a/src/toasts.scss
+++ b/src/toasts.scss
@@ -1,7 +1,6 @@
 body {
   &.swal2-toast-shown {
     .swal2-container {
-      position: fixed;
       background-color: transparent;
 
       &.swal2-shown {

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -64,7 +64,8 @@ const defaultParams = {
   onOpen: null,
   onClose: null,
   useRejections: false,
-  expectRejections: false
+  expectRejections: false,
+  customContainerClass: ''
 }
 
 export const deprecatedParams = [

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -9,6 +9,7 @@ const defaultParams = {
   type: null,
   toast: false,
   customClass: '',
+  customContainerClass: '',
   target: 'body',
   backdrop: true,
   animation: true,
@@ -64,8 +65,7 @@ const defaultParams = {
   onOpen: null,
   onClose: null,
   useRejections: false,
-  expectRejections: false,
-  customContainerClass: ''
+  expectRejections: false
 }
 
 export const deprecatedParams = [

--- a/src/utils/setParameters.js
+++ b/src/utils/setParameters.js
@@ -131,6 +131,10 @@ export default function setParameters (params) {
     dom.addClass(popup, params.customClass)
   }
 
+  if (params.customContainerClass && typeof params.customContainerClass === 'string') {
+    dom.addClass(container, params.customContainerClass)
+  }
+
   // Progress steps
   dom.renderProgressSteps(params)
 

--- a/src/utils/setParameters.js
+++ b/src/utils/setParameters.js
@@ -131,7 +131,7 @@ export default function setParameters (params) {
     dom.addClass(popup, params.customClass)
   }
 
-  if (params.customContainerClass && typeof params.customContainerClass === 'string') {
+  if (params.customContainerClass) {
     dom.addClass(container, params.customContainerClass)
   }
 

--- a/test/qunit/params/positioning.js
+++ b/test/qunit/params/positioning.js
@@ -21,7 +21,7 @@ class PositionChecker {
   }
 
   isTop (clientRect) {
-    return clientRect.top === this._containerTop + this._offset
+    return (Math.abs(clientRect.top - (this._containerTop + this._offset)) < 1)
   }
 
   isCenter (clientRect) {
@@ -30,11 +30,11 @@ class PositionChecker {
   }
 
   isBottom (clientRect) {
-    return clientRect.bottom === this._containerBottom - this._offset
+    return (Math.abs(clientRect.bottom - (this._containerBottom - this._offset)) < 1)
   }
 
   isLeft (clientRect) {
-    return clientRect.left === this._containerLeft + this._offset
+    return (Math.abs(clientRect.left - (this._containerLeft + this._offset)) < 1)
   }
 
   isMiddle (clientRect) {
@@ -43,7 +43,7 @@ class PositionChecker {
   }
 
   isRight (clientRect) {
-    return clientRect.right === this._containerRight - this._offset
+    return (Math.abs(clientRect.right - (this._containerRight - this._offset)) < 1)
   }
 
   check (pos, clientRect) {
@@ -68,8 +68,7 @@ QUnit.test('Modal positions', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
-    console.log(`Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
-    assert.ok(checkPosition.check(position, swalRect), `Failed test position on "${navigator.userAgent}": ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width}) - (${window.innerHeight} ${window.innerWidth})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed modal position on "${navigator.userAgent}": ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width}) - (${window.innerHeight} ${window.innerWidth})`)
     Swal.close()
   })
 
@@ -85,7 +84,7 @@ QUnit.test('Toast positions', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', toast: 'true', position: position })
     let swalRect = document.querySelector('.swal2-container').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed toast position: on "${navigator.userAgent}": ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
     Swal.close()
   })
 
@@ -114,7 +113,7 @@ QUnit.test('Modal positions with target', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width}) - (${window.innerHeight} ${window.innerWidth})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed modal position with target on "${navigator.userAgent}": ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width}) - (${window.innerHeight} ${window.innerWidth})`)
     Swal.close()
   })
 
@@ -142,7 +141,7 @@ QUnit.test('Toast positions with target', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', toast: 'true', position: position })
     let swalRect = document.querySelector('.swal2-container').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed toast position with target on "${navigator.userAgent}": ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
     Swal.close()
   })
 

--- a/test/qunit/params/positioning.js
+++ b/test/qunit/params/positioning.js
@@ -68,7 +68,7 @@ QUnit.test('Modal positions', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), 'Failed test position: ' + position)
+    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
     Swal.close()
   })
 
@@ -84,7 +84,7 @@ QUnit.test('Toast positions', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', toast: 'true', position: position })
     let swalRect = document.querySelector('.swal2-container').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), 'Failed test position: ' + position)
+    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
     Swal.close()
   })
 
@@ -113,7 +113,7 @@ QUnit.test('Modal positions with target', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), 'Failed test position: ' + position)
+    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
     Swal.close()
   })
 
@@ -141,7 +141,7 @@ QUnit.test('Toast positions with target', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', toast: 'true', position: position })
     let swalRect = document.querySelector('.swal2-container').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), 'Failed test position: ' + position)
+    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
     Swal.close()
   })
 

--- a/test/qunit/params/positioning.js
+++ b/test/qunit/params/positioning.js
@@ -25,7 +25,7 @@ class PositionChecker {
   }
 
   isCenter (clientRect) {
-    let rectCenter = clientRect.top + (clientRect.height / 2)
+    let rectCenter = Math.round(clientRect.top + (clientRect.height / 2))
     return rectCenter === this._containerCenter
   }
 
@@ -38,7 +38,7 @@ class PositionChecker {
   }
 
   isMiddle (clientRect) {
-    let clientMiddle = clientRect.left + (clientRect.width / 2)
+    let clientMiddle = Math.round(clientRect.left + (clientRect.width / 2))
     return clientMiddle === this._containerMiddle
   }
 

--- a/test/qunit/params/positioning.js
+++ b/test/qunit/params/positioning.js
@@ -68,7 +68,7 @@ QUnit.test('Modal positions', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), `Failed modal position on "${navigator.userAgent}": ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width}) - (${window.innerHeight} ${window.innerWidth})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed modal position on "${navigator.userAgent}": ${position} \n Swal: (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width})\n Window: (${window.innerHeight} ${window.innerWidth})`)
     Swal.close()
   })
 
@@ -84,7 +84,7 @@ QUnit.test('Toast positions', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', toast: 'true', position: position })
     let swalRect = document.querySelector('.swal2-container').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), `Failed toast position: on "${navigator.userAgent}": ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed toast position: on "${navigator.userAgent}": ${position} \n Swal: (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width})\n Window: (${window.innerHeight} ${window.innerWidth})`)
     Swal.close()
   })
 
@@ -113,7 +113,7 @@ QUnit.test('Modal positions with target', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), `Failed modal position with target on "${navigator.userAgent}": ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width}) - (${window.innerHeight} ${window.innerWidth})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed modal position with target on "${navigator.userAgent}": ${position} \n Swal: (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width})`)
     Swal.close()
   })
 
@@ -141,7 +141,7 @@ QUnit.test('Toast positions with target', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', toast: 'true', position: position })
     let swalRect = document.querySelector('.swal2-container').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), `Failed toast position with target on "${navigator.userAgent}": ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed toast position with target on "${navigator.userAgent}": ${position}\n Swal: (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width})`)
     Swal.close()
   })
 

--- a/test/qunit/params/positioning.js
+++ b/test/qunit/params/positioning.js
@@ -26,7 +26,7 @@ class PositionChecker {
 
   isCenter (clientRect) {
     let rectCenter = Math.round(clientRect.top + (clientRect.height / 2))
-    return rectCenter === this._containerCenter
+    return rectCenter === Math.round(this._containerCenter)
   }
 
   isBottom (clientRect) {
@@ -39,7 +39,7 @@ class PositionChecker {
 
   isMiddle (clientRect) {
     let clientMiddle = Math.round(clientRect.left + (clientRect.width / 2))
-    return clientMiddle === this._containerMiddle
+    return clientMiddle === Math.round(this._containerMiddle)
   }
 
   isRight (clientRect) {

--- a/test/qunit/params/positioning.js
+++ b/test/qunit/params/positioning.js
@@ -25,8 +25,8 @@ class PositionChecker {
   }
 
   isCenter (clientRect) {
-    let rectCenter = Math.round(clientRect.top + (clientRect.height / 2))
-    return rectCenter === Math.round(this._containerCenter)
+    let rectCenter = clientRect.top + (clientRect.height / 2)
+    return (Math.abs(rectCenter - this._containerCenter) < 1)
   }
 
   isBottom (clientRect) {
@@ -38,8 +38,8 @@ class PositionChecker {
   }
 
   isMiddle (clientRect) {
-    let clientMiddle = Math.round(clientRect.left + (clientRect.width / 2))
-    return clientMiddle === Math.round(this._containerMiddle)
+    let clientMiddle = clientRect.left + (clientRect.width / 2)
+    return (Math.abs(clientMiddle - this._containerMiddle) < 1)
   }
 
   isRight (clientRect) {
@@ -68,8 +68,8 @@ QUnit.test('Modal positions', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
-    // console.log(`Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
-    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width}) - (${window.innerHeight} ${window.innerWidth})`)
+    console.log(`Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed test position on "${navigator.userAgent}": ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width}) - (${window.innerHeight} ${window.innerWidth})`)
     Swal.close()
   })
 

--- a/test/qunit/params/positioning.js
+++ b/test/qunit/params/positioning.js
@@ -1,4 +1,4 @@
-const { Swal } = require('../helpers')
+const { Swal, SwalWithoutAnimation } = require('../helpers')
 
 class PositionChecker {
   constructor (container, offset) {
@@ -66,7 +66,7 @@ QUnit.test('Modal positions', (assert) => {
   const checkPosition = new PositionChecker(window, 10)
 
   allowedPostions.forEach(position => {
-    Swal({ animation: 'false', position: position })
+    SwalWithoutAnimation({ position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
     assert.ok(checkPosition.check(position, swalRect), `Failed modal position on "${navigator.userAgent}": ${position} \n Swal: (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width})\n Window: (${window.innerHeight} ${window.innerWidth})`)
     Swal.close()
@@ -82,7 +82,7 @@ QUnit.test('Toast positions', (assert) => {
   const checkPosition = new PositionChecker(window, 0)
 
   allowedPostions.forEach(position => {
-    Swal({ animation: 'false', toast: 'true', position: position })
+    SwalWithoutAnimation({ toast: 'true', position: position })
     let swalRect = document.querySelector('.swal2-container').getBoundingClientRect()
     assert.ok(checkPosition.check(position, swalRect), `Failed toast position: on "${navigator.userAgent}": ${position} \n Swal: (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width})\n Window: (${window.innerHeight} ${window.innerWidth})`)
     Swal.close()
@@ -111,7 +111,7 @@ QUnit.test('Modal positions with target', (assert) => {
   const checkPosition = new PositionChecker(dummyTargetElement, 10)
 
   allowedPostions.forEach(position => {
-    Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', position: position })
+    SwalWithoutAnimation({ target: '#dummy-target', customContainerClass: 'position-absolute', position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
     assert.ok(checkPosition.check(position, swalRect), `Failed modal position with target on "${navigator.userAgent}": ${position} \n Swal: (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width})`)
     Swal.close()
@@ -139,7 +139,7 @@ QUnit.test('Toast positions with target', (assert) => {
   const checkPosition = new PositionChecker(dummyTargetElement, 0)
 
   allowedPostions.forEach(position => {
-    Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', toast: 'true', position: position })
+    SwalWithoutAnimation({ target: '#dummy-target', customContainerClass: 'position-absolute', toast: 'true', position: position })
     let swalRect = document.querySelector('.swal2-container').getBoundingClientRect()
     assert.ok(checkPosition.check(position, swalRect), `Failed toast position with target on "${navigator.userAgent}": ${position}\n Swal: (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width})`)
     Swal.close()

--- a/test/qunit/params/positioning.js
+++ b/test/qunit/params/positioning.js
@@ -1,0 +1,150 @@
+const { Swal } = require('../helpers')
+
+class PositionChecker {
+  constructor (container, offset) {
+    this._offset = offset
+    this._containerTop = (container === window ? 0 : container.offsetTop)
+    this._containerCenter = (container === window) ? window.innerHeight / 2 : container.offsetTop + container.clientHeight / 2
+    this._containerBottom = (container === window) ? window.innerHeight : container.offsetTop + container.clientHeight
+    this._containerLeft = (container === window ? 0 : container.offsetLeft)
+    this._containerMiddle = (container === window) ? window.innerWidth / 2 : container.offsetLeft + container.clientWidth / 2
+    this._containerRight = (container === window) ? window.innerWidth : container.offsetLeft + container.clientWidth
+
+    this._checkFunctions = {
+      'top': this.isTop.bind(this),
+      'center': this.isCenter.bind(this),
+      'bottom': this.isBottom.bind(this),
+      'left': this.isLeft.bind(this),
+      'middle': this.isMiddle.bind(this),
+      'right': this.isRight.bind(this)
+    }
+  }
+
+  isTop (clientRect) {
+    return clientRect.top === this._containerTop + this._offset
+  }
+
+  isCenter (clientRect) {
+    let rectCenter = clientRect.top + (clientRect.height / 2)
+    return rectCenter === this._containerCenter
+  }
+
+  isBottom (clientRect) {
+    return clientRect.bottom === this._containerBottom - this._offset
+  }
+
+  isLeft (clientRect) {
+    return clientRect.left === this._containerLeft + this._offset
+  }
+
+  isMiddle (clientRect) {
+    let clientMiddle = clientRect.left + (clientRect.width / 2)
+    return clientMiddle === this._containerMiddle
+  }
+
+  isRight (clientRect) {
+    return clientRect.right === this._containerRight - this._offset
+  }
+
+  check (pos, clientRect) {
+    let verPos = pos.split('-')[0]
+    let horPos = pos.split('-')[1] || 'middle'
+    return this._checkFunctions[verPos](clientRect) && this._checkFunctions[horPos](clientRect)
+  }
+}
+
+const allowedPostions = [
+  'top-left', 'top', 'top-right',
+  'center-left', 'center', 'center-right',
+  'bottom-left', 'bottom', 'bottom-right'
+]
+
+QUnit.test('Modal positions', (assert) => {
+  const warn = console.warn // Suppress the warnings
+  console.warn = () => true // Suppress the warnings
+
+  const checkPosition = new PositionChecker(window, 10)
+
+  allowedPostions.forEach(position => {
+    Swal({ animation: 'false', position: position })
+    let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
+    assert.ok(checkPosition.check(position, swalRect), 'Failed test position: ' + position)
+    Swal.close()
+  })
+
+  console.warn = warn //  Re-enable warnings
+})
+
+QUnit.test('Toast positions', (assert) => {
+  const warn = console.warn // Suppress the warnings
+  console.warn = () => true // Suppress the warnings
+
+  const checkPosition = new PositionChecker(window, 0)
+
+  allowedPostions.forEach(position => {
+    Swal({ animation: 'false', toast: 'true', position: position })
+    let swalRect = document.querySelector('.swal2-container').getBoundingClientRect()
+    assert.ok(checkPosition.check(position, swalRect), 'Failed test position: ' + position)
+    Swal.close()
+  })
+
+  console.warn = warn //  Re-enable warnings
+})
+
+QUnit.test('Modal positions with target', (assert) => {
+  const warn = console.warn // Suppress the warnings
+  console.warn = () => true // Suppress the warnings
+
+  const targetWidth = 600
+  const targetHeight = 300
+
+  // Add custom style
+  const style = document.createElement('style')
+  style.innerHTML += '.position-absolute { position: absolute; }'
+  document.body.appendChild(style)
+
+  // Create target container
+  const dummyTargetElement = Object.assign(document.createElement('div'), { id: 'dummy-target' })
+  dummyTargetElement.setAttribute('style', `width: ${targetWidth}px; height: ${targetHeight}px; position: relative;`)
+  document.body.appendChild(dummyTargetElement)
+
+  const checkPosition = new PositionChecker(dummyTargetElement, 10)
+
+  allowedPostions.forEach(position => {
+    Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', position: position })
+    let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
+    assert.ok(checkPosition.check(position, swalRect), 'Failed test position: ' + position)
+    Swal.close()
+  })
+
+  dummyTargetElement.parentNode.removeChild(dummyTargetElement) // Remove target element before next test
+  console.warn = warn // Re-enable warnings
+})
+
+QUnit.test('Toast positions with target', (assert) => {
+  const warn = console.warn // Suppress the warnings
+  console.warn = () => true // Suppress the warnings
+
+  const targetWidth = 600
+  const targetHeight = 300
+
+  const style = document.createElement('style')
+  style.innerHTML += '.position-absolute { position: absolute; }'
+  document.body.appendChild(style)
+
+  const dummyTargetElement = Object.assign(document.createElement('div'), { id: 'dummy-target' })
+  dummyTargetElement.setAttribute('style', `width: ${targetWidth}px; height: ${targetHeight}px; position: relative;`)
+  document.body.appendChild(dummyTargetElement)
+
+  const checkPosition = new PositionChecker(dummyTargetElement, 0)
+
+  allowedPostions.forEach(position => {
+    Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', toast: 'true', position: position })
+    let swalRect = document.querySelector('.swal2-container').getBoundingClientRect()
+    assert.ok(checkPosition.check(position, swalRect), 'Failed test position: ' + position)
+    Swal.close()
+  })
+
+  dummyTargetElement.parentNode.removeChild(dummyTargetElement) // Remove target element before next test
+  console.warn = warn // Re-enable warnings
+})

--- a/test/qunit/params/positioning.js
+++ b/test/qunit/params/positioning.js
@@ -68,7 +68,8 @@ QUnit.test('Modal positions', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
+    // console.log(`Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width}) - (${window.innerHeight} ${window.innerWidth})`)
     Swal.close()
   })
 
@@ -113,7 +114,7 @@ QUnit.test('Modal positions with target', (assert) => {
   allowedPostions.forEach(position => {
     Swal({ animation: 'false', target: '#dummy-target', customContainerClass: 'position-absolute', position: position })
     let swalRect = document.querySelector('.swal2-popup').getBoundingClientRect()
-    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})`)
+    assert.ok(checkPosition.check(position, swalRect), `Failed test position: ${position} (${swalRect.top}, ${swalRect.right}, ${swalRect.bottom}, ${swalRect.left})x(${swalRect.height}, ${swalRect.width}) - (${window.innerHeight} ${window.innerWidth})`)
     Swal.close()
   })
 

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -121,6 +121,11 @@ QUnit.test('custom class', (assert) => {
   assert.ok(Swal.getPopup().classList.contains('custom-class'))
 })
 
+QUnit.test('custom container class', (assert) => {
+  Swal({ customContainerClass: 'custom-class' })
+  assert.ok(Swal.getContainer().classList.contains('custom-class'))
+})
+
 QUnit.test('getters', (assert) => {
   Swal('Title', 'Content')
   assert.equal(Swal.getTitle().innerText, 'Title')


### PR DESCRIPTION
As discussed in #1244 this adds a `customContainerClass` parameter to specify a customer class for swal2 container element. 

One possible use case could be to apply custom positioning to the swal in order to display a swal inside a target element.  