### PR TITLE
Drop detect-browser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "babel-plugin-array-includes": "^2.0.3",
     "browser-sync": "^2.26.3",
     "custom-event-polyfill": "^1.0.6",
-    "detect-browser": "^4.0.1",
     "eslint": "^5.11.1",
     "execa": "^1.0.0",
     "gulp": "^4.0.0",

--- a/test/qunit/focus-trap.js
+++ b/test/qunit/focus-trap.js
@@ -1,7 +1,4 @@
-const { Swal, triggerKeydownEvent } = require('./helpers')
-const { detect } = require('detect-browser')
-
-const browser = detect()
+const { Swal, triggerKeydownEvent, isIE } = require('./helpers')
 
 QUnit.test('focus trap forward', (assert) => {
   const done = assert.async()
@@ -50,9 +47,9 @@ QUnit.test('arrow keys', (assert) => {
   Swal.fire({
     showCancelButton: true,
     onOpen: () => {
-      triggerKeydownEvent(document.activeElement, browser.name === 'ie' ? 'Right' : 'ArrowRight')
+      triggerKeydownEvent(document.activeElement, isIE ? 'Right' : 'ArrowRight')
       assert.equal(document.activeElement, Swal.getCancelButton())
-      triggerKeydownEvent(document.activeElement, browser.name === 'ie' ? 'Left' : 'ArrowLeft')
+      triggerKeydownEvent(document.activeElement, isIE ? 'Left' : 'ArrowLeft')
       assert.equal(document.activeElement, Swal.getConfirmButton())
       done()
     }

--- a/test/qunit/helpers.js
+++ b/test/qunit/helpers.js
@@ -1,17 +1,16 @@
 /* global CustomEvent */
 require('custom-event-polyfill') // for IE11
-const { detect } = require('detect-browser')
-
-const browser = detect()
 
 export const $ = document.querySelector.bind(document)
+
+export const isIE = window.navigator.userAgent.indexOf('Trident/') > 0
 
 export const isVisible = (elem) => elem && (elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)
 export const isHidden = (elem) => !isVisible(elem)
 
 export let TIMEOUT = 1
 
-if (browser.name === 'ie') {
+if (isIE) {
   TIMEOUT = 100
 }
 

--- a/test/qunit/params/input.js
+++ b/test/qunit/params/input.js
@@ -1,8 +1,5 @@
-const { $, Swal, SwalWithoutAnimation, isVisible, TIMEOUT, triggerKeydownEvent, dispatchCustomEvent } = require('../helpers')
+const { $, Swal, SwalWithoutAnimation, isVisible, TIMEOUT, triggerKeydownEvent, dispatchCustomEvent, isIE } = require('../helpers')
 const sinon = require('sinon/pkg/sinon')
-const { detect } = require('detect-browser')
-
-const browser = detect()
 
 QUnit.test('should throw console error about unexpected input type', (assert) => {
   const _consoleError = console.error
@@ -149,7 +146,7 @@ QUnit.test('input range', (assert) => {
   assert.equal(input.getAttribute('max'), '10')
   assert.equal(input.value, '5')
 
-  if (browser.name !== 'ie') { // TODO (@limonte): make IE happy
+  if (!isIE) { // TODO (@limonte): make IE happy
     input.value = 10
     dispatchCustomEvent(input, 'input')
     assert.equal(output.textContent, '10')
@@ -160,41 +157,39 @@ QUnit.test('input range', (assert) => {
   }
 })
 
-if (typeof Map !== 'undefined') { // There's no Map in Adroid 4.4 - skip tests
-  QUnit.test('input type "select", inputOptions Map', (assert) => {
-    const inputOptions = new Map()
-    inputOptions.set(2, 'Richard Stallman')
-    inputOptions.set(1, 'Linus Torvalds')
-    SwalWithoutAnimation.fire({
-      input: 'select',
-      inputOptions,
-      inputValue: 1
-    })
-    assert.equal($('.swal2-select').querySelectorAll('option').length, 2)
-    assert.equal($('.swal2-select option:nth-child(1)').innerHTML, 'Richard Stallman')
-    assert.equal($('.swal2-select option:nth-child(1)').value, '2')
-    assert.equal($('.swal2-select option:nth-child(2)').innerHTML, 'Linus Torvalds')
-    assert.equal($('.swal2-select option:nth-child(2)').value, '1')
-    assert.equal($('.swal2-select option:nth-child(2)').selected, true)
+QUnit.test('input type "select", inputOptions Map', (assert) => {
+  const inputOptions = new Map()
+  inputOptions.set(2, 'Richard Stallman')
+  inputOptions.set(1, 'Linus Torvalds')
+  SwalWithoutAnimation.fire({
+    input: 'select',
+    inputOptions,
+    inputValue: 1
   })
+  assert.equal($('.swal2-select').querySelectorAll('option').length, 2)
+  assert.equal($('.swal2-select option:nth-child(1)').innerHTML, 'Richard Stallman')
+  assert.equal($('.swal2-select option:nth-child(1)').value, '2')
+  assert.equal($('.swal2-select option:nth-child(2)').innerHTML, 'Linus Torvalds')
+  assert.equal($('.swal2-select option:nth-child(2)').value, '1')
+  assert.equal($('.swal2-select option:nth-child(2)').selected, true)
+})
 
-  QUnit.test('input type "radio", inputOptions Map', (assert) => {
-    const inputOptions = new Map()
-    inputOptions.set(2, 'Richard Stallman')
-    inputOptions.set(1, 'Linus Torvalds')
-    Swal.fire({
-      input: 'radio',
-      inputOptions,
-      inputValue: 1
-    })
-    assert.equal($('.swal2-radio').querySelectorAll('label').length, 2)
-    assert.equal($('.swal2-radio label:nth-child(1)').textContent, 'Richard Stallman')
-    assert.equal($('.swal2-radio label:nth-child(1) input').value, '2')
-    assert.equal($('.swal2-radio label:nth-child(2)').textContent, 'Linus Torvalds')
-    assert.equal($('.swal2-radio label:nth-child(2) input').value, '1')
-    assert.equal($('.swal2-radio label:nth-child(2) input').checked, true)
+QUnit.test('input type "radio", inputOptions Map', (assert) => {
+  const inputOptions = new Map()
+  inputOptions.set(2, 'Richard Stallman')
+  inputOptions.set(1, 'Linus Torvalds')
+  Swal.fire({
+    input: 'radio',
+    inputOptions,
+    inputValue: 1
   })
-}
+  assert.equal($('.swal2-radio').querySelectorAll('label').length, 2)
+  assert.equal($('.swal2-radio label:nth-child(1)').textContent, 'Richard Stallman')
+  assert.equal($('.swal2-radio label:nth-child(1) input').value, '2')
+  assert.equal($('.swal2-radio label:nth-child(2)').textContent, 'Linus Torvalds')
+  assert.equal($('.swal2-radio label:nth-child(2) input').value, '1')
+  assert.equal($('.swal2-radio label:nth-child(2) input').checked, true)
+})
 
 QUnit.test('input radio', (assert) => {
   Swal.fire({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,11 +2350,6 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-detect-browser@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-4.0.3.tgz#a5d152db1ed636bb479c38ea7df2fa5fec85cf4b"
-  integrity sha512-eUdeEHoRkcPYPdz/fpb8mF0rwzgpcBFx9BbqGkS0H5jrogGi8+sAtEb+3Bi4/CrVIXFjlHm76Cv7AWhranqi4g==
-
 detect-file@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63"


### PR DESCRIPTION
We are detecting IE11 only, no need for the additional dependency for that simple task.

Also, `detect-browser` has shown itself as an unstable dependency:

- https://github.com/DamonOehlman/detect-browser/issues/86
- https://github.com/DamonOehlman/detect-browser/issues/89