### PR TITLE
Replaced deprecated `jsnext:main` with `module` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://sweetalert2.github.io/",
   "description": "A beautiful, responsive, customizable and accessible (WAI-ARIA) replacement for JavaScript's popup boxes, supported fork of sweetalert",
   "main": "dist/sweetalert2.all.js",
-  "jsnext:main": "src/sweetalert2.js",
+  "module": "src/sweetalert2.js",
   "types": "sweetalert2.d.ts",
   "devDependencies": {
     "@babel/core": "^7.2.2",


### PR DESCRIPTION
`jsnext:main` is deprecated in favour of `module` (see also [here](https://github.com/rollup/rollup/wiki/pkg.module))

Closes #1376 and closes #1049 