### PR TITLE
Breaking change: close() as instance method

### DIFF
--- a/src/instanceMethods.js
+++ b/src/instanceMethods.js
@@ -1,6 +1,8 @@
 export * from './instanceMethods/hideLoading.js'
 export * from './instanceMethods/getInput.js'
+export * from './instanceMethods/close.js'
 export * from './instanceMethods/enable-disable-elements.js'
 export * from './instanceMethods/show-reset-validation-error.js'
 export * from './instanceMethods/progress-steps.js'
 export * from './instanceMethods/_main.js'
+

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -47,7 +47,6 @@ export function _main (userParams) {
       resolve({ value })
     }
     const dismissWith = (dismiss) => {
-      // constructor.closePopup()
       this.closePopup()
       resolve({ dismiss })
     }

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -43,11 +43,12 @@ export function _main (userParams) {
   return new Promise((resolve) => {
     // functions to handle all closings/dismissals
     const succeedWith = (value) => {
-      constructor.closePopup(innerParams.onClose, innerParams.onAfterClose) // TODO: make closePopup an *instance* method
+      this.closePopup()
       resolve({ value })
     }
     const dismissWith = (dismiss) => {
-      constructor.closePopup(innerParams.onClose, innerParams.onAfterClose)
+      // constructor.closePopup()
+      this.closePopup()
       resolve({ dismiss })
     }
 

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -7,6 +7,7 @@ import setParameters from '../utils/setParameters.js'
 import globalState from '../globalState.js'
 import { openPopup } from '../utils/openPopup.js'
 import privateProps from '../privateProps.js'
+import privateMethods from '../privateMethods.js'
 
 export function _main (userParams) {
   showWarningsForParams(userParams)
@@ -43,19 +44,17 @@ export function _main (userParams) {
   return new Promise((resolve) => {
     // functions to handle all closings/dismissals
     const succeedWith = (value) => {
-      this.closePopup()
-      resolve({ value })
+      this.closePopup({ value })
     }
     const dismissWith = (dismiss) => {
-      this.closePopup()
-      resolve({ dismiss })
+      this.closePopup({ dismiss })
     }
 
-    const innerFunctions = {
-      swalPromiseResolve: resolve,
-      swalPromiseReject: reject
+    const swalPromise = {
+      'resolve': resolve,
+      'reject': reject
     }
-    privateProps.innerFunctions.set(this, innerFunctions)
+    privateMethods.swalPromise.set(this, swalPromise)
 
     // Close on timer
     if (innerParams.timer) {

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -51,6 +51,12 @@ export function _main (userParams) {
       resolve({ dismiss })
     }
 
+    const innerFunctions = {
+      swalPromiseResolve: resolve,
+      swalPromiseReject: reject
+    }
+    privateProps.innerFunctions.set(this, innerFunctions)
+
     // Close on timer
     if (innerParams.timer) {
       globalState.timeout = new Timer(() => {

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -50,11 +50,7 @@ export function _main (userParams) {
       this.closePopup({ dismiss })
     }
 
-    const swalPromise = {
-      'resolve': resolve,
-      'reject': reject
-    }
-    privateMethods.swalPromise.set(this, swalPromise)
+    privateMethods.swalPromiseResolve.set(this, resolve)
 
     // Close on timer
     if (innerParams.timer) {

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -6,15 +6,15 @@ import * as dom from '../utils/dom/index.js'
 import { swalClasses } from '../utils/classes.js'
 import globalState, { restoreActiveElement } from '../globalState.js'
 import privateProps from '../privateProps.js'
-
+import privateMethods from '../privateMethods.js'
 /*
  * Instance method to close sweetAlert
  */
-export function close () {
+export function close (resolveValue, rejectValue) {
   const container = dom.getContainer()
   const popup = dom.getPopup()
   const innerParams = privateProps.innerParams.get(this)
-  const innerFunctions = privateProps.innerFunctions.get(this)
+  const swalPromise = privateMethods.swalPromise.get(this)
   const onClose = innerParams.onClose
   const onAfterClose = innerParams.onAfterClose
 
@@ -72,7 +72,15 @@ export function close () {
     // Otherwise, remove immediately
     removePopupAndResetState()
   }
-  innerFunctions.swalPromiseResolve({})
+
+  // Resolve / reject Swal promise
+  if (resolveValue) {
+    swalPromise.resolve(resolveValue)
+  } else if (rejectValue) {
+    swalPromise.reject(rejectValue)
+  } else {
+    swalPromise.resolve({})
+  }
 }
 
 const triggerOnAfterClose = (onAfterClose) => {

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -82,5 +82,7 @@ const triggerOnAfterClose = (onAfterClose) => {
 }
 
 export {
-  close as closePopup
+  close as closePopup,
+  close as closeModal,
+  close as closeToast
 }

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -82,7 +82,5 @@ const triggerOnAfterClose = (onAfterClose) => {
 }
 
 export {
-  close as closePopup,
-  close as closeModal,
-  close as closeToast
+  close as closePopup
 }

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -5,13 +5,18 @@ import { unsetAriaHidden } from '../utils/aria.js'
 import * as dom from '../utils/dom/index.js'
 import { swalClasses } from '../utils/classes.js'
 import globalState, { restoreActiveElement } from '../globalState.js'
+import privateProps from '../privateProps.js'
 
 /*
- * Global function to close sweetAlert
+ * Instance method to close sweetAlert
  */
-const close = (onClose, onAfterClose) => {
+export function close () {
   const container = dom.getContainer()
   const popup = dom.getPopup()
+  const innerParams = privateProps.innerParams.get(this)
+  const onClose = innerParams.onClose
+  const onAfterClose = innerParams.onAfterClose
+
   if (!popup) {
     return
   }
@@ -77,7 +82,6 @@ const triggerOnAfterClose = (onAfterClose) => {
 }
 
 export {
-  close,
   close as closePopup,
   close as closeModal,
   close as closeToast

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -14,6 +14,7 @@ export function close () {
   const container = dom.getContainer()
   const popup = dom.getPopup()
   const innerParams = privateProps.innerParams.get(this)
+  const innerFunctions = privateProps.innerFunctions.get(this)
   const onClose = innerParams.onClose
   const onAfterClose = innerParams.onAfterClose
 
@@ -71,6 +72,7 @@ export function close () {
     // Otherwise, remove immediately
     removePopupAndResetState()
   }
+  innerFunctions.swalPromiseResolve({})
 }
 
 const triggerOnAfterClose = (onAfterClose) => {

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -10,11 +10,11 @@ import privateMethods from '../privateMethods.js'
 /*
  * Instance method to close sweetAlert
  */
-export function close (resolveValue, rejectValue) {
+export function close (resolveValue) {
   const container = dom.getContainer()
   const popup = dom.getPopup()
   const innerParams = privateProps.innerParams.get(this)
-  const swalPromise = privateMethods.swalPromise.get(this)
+  const swalPromiseResolve = privateMethods.swalPromiseResolve.get(this)
   const onClose = innerParams.onClose
   const onAfterClose = innerParams.onAfterClose
 
@@ -73,14 +73,8 @@ export function close (resolveValue, rejectValue) {
     removePopupAndResetState()
   }
 
-  // Resolve / reject Swal promise
-  if (resolveValue) {
-    swalPromise.resolve(resolveValue)
-  } else if (rejectValue) {
-    swalPromise.reject(rejectValue)
-  } else {
-    swalPromise.resolve({})
-  }
+  // Resolve Swal promise
+  swalPromiseResolve(resolveValue || {})
 }
 
 const triggerOnAfterClose = (onAfterClose) => {

--- a/src/privateMethods.js
+++ b/src/privateMethods.js
@@ -9,7 +9,6 @@
  */
 
 export default {
-  promise: new WeakMap(),
-  innerParams: new WeakMap(),
-  domCache: new WeakMap()
+  swalPromise: new WeakMap()
 }
+

--- a/src/privateMethods.js
+++ b/src/privateMethods.js
@@ -9,6 +9,6 @@
  */
 
 export default {
-  swalPromise: new WeakMap()
+  swalPromiseResolve: new WeakMap()
 }
 

--- a/src/privateProps.js
+++ b/src/privateProps.js
@@ -11,5 +11,6 @@
 export default {
   promise: new WeakMap(),
   innerParams: new WeakMap(),
-  domCache: new WeakMap()
+  domCache: new WeakMap(),
+  innerFunctions: new WeakMap()
 }

--- a/src/staticMethods.js
+++ b/src/staticMethods.js
@@ -1,5 +1,5 @@
 export * from './staticMethods/argsToParams.js'
-export * from './staticMethods/close.js'
+// export * from './staticMethods/close.js'
 export * from './staticMethods/dom.js'
 export * from './staticMethods/fire.js'
 export * from './staticMethods/mixin.js'

--- a/src/staticMethods.js
+++ b/src/staticMethods.js
@@ -1,5 +1,4 @@
 export * from './staticMethods/argsToParams.js'
-// export * from './staticMethods/close.js'
 export * from './staticMethods/dom.js'
 export * from './staticMethods/fire.js'
 export * from './staticMethods/mixin.js'

--- a/test/qunit/methods/close.js
+++ b/test/qunit/methods/close.js
@@ -1,0 +1,57 @@
+const { Swal } = require('../helpers')
+
+QUnit.test('close() method', (assert) => {
+  const done = assert.async()
+
+  // create a modal with an onAfterClose callback
+  Swal.fire({
+    title: 'Swal.close() test'
+  })
+
+  Swal.close()
+  assert.ok(Swal.getPopup().classList.contains('swal2-hide'))
+  done()
+})
+
+QUnit.test('onClose using close() method', (assert) => {
+  const done = assert.async()
+  let onCloseCalled = false
+
+  // create a modal with an onAfterClose callback
+  Swal.fire({
+    title: 'Swal.close() test',
+    onClose: () => {
+      // Here we test only that onClose is called
+      // For more exahustive test on onClose see tests.js
+      onCloseCalled = true
+    }
+  })
+
+  Swal.close()
+  assert.ok(onCloseCalled)
+  done()
+})
+
+QUnit.test('onAfterClose using close() method', (assert) => {
+  const done = assert.async()
+
+  // create a modal with an onAfterClose callback
+  Swal.fire({
+    title: 'onAfterClose test',
+    animation: false,
+    onAfterClose: () => {
+      // Here we test only that onAfterClose is called
+      // For more exahustive test on onAfterClose see tests.js
+      clearTimeout(timer)
+      assert.ok(true)
+      done()
+    }
+  })
+
+  // Set a timneout to check since onAfterClose is executed async
+  let timer = setTimeout(() => {
+    assert.ok(false, 'onAfterClose test timed out')
+    done()
+  }, 500)
+  Swal.close()
+})

--- a/test/qunit/methods/close.js
+++ b/test/qunit/methods/close.js
@@ -3,7 +3,6 @@ const { Swal } = require('../helpers')
 QUnit.test('close() method', (assert) => {
   const done = assert.async()
 
-  // create a modal with an onAfterClose callback
   Swal.fire({
     title: 'Swal.close() test'
   })
@@ -16,7 +15,6 @@ QUnit.test('close() method', (assert) => {
 QUnit.test('close() resolves to empty object', (assert) => {
   const done = assert.async()
 
-  // create a modal with an onAfterClose callback
   Swal.fire({
     title: 'Swal.close() test'
   }).then(result => {
@@ -31,9 +29,8 @@ QUnit.test('onClose using close() method', (assert) => {
   const done = assert.async()
   let onCloseCalled = false
 
-  // create a modal with an onAfterClose callback
   Swal.fire({
-    title: 'Swal.close() test',
+    title: 'onClose test',
     onClose: () => {
       // Here we test only that onClose is called
       // For more exahustive test on onClose see tests.js
@@ -49,7 +46,6 @@ QUnit.test('onClose using close() method', (assert) => {
 QUnit.test('onAfterClose using close() method', (assert) => {
   const done = assert.async()
 
-  // create a modal with an onAfterClose callback
   Swal.fire({
     title: 'onAfterClose test',
     animation: false,

--- a/test/qunit/methods/close.js
+++ b/test/qunit/methods/close.js
@@ -13,6 +13,20 @@ QUnit.test('close() method', (assert) => {
   done()
 })
 
+QUnit.test('close() resolves to empty object', (assert) => {
+  const done = assert.async()
+
+  // create a modal with an onAfterClose callback
+  Swal.fire({
+    title: 'Swal.close() test'
+  }).then(result => {
+    assert.deepEqual(result, {})
+    done()
+  })
+
+  Swal.close()
+})
+
 QUnit.test('onClose using close() method', (assert) => {
   const done = assert.async()
   let onCloseCalled = false


### PR DESCRIPTION
I noticed the TODO comment on: https://github.com/sweetalert2/sweetalert2/blob/f76808ef4876a2f0602a4da04a07223e0e8c5821/src/instanceMethods/_main.js#L46

and I took the opportunity of the fix for issue #919 to refactor `close()` as instance method. 

I also removed the aliases `closeModal()` and `closeToast()` that were not used / documented anywhere. 

@limonte @zenflow let me know if I _went too far_ and i'm happy to implement to implement the fix for `close()` as static method. 