### PR TITLE
Remove the 'module' field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "homepage": "https://sweetalert2.github.io/",
   "description": "A beautiful, responsive, customizable and accessible (WAI-ARIA) replacement for JavaScript's popup boxes, supported fork of sweetalert",
   "main": "dist/sweetalert2.all.js",
-  "module": "src/sweetalert2.js",
   "types": "sweetalert2.d.ts",
   "devDependencies": {
     "@babel/core": "^7.2.2",


### PR DESCRIPTION
Fixes #1390 
Fixes #1391 

Unfortunately, we need to remove the `module` field from `package.json` and make https://www.pikapkg.com unhappy.

The reason for that is that `webpack` is prioritizing `module` over `main` (https://github.com/webpack/webpack/issues/5756) and ES6 code without CSS (`src/sweetalert2.js`) is bundled instead of expected `dist/sweetalert2.all.js`

It will still be possible to use SweetAlert2 as ES module:

```html
<link rel="stylesheet" href="<path_to_sweetalert2>/dist/sweetalert2.css">

<script type="module">
  import Swal from '<path_to_sweetalert2>/src/sweetalert2.js'
  Swal.fire('hi')
</script>
```