### PR TITLE
Include branch name into surge domain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,13 @@ after_success:
       semantic-release;
     fi;
 
-  # report coverage to coveralls.io and upload to transfer.sh
+  # report coverage to coveralls.io and deploy to surge.sh
+  # https://github.com/travis-ci/travis-ci/issues/6652#issuecomment-255597049
+  # '/' symbols must be replaced, https://stackoverflow.com/a/13210909
   - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then
       yarn global add coveralls@3 surge &&
       cat ./coverage/lcov.info | coveralls &&
-      surge coverage sweetalert2-coverage.surge.sh;
+      BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} &&
+      BRANCH_NAME=${BRANCH_NAME//\//-} &&
+      surge coverage "sweetalert2-coverage-${BRANCH_NAME}.surge.sh";
     fi;


### PR DESCRIPTION
Follow-up to #1395 

Include the branch name into surge domain name.

Before: https://sweetalert2-coverage.surge.sh
After: `https://sweetalert2-coverage-<branch_name>.surge.sh` e.g. https://sweetalert2-coverage-master.surge.sh