### PR TITLE
Fix for preConfirmValue check preConfirmPromise

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -101,7 +101,7 @@ export function _main (userParams) {
             if (dom.isVisible(domCache.validationMessage) || preConfirmValue === false) {
               this.hideLoading()
             } else {
-              succeedWith(preConfirmValue || value)
+              succeedWith(typeof (preConfirmValue) === 'undefined' ? value : preConfirmValue)
             }
           }
         )

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -767,17 +767,17 @@ QUnit.test('Custom content', (assert) => {
   })
 })
 
-QUnit.test('preConfirm returns undefined', (assert) => {
+QUnit.test('preConfirm returns 0', (assert) => {
   const done = assert.async()
   SwalWithoutAnimation.fire({
     onOpen: () => {
       Swal.clickConfirm()
     },
     preConfirm: () => {
-      return undefined
+      return 0
     }
   }).then(result => {
-    assert.ok(result.value)
+    assert.equal(result.value, 0)
     done()
   })
 })

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -766,3 +766,18 @@ QUnit.test('Custom content', (assert) => {
     done()
   })
 })
+
+QUnit.test('preConfirm returns undefined', (assert) => {
+  const done = assert.async()
+  SwalWithoutAnimation.fire({
+    onOpen: () => {
+      Swal.clickConfirm()
+    },
+    preConfirm: () => {
+      return undefined
+    }
+  }).then(result => {
+    assert.ok(result.value)
+    done()
+  })
+})


### PR DESCRIPTION
Closes #1402 

Currently the check on `preConfirmValue` is done on a _falsy_ value:

https://github.com/sweetalert2/sweetalert2/blob/ca9d19724b85b79f217a461ef24e013a7e081718/src/instanceMethods/_main.js#L104

This check considers also 0 as _falsy_, which could actually be a valid return value.

Replacing this with a check for `undefined` value, which is the only case where we may want to return something different than `preConfirmValue`