### PR TITLE
Fix for restore correct padding when scrollbar is present

### DIFF
--- a/src/utils/scrollbarFix.js
+++ b/src/utils/scrollbarFix.js
@@ -15,7 +15,7 @@ export const fixScrollbar = () => {
 
 export const undoScrollbar = () => {
   if (dom.states.previousBodyPadding !== null) {
-    document.body.style.paddingRight = dom.states.previousBodyPadding
+    document.body.style.paddingRight = dom.states.previousBodyPadding + 'px'
     dom.states.previousBodyPadding = null
   }
 }

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -78,14 +78,18 @@ QUnit.test('the vertical scrollbar should be hidden and the according padding-ri
 
   const scrollbarWidth = measureScrollbar()
 
-  Swal.fire('The body has visible scrollbar, I will hide it and adjust padding-right on body')
-
-  const bodyStyles = window.getComputedStyle(document.body);
+  Swal.fire({
+    title: 'The body has visible scrollbar, I will hide it and adjust padding-right on body',
+    onAfterClose: () => {
+      assert.equal(bodyStyles.paddingRight, '30px')
+      document.body.removeChild(talltDiv)
+    }
+  })
+  const bodyStyles = window.getComputedStyle(document.body)
 
   assert.equal(bodyStyles.paddingRight, (scrollbarWidth + 30) + 'px')
   assert.equal(bodyStyles.overflow, 'hidden')
-
-  document.body.removeChild(talltDiv)
+  Swal.clickConfirm()
 })
 
 QUnit.test('modal width', (assert) => {


### PR DESCRIPTION
Closes #1409 

When the body padding is not 0 and a scrollbar is present, the `undoScrollbar()` fails to set back the previous value for the body padding. The reason is that the measure (i.e. `px`) is not provided. Note that when the previous padding is 0, everything works fine (0 doesn't need to specify a measure). 