### PR TITLE
Adding `scrollbarPadding` parameter

### DIFF
--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -45,7 +45,7 @@ export const openPopup = (params) => {
   }
 
   if (dom.isModal()) {
-    fixScrollbar()
+    if (params.scrollbarPadding) { fixScrollbar() }
     iOSfix()
     IEfix()
     setAriaHidden()

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -63,7 +63,8 @@ const defaultParams = {
   onBeforeOpen: null,
   onAfterClose: null,
   onOpen: null,
-  onClose: null
+  onClose: null,
+  scrollbarPadding: true
 }
 
 export const deprecatedParams = []

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -832,6 +832,13 @@ declare module 'sweetalert2' {
          * @default null
          */
         onClose?: (modalElement: HTMLElement) => void;
+        
+        /**
+         * Set to false to disable body padding adjustment when scrollbar is present. 
+         *
+         * @default false
+         */
+        scrollbarPadding?: boolean;
     }
 
     export default Swal;

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -836,7 +836,7 @@ declare module 'sweetalert2' {
         /**
          * Set to false to disable body padding adjustment when scrollbar is present. 
          *
-         * @default false
+         * @default true
          */
         scrollbarPadding?: boolean;
     }

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -92,6 +92,25 @@ QUnit.test('the vertical scrollbar should be hidden and the according padding-ri
   Swal.clickConfirm()
 })
 
+QUnit.test('scrollbarPadding disabled', (assert) => {
+  const talltDiv = document.createElement('div')
+  talltDiv.innerHTML = Array(100).join('<div>lorem ipsum</div>')
+  document.body.appendChild(talltDiv)
+  document.body.style.paddingRight = '30px'
+
+  Swal.fire({
+    title: 'Padding right adjustment disabled',
+    scrollbarPadding: false,
+    onAfterClose: () => {
+      document.body.removeChild(talltDiv)
+    }
+  })
+
+  const bodyStyles = window.getComputedStyle(document.body)
+  assert.equal(bodyStyles.paddingRight, '30px')
+  Swal.clickConfirm()
+})
+
 QUnit.test('modal width', (assert) => {
   Swal.fire({ text: '300px', width: 300 })
   assert.equal($('.swal2-modal').style.width, '300px')


### PR DESCRIPTION
Default value: `true`. When set to `false` no padding is added to the `body` if the scrollbar is present. 

To implement that, the `fixScrollbar()` is called only if the `scrollbarPadding` is `true`. There is no need to add similar check before calling `undoScrollbar()`, even though it would be cleaner code. 

On a different note, we may want to change the name of the functions to: 

*  `fixScrollbar()` to `addPadding()` 
* `undoScrollbar()` to `removePadding()`

Closes #1412  