### PR TITLE
Fix crash if swal2 action buttons classes are applied to elements in html prop

### DIFF
--- a/src/utils/dom/getters.js
+++ b/src/utils/dom/getters.js
@@ -4,9 +4,13 @@ import { isVisible } from './domUtils.js'
 
 export const getContainer = () => document.body.querySelector('.' + swalClasses.container)
 
-const elementByClass = (className) => {
+const elementBySelector = (selectorString) => {
   const container = getContainer()
-  return container ? container.querySelector('.' + className) : null
+  return container ? container.querySelector(selectorString) : null
+}
+
+const elementByClass = (className) => {
+  return elementBySelector('.' + className)
 }
 
 export const getPopup = () => elementByClass(swalClasses.popup)
@@ -26,9 +30,9 @@ export const getProgressSteps = () => elementByClass(swalClasses['progress-steps
 
 export const getValidationMessage = () => elementByClass(swalClasses['validation-message'])
 
-export const getConfirmButton = () => elementByClass(swalClasses.confirm)
+export const getConfirmButton = () => elementBySelector('.' + swalClasses.actions + ' .' + swalClasses.confirm)
 
-export const getCancelButton = () => elementByClass(swalClasses.cancel)
+export const getCancelButton = () => elementBySelector('.' + swalClasses.actions + ' .' + swalClasses.cancel)
 
 export const getActions = () => elementByClass(swalClasses.actions)
 

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -809,6 +809,7 @@ QUnit.test('Model shows with swal2 classes used in html', (assert) => {
   Swal.fire({
     html: '<span class="swal2-cancel"></span>'
   })
-  assert.ok(Swal.getPopup().classList.contains('swal2-show'))
+  assert.ok(Swal.getContent().querySelector('.swal2-cancel'))
+  assert.ok(Swal.getActions().querySelector('.swal2-cancel'))
   Swal.close()
 })

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -804,3 +804,11 @@ QUnit.test('preConfirm returns 0', (assert) => {
     done()
   })
 })
+
+QUnit.test('Model shows with swal2 classes used in html', (assert) => {
+  Swal.fire({
+    html: '<span class="swal2-cancel"></span>'
+  })
+  assert.ok(Swal.getPopup().classList.contains('swal2-show'))
+  Swal.close()
+})


### PR DESCRIPTION
Closes #1419 

* Added a function `elementBySelector()` to select element(s) using a selector string.
* Changed `elementByClass()` to make use of the newly defined `elementBySelector()`
* Changed the getters for confirm and cancel button to select the default swal2 buttons (i.e. the one  inside the div identified by class `.swal2-actions`

This will: 

* Make the swal2 code more robust adding an extra parameter for the selection of the action buttons
* Fix the error reported in #1419, that is caused by the following code that assumes that the confirm and cancel buttons are always sibling: 

https://github.com/sweetalert2/sweetalert2/blob/f6e1a30005b93841edb8ab4f744577297d3f30ba/src/instanceMethods/_main.js#L230-L234
