### PR TITLE
Fixed bug in isVisible() method

### DIFF
--- a/src/staticMethods/dom.js
+++ b/src/staticMethods/dom.js
@@ -21,7 +21,13 @@ export {
  * Global function to determine if SweetAlert2 popup is shown
  */
 export const isVisible = () => {
-  return !!dom.getPopup()
+  let isVisible = false
+  const swalPopup = dom.getPopup()
+  if (swalPopup) {
+    const swalPopupComputedStyle = window.getComputedStyle(swalPopup)
+    isVisible = !(swalPopupComputedStyle.display === 'none' || swalPopupComputedStyle.visibility === 'hidden' || swalPopupComputedStyle.opacity === '0')
+  }
+  return isVisible
 }
 
 /*

--- a/test/qunit/helpers.js
+++ b/test/qunit/helpers.js
@@ -5,7 +5,10 @@ export const $ = document.querySelector.bind(document)
 
 export const isIE = window.navigator.userAgent.indexOf('Trident/') > 0
 
-export const isVisible = (elem) => elem && (elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)
+export const isVisible = (elem) => {
+  const computedStyle = window.getComputedStyle(elem)
+  return !(computedStyle.display === 'none' || computedStyle.visibility === 'hidden' || computedStyle.opacity === '0')
+}
 export const isHidden = (elem) => !isVisible(elem)
 
 export let TIMEOUT = 1

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -812,3 +812,13 @@ QUnit.test('Model shows with swal2 classes used in html', (assert) => {
   assert.ok(Swal.getPopup().classList.contains('swal2-show'))
   Swal.close()
 })
+
+QUnit.test('isVisible() should return false in onBeforeOpen', (assert) => {
+  Swal.fire({
+    title: 'Simple swal',
+    onBeforeOpen: () => {
+      assert.notOk(Swal.isVisible())
+    }
+  })
+  Swal.clickConfirm()
+})


### PR DESCRIPTION
Closes #1421 

The current implementation of `isVisible()` is simply checking that the popup is in the DOM. This is not enough to confirm that the popup is actually visible. 

The new implementation will actually check the computed style and check the following properties: 
* `display`
* `visibility`
* `opacity` 

Note that in the swal internal code for the `dom` object, the `isVisible()` function is using the jQuery interpretation of `:visible` selector: 

https://github.com/sweetalert2/sweetalert2/blob/9d71cdc3c78740049dd85034d2ff1273d56655c2/src/utils/dom/domUtils.js#L68-L69

Based on jquery documentation [here](https://api.jquery.com/visible-selector/):

> Elements are considered visible if they consume space in the document. Visible elements have a width or height that is greater than zero.

The new implementation is more similar to the jQuery [`:hidden`](https://api.jquery.com/hidden-selector/) selector. 

Also the new implementation makes use of the calculated style using the `window.getComputedStyle()` method.