### PR TITLE
Get rid of Surge, it's not working for external PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,13 +46,8 @@ after_success:
       semantic-release;
     fi;
 
-  # report coverage to coveralls.io and deploy to surge.sh
-  # https://github.com/travis-ci/travis-ci/issues/6652#issuecomment-255597049
-  # '/' symbols must be replaced, https://stackoverflow.com/a/13210909
+  # report coverage to coveralls.io
   - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then
-      yarn global add coveralls@3 surge &&
-      cat ./coverage/lcov.info | coveralls &&
-      BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} &&
-      BRANCH_NAME=${BRANCH_NAME//\//-} &&
-      surge coverage "sweetalert2-coverage-${BRANCH_NAME}.surge.sh";
+      yarn global add coveralls@3 &&
+      cat ./coverage/lcov.info | coveralls;
     fi;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,6 +4,7 @@ const noLaunch = process.argv.includes('--no-launch')
 const isWindows = process.platform === 'win32'
 const testMinified = process.argv.includes('--minified')
 const isSauce = process.argv.includes('--sauce')
+const isNetlify = process.argv.includes('--netlify')
 
 module.exports = function (config) {
   const sauceLabsLaunchers = {
@@ -62,6 +63,11 @@ module.exports = function (config) {
         process.exit(1)
       }
       browsers = Object.keys(sauceLabsLaunchers)
+    // Netlify
+    } else if (isNetlify) {
+      process.env.CHROME_BIN = require('puppeteer').executablePath()
+      browsers = ['ChromeHeadless']
+      reporters.push('coverage')
     } else if (isCi) {
       // AppVeyor
       if (isWindows) {


### PR DESCRIPTION
From https://github.com/sweetalert2/sweetalert2/pull/1424#issuecomment-466515824

> I do not know why the build is failing though. It looks to be something with `surge`.

---

Deploying to Surge requires authentication with `SURGE_LOGIN` and `SURGE_TOKEN` env variables which aren't available for PR builds for security reasons

https://docs.travis-ci.com/user/environment-variables/

> environment variables are not available to pull requests from forks due to the security risk of exposing such information to unknown code.

---

Instead of Surge, let's use Netlify which is already used for previews.

Starting from now, the code coverage is available on `<netlify_link>/coverage`, e.g.  https://deploy-preview-1425--sweetalert2.netlify.com/coverage/

Duplicating Netlify config here:

```sh
yarn install 
yarn add --dev puppeteer 
yarn build 
yarn check:qunit --netlify 
curl https://sweetalert2.github.io -o index.html 
sed -i 's|src="/|src="https://sweetalert2.github.io/|g' index.html 
sed -i 's|https://cdn.jsdelivr.net/npm/sweetalert2@7|/dist/sweetalert2.all.min.js|g' index.html 
sed -i 's|="./|="https://sweetalert2.github.io/|g' index.html
```