### PR TITLE
Fix inactive step background

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -784,25 +784,25 @@ body {
   }
 
   .swal2-progress-step {
-    width: $swal2-progress-steps-width;
-    height: $swal2-progress-steps-height;
-    border-radius: $swal2-progress-steps-border-radius;
-    background: $swal2-progress-steps-active-step-background;
-    color: $swal2-progress-steps-active-step-color;
-    line-height: $swal2-progress-steps-height;
+    width: $swal2-progress-step-width;
+    height: $swal2-progress-step-height;
+    border-radius: $swal2-progress-step-border-radius;
+    background: $swal2-active-step-background;
+    color: $swal2-active-step-color;
+    line-height: $swal2-progress-step-height;
     text-align: center;
     z-index: 20;
 
     &.swal2-active-progress-step {
-      background: $swal2-progress-steps-active-step-background;
+      background: $swal2-active-step-background;
 
       ~ .swal2-progress-step {
-        background: $swal2-progress-steps-step-background;
-        color: $swal2-progress-steps-color;
+        background: $swal2-progress-step-background;
+        color: $swal2-progress-step-color;
       }
 
       ~ .swal2-progress-step-line {
-        background: $swal2-progress-steps-step-background;
+        background: $swal2-progress-step-background;
       }
     }
   }
@@ -811,7 +811,7 @@ body {
     width: $swal2-progress-steps-distance;
     height: .4em;
     margin: 0 -1px;
-    background: $swal2-progress-steps-active-step-background;
+    background: $swal2-active-step-background;
     z-index: 10;
   }
 }

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -797,12 +797,12 @@ body {
       background: $swal2-progress-steps-active-step-background;
 
       ~ .swal2-progress-step {
-        background: $swal2-progress-steps-background;
+        background: $swal2-progress-steps-step-background;
         color: $swal2-progress-steps-color;
       }
 
       ~ .swal2-progress-step-line {
-        background: $swal2-progress-steps-background;
+        background: $swal2-progress-steps-step-background;
       }
     }
   }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -76,7 +76,7 @@ $swal2-progress-steps-distance: 2.5em !default;
 $swal2-progress-steps-width: 2em;
 $swal2-progress-steps-height: 2em;
 $swal2-progress-steps-border-radius: 2em;
-$swal2-progress-steps-background: #add8e6 !default;
+$swal2-progress-steps-step-background: #add8e6 !default;
 $swal2-progress-steps-color: $swal2-white !default;
 $swal2-progress-steps-active-step-background: #3085d6 !default;
 $swal2-progress-steps-active-step-color: $swal2-white !default;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -73,13 +73,13 @@ $swal2-progress-steps-margin: 0 0 1.25em !default;
 $swal2-progress-steps-padding: 0 !default;
 $swal2-progress-steps-font-weight: 600 !default;
 $swal2-progress-steps-distance: 2.5em !default;
-$swal2-progress-steps-width: 2em;
-$swal2-progress-steps-height: 2em;
-$swal2-progress-steps-border-radius: 2em;
-$swal2-progress-steps-step-background: #add8e6 !default;
-$swal2-progress-steps-color: $swal2-white !default;
-$swal2-progress-steps-active-step-background: #3085d6 !default;
-$swal2-progress-steps-active-step-color: $swal2-white !default;
+$swal2-progress-step-width: 2em;
+$swal2-progress-step-height: 2em;
+$swal2-progress-step-border-radius: 2em;
+$swal2-progress-step-background: #add8e6 !default;
+$swal2-progress-step-color: $swal2-white !default;
+$swal2-active-step-background: #3085d6 !default;
+$swal2-active-step-color: $swal2-white !default;
 
 // FOOTER
 $swal2-footer-margin: 1.25em 0 0 !default;


### PR DESCRIPTION
In PR #1411 we introduced `$swal2-progress-steps-background` but this was defined twice: 

https://github.com/sweetalert2/sweetalert2/blob/07a79db552bfe0a76164660b0ad74b6af67d7788/src/variables.scss#L71

and

https://github.com/sweetalert2/sweetalert2/blob/07a79db552bfe0a76164660b0ad74b6af67d7788/src/variables.scss#L79

This caused the _inactive_ steps in a queue to have white background: 

![image](https://user-images.githubusercontent.com/17089396/53350825-d6a9e400-3917-11e9-9952-ddf0703c3e21.png)

I restored back the variable `$swal2-progress-steps-background` that @limonte correctly created, and I wrongly asked to be changed. Apologies for that.  