### PR TITLE
Remove excessive is visible check, support Jest testing enviroment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,8 +16,5 @@ module.exports = {
     'no-var': ['error'],
     'object-curly-spacing': ['error', 'always'],
     'quotes': ['error', 'single', { allowTemplateLiterals: true }]
-  },
-  globals: {
-    'QUnit': false
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ install:
 
 script:
   - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then
-      yarn run check;
+      yarn run check &&
+      yarn add --dev jest &&
+      yarn run check:jest;
     fi;
 
   - if [[ "$TRAVIS_EVENT_TYPE" = "cron" ]]; then

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "check:sauce": "npm run check:qunit:sauce && npm run check:qunit:minified:sauce",
     "check:lint": "gulp lint",
     "check:require-in-node": "node test/require-in-node",
+    "check:jest": "jest --ci",
     "check:qunit": "karma start karma.conf.js --single-run",
     "check:qunit:minified": "karma start karma.conf.js --single-run --minified",
     "check:qunit:sauce": "karma start karma.conf.js --single-run --sauce",

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -120,7 +120,7 @@ export function _main (userParams) {
       switch (e.type) {
         case 'click':
           // Clicked 'confirm'
-          if (targetedConfirm && constructor.isVisible()) {
+          if (targetedConfirm) {
             this.disableButtons()
             if (innerParams.input) {
               const inputValue = getInputValue()
@@ -149,8 +149,8 @@ export function _main (userParams) {
               confirm(true)
             }
 
-            // Clicked 'cancel'
-          } else if (targetedCancel && constructor.isVisible()) {
+          // Clicked 'cancel'
+          } else if (targetedCancel) {
             this.disableButtons()
             dismissWith(constructor.DismissReason.cancel)
           }

--- a/src/staticMethods/dom.js
+++ b/src/staticMethods/dom.js
@@ -28,9 +28,9 @@ export const isVisible = () => {
 /*
  * Global function to click 'Confirm' button
  */
-export const clickConfirm = () => dom.getConfirmButton().click()
+export const clickConfirm = () => dom.getConfirmButton() && dom.getConfirmButton().click()
 
 /*
  * Global function to click 'Cancel' button
  */
-export const clickCancel = () => dom.getCancelButton().click()
+export const clickCancel = () => dom.getCancelButton() && dom.getCancelButton().click()

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  globals: {
+    'beforeAll': false,
+    'describe': false,
+    'it': false,
+    'QUnit': false
+  }
+}

--- a/test/jest/jest.test.js
+++ b/test/jest/jest.test.js
@@ -1,0 +1,20 @@
+const Swal = require('../../dist/sweetalert2')
+
+describe('sweetalert2', () => {
+  beforeAll(() => {
+    // jest (or more precisely, jsdom) doesn't implement `window.scrollTo` so we need to mock it
+    window.scrollTo = () => {}
+  })
+
+  it('resolves', () => {
+    return Promise.resolve()
+      .then(() => {
+        return Swal.fire({
+          animation: false,
+          onOpen: () => {
+            Swal.clickConfirm()
+          }
+        })
+      })
+  })
+})

--- a/test/qunit/methods/clickConfirm.js
+++ b/test/qunit/methods/clickConfirm.js
@@ -1,0 +1,24 @@
+const { $, Swal, SwalWithoutAnimation } = require('../helpers')
+
+QUnit.test('clickConfirm() should click the confirm button', (assert) => {
+  const done = assert.async()
+  Swal.fire({
+    input: 'radio',
+    inputOptions: {
+      'one': 'one',
+      'two': 'two'
+    }
+  }).then((result) => {
+    assert.deepEqual(result, { value: 'two' })
+    done()
+  })
+  $('.swal2-radio').querySelector('input[value="two"]').checked = true
+  Swal.clickConfirm()
+})
+
+QUnit.test('clickConfirm() should not fail if a popup is not visible' , (assert) => {
+  SwalWithoutAnimation.fire()
+  Swal.close()
+  assert.notOk(Swal.isVisible())
+  Swal.clickConfirm()
+})

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -674,22 +674,6 @@ QUnit.test('timer', (assert) => {
   })
 })
 
-QUnit.test('confirm button', (assert) => {
-  const done = assert.async()
-  Swal.fire({
-    input: 'radio',
-    inputOptions: {
-      'one': 'one',
-      'two': 'two'
-    }
-  }).then((result) => {
-    assert.deepEqual(result, { value: 'two' })
-    done()
-  })
-  $('.swal2-radio').querySelector('input[value="two"]').checked = true
-  Swal.clickConfirm()
-})
-
 QUnit.test('params validation', (assert) => {
   assert.ok(Swal.isValidParameter('title'))
   assert.notOk(Swal.isValidParameter('foobar'))


### PR DESCRIPTION
Fixes #1426

With the help of https://github.com/facebook/jest/issues/8062 I figured out that:

- `elem.offsetWidth` and similar are always `0`
- `isVisible()` always returns `false`
- `if (targetedConfirm && constructor.isVisible()) {` will never be `true` 
- confirm button never got clicked in https://github.com/sweetalert2/swal-not-resolve-in-jest-bug/blob/master/test.js#L18
- swal never resolves

~I think that those checks are legacy and not needed anymore.~ (my mistake, thanks @gverni!)