### PR TITLE
Add customClass.icon support, add Swal.getIcon() method

### DIFF
--- a/src/staticMethods/dom.js
+++ b/src/staticMethods/dom.js
@@ -7,6 +7,7 @@ export {
   getTitle,
   getContent,
   getImage,
+  getIcon,
   getIcons,
   getCloseButton,
   getActions,

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -649,7 +649,10 @@ body {
   user-select: none;
   zoom: $swal2-icon-zoom;
 
-  &-text {
+  &::before {
+    display: flex;
+    align-items: center;
+    height: 92%;
     font-size: 3.75em;
   }
 
@@ -685,16 +688,28 @@ body {
   &.swal2-warning {
     border-color: lighten($swal2-warning, 7);
     color: $swal2-warning;
+
+    &::before {
+      content: '!';
+    }
   }
 
   &.swal2-info {
     border-color: lighten($swal2-info, 20);
     color: $swal2-info;
+
+    &::before {
+      content: 'i';
+    }
   }
 
   &.swal2-question {
     border-color: lighten($swal2-question, 20);
     color: $swal2-question;
+
+    &::before {
+      content: '?';
+    }
   }
 
   &.swal2-success {

--- a/src/toasts.scss
+++ b/src/toasts.scss
@@ -156,10 +156,15 @@ body {
       height: 2em;
       margin: 0;
 
-      &-text {
+      &::before {
+        display: flex;
+        align-items: center;
         font-size: 2em;
         font-weight: bold;
-        line-height: 1em;
+
+        @include ie {
+          font-size: .25em;
+        }
       }
 
       &.swal2-success {

--- a/src/utils/classes.js
+++ b/src/utils/classes.js
@@ -32,7 +32,6 @@ export const swalClasses = prefix([
   'cancel',
   'footer',
   'icon',
-  'icon-text',
   'image',
   'input',
   'file',

--- a/src/utils/dom/getters.js
+++ b/src/utils/dom/getters.js
@@ -20,6 +20,11 @@ export const getIcons = () => {
   return toArray(popup.querySelectorAll('.' + swalClasses.icon))
 }
 
+export const getIcon = () => {
+  const visibleIcon = getIcons().filter(icon => isVisible(icon))
+  return visibleIcon.length ? visibleIcon[0] : null
+}
+
 export const getTitle = () => elementByClass(swalClasses.title)
 
 export const getContent = () => elementByClass(swalClasses.content)

--- a/src/utils/dom/init.js
+++ b/src/utils/dom/init.js
@@ -12,15 +12,9 @@ const sweetHTML = `
      <div class="${swalClasses.icon} ${iconTypes.error}">
        <span class="swal2-x-mark"><span class="swal2-x-mark-line-left"></span><span class="swal2-x-mark-line-right"></span></span>
      </div>
-     <div class="${swalClasses.icon} ${iconTypes.question}">
-       <span class="${swalClasses['icon-text']}">?</span>
-      </div>
-     <div class="${swalClasses.icon} ${iconTypes.warning}">
-       <span class="${swalClasses['icon-text']}">!</span>
-      </div>
-     <div class="${swalClasses.icon} ${iconTypes.info}">
-       <span class="${swalClasses['icon-text']}">i</span>
-      </div>
+     <div class="${swalClasses.icon} ${iconTypes.question}"></div>
+     <div class="${swalClasses.icon} ${iconTypes.warning}"></div>
+     <div class="${swalClasses.icon} ${iconTypes.info}"></div>
      <div class="${swalClasses.icon} ${iconTypes.success}">
        <div class="swal2-success-circular-line-left"></div>
        <span class="swal2-success-line-tip"></span> <span class="swal2-success-line-long"></span>

--- a/src/utils/dom/renderers/renderIcon.js
+++ b/src/utils/dom/renderers/renderIcon.js
@@ -13,6 +13,11 @@ export const renderIcon = (params) => {
       const icon = sweetAlert.getPopup().querySelector(`.${swalClasses.icon}.${iconTypes[params.type]}`)
       dom.show(icon)
 
+      // Custom class
+      if (params.customClass) {
+        dom.addClass(icon, params.customClass.icon)
+      }
+
       // Animate icon
       if (params.animation) {
         dom.addClass(icon, `swal2-animate-${params.type}-icon`)

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -88,6 +88,11 @@ declare module 'sweetalert2' {
         function getCloseButton(): HTMLElement;
 
         /**
+         * Gets the current visible icon.
+         */
+        function getIcon(): HTMLElement | null;
+
+        /**
          * Gets all icons. The current visible icon will have `style="display: flex"`,
          * all other will be hidden by `style="display: none"`.
          */

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -329,6 +329,7 @@ declare module 'sweetalert2' {
         header?: string;
         title?: string;
         closeButton?: string;
+        icon?: string;
         image?: string;
         content?: string;
         input?: string;
@@ -478,6 +479,7 @@ declare module 'sweetalert2' {
          *       header: 'header-class',
          *       title: 'title-class',
          *       closeButton: 'close-button-class',
+         *       icon: 'icon-class',
          *       image: 'image-class',
          *       content: 'content-class',
          *       input: 'input-class',

--- a/test/qunit/methods/getIcon.js
+++ b/test/qunit/methods/getIcon.js
@@ -1,0 +1,6 @@
+import { $, Swal } from '../helpers.js'
+
+QUnit.test('getIcon() method', (assert) => {
+  Swal.fire({ type: 'success' })
+  assert.equal(Swal.getIcon(), $('.swal2-success'))
+})

--- a/test/qunit/methods/update.js
+++ b/test/qunit/methods/update.js
@@ -1,4 +1,4 @@
-const { Swal, SwalWithoutAnimation, isVisible } = require('../helpers')
+const { $, Swal, SwalWithoutAnimation, isVisible } = require('../helpers')
 
 QUnit.test('update() method', (assert) => {
   SwalWithoutAnimation.fire()
@@ -16,7 +16,8 @@ QUnit.test('update() method', (assert) => {
   assert.equal(Swal.getTitle().textContent, 'New title')
   assert.equal(Swal.getContent().textContent, 'New content')
 
-  assert.ok(isVisible(Swal.getIcons().filter(icon => icon.classList.contains('swal2-success'))[0]))
+  assert.ok(isVisible(Swal.getIcon()))
+  assert.equal(Swal.getIcon(), $('.swal2-success'))
 
   assert.ok(isVisible(Swal.getImage()))
   assert.ok(Swal.getImage().src.indexOf('/assets/swal2-logo.png') > 0)

--- a/test/qunit/params/customClass.js
+++ b/test/qunit/params/customClass.js
@@ -7,6 +7,7 @@ QUnit.test('customClass as a string', (assert) => {
 
 QUnit.test('customClass as an object', (assert) => {
   Swal.fire({
+    type: 'question',
     input: 'text',
     imageUrl: '/assets/swal2-logo.png',
     customClass: {
@@ -15,6 +16,7 @@ QUnit.test('customClass as an object', (assert) => {
       header: 'header-class',
       title: 'title-class',
       closeButton: 'close-button-class',
+      icon: 'icon-class',
       image: 'image-class',
       content: 'content-class',
       input: 'input-class',
@@ -29,6 +31,7 @@ QUnit.test('customClass as an object', (assert) => {
   assert.ok(Swal.getHeader().classList.contains('header-class'))
   assert.ok(Swal.getTitle().classList.contains('title-class'))
   assert.ok(Swal.getCloseButton().classList.contains('close-button-class'))
+  assert.ok(Swal.getIcon().classList.contains('icon-class'))
   assert.ok(Swal.getImage().classList.contains('image-class'))
   assert.ok(Swal.getContent().classList.contains('content-class'))
   assert.ok(Swal.getInput().classList.contains('input-class'))


### PR DESCRIPTION
Remove hardcoded icons chars (`?`, `!`, `i`) from the markup, and move them to styles so users will be able to change them if needed, e.g. replace `?` with `؟` for Arabic UIs:

```css
.my-question-icon::before {
  content: '؟'
}
```

```js
Swal.fire({
  type: 'question',
  customClass: {
    icon: 'my-question-icon'
  }
})
```

- add `customClass.icon` to be able to add custom class to the icon
- add `Swal.getIcon()` public API method  to be able to get the current icon (API docs: https://github.com/sweetalert2/sweetalert2.github.io/issues/67)
