### PR TITLE
Add .swal2-arabic-question-mark

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -710,6 +710,10 @@ body {
     &::before {
       content: '?';
     }
+
+    &.swal2-arabic-question-mark::before {
+      content: '؟';
+    }
   }
 
   &.swal2-success {


### PR DESCRIPTION
It'll be useful for Arabic/Persian UIs:

```js
Swal.fire({
  type: 'question',
  customClass: {
    icon: 'swal2-arabic-question-mark'
  }
})
```