### PR TITLE
Re-implemented applying `params.width` and `params.padding`

### DIFF
--- a/src/utils/setParameters.js
+++ b/src/utils/setParameters.js
@@ -44,15 +44,13 @@ export default function setParameters (params) {
     popup = oldPopup || dom.init(params)
   }
 
-  // Set popup width
-  if (params.width) {
-    popup.style.width = (typeof params.width === 'number') ? params.width + 'px' : params.width
-  }
-
-  // Set popup padding
-  if (params.padding !== null) {
-    popup.style.padding = (typeof params.padding === 'number') ? params.padding + 'px' : params.padding
-  }
+  // Set popup width and padding
+  ['width', 'padding'].forEach(param => {
+    const paramValue = params[param]
+    if (paramValue !== null) {
+      popup.style[param] = (typeof paramValue === 'number') ? paramValue + 'px' : paramValue
+    }
+  })
 
   // Set popup background
   if (params.background) {


### PR DESCRIPTION
Changes to eliminate similar code as reported in #1450. 

I don't particularly like this implementation because I don't think it's reducing code size, and on the other hand is making code less readable and it changes the behavior for `params.width === 0` (with this code the width 0 is applied)

Closes #1450