### PR TITLE
Allow image size to be set in any possible CSS units

### DIFF
--- a/src/utils/dom/domUtils.js
+++ b/src/utils/dom/domUtils.js
@@ -90,6 +90,14 @@ export const getChildByClass = (elem, className) => {
   }
 }
 
+export const applyNumericalStyle = (elem, property, value) => {
+  if (value || parseInt(value) === 0) {
+    elem.style[property] = (typeof value === 'number') ? value + 'px' : value
+  } else {
+    elem.style.removeProperty(property)
+  }
+}
+
 export const show = (elem, display = 'flex') => {
   elem.style.opacity = ''
   elem.style.display = display

--- a/src/utils/dom/renderers/renderImage.js
+++ b/src/utils/dom/renderers/renderImage.js
@@ -4,31 +4,24 @@ import * as dom from '../../dom/index.js'
 export const renderImage = (params) => {
   const image = dom.getImage()
 
-  if (params.imageUrl) {
-    image.setAttribute('src', params.imageUrl)
-    image.setAttribute('alt', params.imageAlt)
-    dom.show(image)
+  if (!params.imageUrl) {
+    return dom.hide(image)
+  }
 
-    if (params.imageWidth) {
-      image.setAttribute('width', params.imageWidth)
-    } else {
-      image.removeAttribute('width')
-    }
+  dom.show(image)
 
-    if (params.imageHeight) {
-      image.setAttribute('height', params.imageHeight)
-    } else {
-      image.removeAttribute('height')
-    }
+  // Src, alt
+  image.setAttribute('src', params.imageUrl)
+  image.setAttribute('alt', params.imageAlt)
 
-    image.className = swalClasses.image
-    if (params.imageClass) {
-      dom.addClass(image, params.imageClass)
-    }
-    if (params.customClass) {
-      dom.addClass(image, params.customClass.image)
-    }
-  } else {
-    dom.hide(image)
+  // Width, height
+  dom.applyNumericalStyle(image, 'width', params.imageWidth)
+  dom.applyNumericalStyle(image, 'height', params.imageHeight)
+
+  // Class
+  image.className = swalClasses.image
+  dom.applyCustomClass(image, params.customClass, 'image')
+  if (params.imageClass) {
+    dom.addClass(image, params.imageClass)
   }
 }

--- a/src/utils/dom/renderers/renderPopup.js
+++ b/src/utils/dom/renderers/renderPopup.js
@@ -2,15 +2,13 @@ import { swalClasses } from '../../classes.js'
 import * as dom from '../../dom/index.js'
 
 export const renderPopup = (params) => {
-  const popup = dom.getPopup();
+  const popup = dom.getPopup()
 
-  // Width and Padding
-  ['width', 'padding'].forEach(param => {
-    const paramValue = params[param]
-    if (paramValue !== null) {
-      popup.style[param] = (typeof paramValue === 'number') ? paramValue + 'px' : paramValue
-    }
-  })
+  // Width
+  dom.applyNumericalStyle(popup, 'width', params.width)
+
+  // Padding
+  dom.applyNumericalStyle(popup, 'padding', params.padding)
 
   // Background
   if (params.background) {

--- a/test/qunit/params/image.js
+++ b/test/qunit/params/image.js
@@ -7,6 +7,33 @@ QUnit.test('imageUrl, imageWidth, imageHeight', (assert) => {
     imageHeight: 84
   })
   assert.equal(Swal.getImage().src, 'https://sweetalert2.github.io/images/swal2-logo.png')
-  assert.equal(Swal.getImage().getAttribute('width'), '498')
-  assert.equal(Swal.getImage().getAttribute('height'), '84')
+  assert.equal(Swal.getImage().style.width, '498px')
+  assert.equal(Swal.getImage().style.height, '84px')
+})
+
+QUnit.test('image dimentions in custom CSS units', (assert) => {
+  Swal.fire({
+    imageUrl: 'https://sweetalert2.github.io/images/swal2-logo.png',
+    imageWidth: '50%',
+    imageHeight: '3em'
+  })
+  assert.equal(Swal.getImage().style.width, '50%')
+  assert.equal(Swal.getImage().style.height, '3em')
+})
+
+QUnit.test('image alt text and custom class', (assert) => {
+  Swal.fire({
+    text: 'Custom class is set',
+    imageUrl: '/assets/swal2-logo.png',
+    imageAlt: 'Custom icon',
+    imageClass: 'image-custom-class'
+  })
+  assert.ok(Swal.getImage().classList.contains('image-custom-class'))
+  assert.equal(Swal.getImage().getAttribute('alt'), 'Custom icon')
+
+  Swal.fire({
+    text: 'Custom class isn\'t set',
+    imageUrl: '/assets/swal2-logo.png'
+  })
+  assert.notOk(Swal.getImage().classList.contains('image-custom-class'))
 })

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -444,23 +444,6 @@ QUnit.test('reversed buttons', (assert) => {
   assert.equal($('.swal2-cancel').previousSibling, $('.swal2-confirm'))
 })
 
-QUnit.test('image alt text and custom class', (assert) => {
-  Swal.fire({
-    text: 'Custom class is set',
-    imageUrl: '/assets/swal2-logo.png',
-    imageAlt: 'Custom icon',
-    imageClass: 'image-custom-class'
-  })
-  assert.ok($('.swal2-image').classList.contains('image-custom-class'))
-  assert.equal($('.swal2-image').getAttribute('alt'), 'Custom icon')
-
-  Swal.fire({
-    text: 'Custom class isn\'t set',
-    imageUrl: '/assets/swal2-logo.png'
-  })
-  assert.notOk($('.swal2-image').classList.contains('image-custom-class'))
-})
-
 QUnit.test('modal vertical offset', (assert) => {
   const done = assert.async(1)
   // create a modal with dynamic-height content


### PR DESCRIPTION
Allow setting image size in any possible CSS units: 

```js
Swal.fire({
  imageUrl: '...',
  imageWidth: '50%',
  imageHeight: '5em'
})
```

Closes #1481