### PR TITLE
Reduce complexity of openPopup()

### DIFF
--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -27,9 +27,6 @@ export const openPopup = (params) => {
   if (params.animation) {
     dom.addClass(popup, swalClasses.show)
     dom.addClass(container, swalClasses.fade)
-    dom.removeClass(popup, swalClasses.hide)
-  } else {
-    dom.removeClass(popup, swalClasses.fade)
   }
   dom.show(popup)
 

--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -6,6 +6,11 @@ import { IEfix } from './ieFix.js'
 import { setAriaHidden } from './aria.js'
 import globalState from '../globalState.js'
 
+function swalOpenAnimationFinished (popup, container) {
+  popup.removeEventListener(dom.animationEndEvent, swalOpenAnimationFinished)
+  container.style.overflowY = 'auto'
+}
+
 /**
  * Open popup, add necessary classes and styles, fix scrollbar
  *
@@ -31,10 +36,7 @@ export const openPopup = (params) => {
   // scrolling is 'hidden' until animation is done, after that 'auto'
   container.style.overflowY = 'hidden'
   if (dom.animationEndEvent && !dom.hasClass(popup, swalClasses.noanimation)) {
-    popup.addEventListener(dom.animationEndEvent, function swalCloseEventFinished () {
-      popup.removeEventListener(dom.animationEndEvent, swalCloseEventFinished)
-      container.style.overflowY = 'auto'
-    })
+    popup.addEventListener(dom.animationEndEvent, swalOpenAnimationFinished.bind(null, popup, container))
   } else {
     container.style.overflowY = 'auto'
   }

--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -31,8 +31,8 @@ export const openPopup = (params) => {
   dom.show(popup)
 
   // scrolling is 'hidden' until animation is done, after that 'auto'
-  container.style.overflowY = 'hidden'
   if (dom.animationEndEvent && !dom.hasClass(popup, swalClasses.noanimation)) {
+    container.style.overflowY = 'hidden'
     popup.addEventListener(dom.animationEndEvent, swalOpenAnimationFinished.bind(null, popup, container))
   } else {
     container.style.overflowY = 'auto'


### PR DESCRIPTION
This was done to reduce the complexity of openPopup. The name of the function has been
changed from `swalCloseEventFinished` to a more descriptive `swalOpenAnimationFinished`

Closes #1491