### PR TITLE
Tools: Added git client hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+./node_modules/.bin/gulp lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,8 @@ notifications:
 after_success:
   # run automated release process with semantic-release
   - if [[ "$TRAVIS_BRANCH" = "master" ]]; then
-      yarn global add semantic-release@16.0.0-beta.18 @semantic-release/changelog@3 @semantic-release/exec@3.4.0-beta.2 @semantic-release/git@7.1.0-beta.3;
+      yarn run uninstall-git-client-hooks &&
+      yarn global add semantic-release@16.0.0-beta.18 @semantic-release/changelog@3 @semantic-release/exec@3.4.0-beta.2 @semantic-release/git@7.1.0-beta.3 &&
       semantic-release;
     fi;
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,8 +10,9 @@ const browserSync = require('browser-sync').create()
 const packageJson = require('./package.json')
 const execute = require('./utils/execute')
 const log = require('fancy-log')
+const del = require('del')
+const vinylPaths = require('vinyl-paths')
 const version = process.env.VERSION || packageJson.version
-const fsPromises = require('fs').promises
 
 const banner = `/*!
 * ${packageJson.name} v${version}
@@ -30,20 +31,8 @@ const skipStandalone = process.argv.includes('--skip-standalone')
 // ---
 
 gulp.task('clean', () => {
-  return fsPromises.readdir('dist')
-    .then(fileList => {
-      if (fileList.length > 0) {
-        let unlinkPromises = []
-        fileList.forEach(fileName => {
-          unlinkPromises.push(fsPromises.unlink(`dist/${fileName}`))
-        })
-        return Promise.all(unlinkPromises)
-      }
-    }).catch(error => {
-      if (error.code !== 'ENOENT') {
-        return Promise.reject(error)
-      }
-    })
+  return gulp.src('dist/*')
+    .pipe(vinylPaths(del))
 })
 
 gulp.task('build:scripts', () => {
@@ -186,4 +175,9 @@ gulp.task('develop', gulp.series(
 gulp.task('install-git-client-hooks', () => {
   return gulp.src('.githooks/*')
     .pipe(gulp.dest('.git/hooks/'))
+})
+
+gulp.task('uninstall-git-client-hooks', () => {
+  return gulp.src('.git/hooks/*')
+    .pipe(vinylPaths(del))
 })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -182,3 +182,8 @@ gulp.task('develop', gulp.series(
     await execute(`karma start karma.conf.js --no-launch`)
   }
 ))
+
+gulp.task('install-git-client-hooks', () => {
+  return gulp.src('.githooks/*')
+    .pipe(gulp.dest('.git/hooks/'))
+})

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "check:third-party": "npm run check:unpkg && npm run check:jsdelivr && npm run check:wappalyzer",
     "check:wappalyzer": "curl 'https://api.wappalyzer.com/lookup-basic/v1/?url=https%3A%2F%2Fsweetalert2.github.io' 2>&1 | grep --quiet 'SweetAlert2'",
     "check:unpkg": "curl --location 'https://unpkg.com/sweetalert2' 2>&1 | grep --quiet 'window.Swal'",
-    "check:jsdelivr": "curl --location 'https://cdn.jsdelivr.net/npm/sweetalert2' 2>&1 | grep --quiet 'window.Swal'"
+    "check:jsdelivr": "curl --location 'https://cdn.jsdelivr.net/npm/sweetalert2' 2>&1 | grep --quiet 'window.Swal'",
+    "postinstall": "./node_modules/.bin/gulp install-git-client-hooks"
   },
   "bugs": "https://github.com/sweetalert2/sweetalert2/issues",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "browser-sync": "^2.26.3",
     "ci-info": "^2.0.0",
     "custom-event-polyfill": "^1.0.6",
+    "del": "^4.1.0",
     "eslint": "^5.12.1",
     "execa": "^1.0.0",
     "gulp": "^4.0.0",
@@ -57,6 +58,7 @@
     "stylelint-scss": "^3.5.4",
     "tslint": "^5.12.1",
     "typescript": "^3.2.4",
+    "vinyl-paths": "^2.1.0",
     "webpack": "^4.29.0"
   },
   "files": [
@@ -106,7 +108,8 @@
     "check:wappalyzer": "curl 'https://api.wappalyzer.com/lookup-basic/v1/?url=https%3A%2F%2Fsweetalert2.github.io' 2>&1 | grep --quiet 'SweetAlert2'",
     "check:unpkg": "curl --location 'https://unpkg.com/sweetalert2' 2>&1 | grep --quiet 'window.Swal'",
     "check:jsdelivr": "curl --location 'https://cdn.jsdelivr.net/npm/sweetalert2' 2>&1 | grep --quiet 'window.Swal'",
-    "postinstall": "./node_modules/.bin/gulp install-git-client-hooks"
+    "postinstall": "gulp install-git-client-hooks",
+    "uninstall-git-client-hooks": "gulp uninstall-git-client-hooks"
   },
   "bugs": "https://github.com/sweetalert2/sweetalert2/issues",
   "license": "MIT"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,7 +1114,7 @@ array-sort@^1.0.0:
     get-value "^2.0.6"
     kind-of "^5.0.2"
 
-array-union@^1.0.2:
+array-union@^1.0.1, array-union@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
   integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
@@ -2440,6 +2440,18 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+del@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-4.1.0.tgz#049543b8290e1a9293e2bd150ab3a06f637322b8"
+  integrity sha512-C4kvKNlYrwXhKxz97BuohF8YoGgQ23Xm9lvoHmgT7JaPGprSEjk3+XFled74Yt/x0ZABUHg2D67covzAPUKx5Q==
+  dependencies:
+    globby "^6.1.0"
+    is-path-cwd "^2.0.0"
+    is-path-in-cwd "^2.0.0"
+    p-map "^2.0.0"
+    pify "^4.0.1"
+    rimraf "^2.6.3"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -3655,6 +3667,17 @@ globals@^11.1.0, globals@^11.7.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
   integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
 
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  integrity sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
@@ -4547,6 +4570,25 @@ is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-path-cwd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.0.0.tgz#d4777a8e227a00096a31f030db3770f84b116c02"
+  integrity sha512-m5dHHzpOXEiv18JEORttBO64UgTEypx99vCxQLjbBvGhOJxnTNglYoFXxwo6AbsQb79sqqycQEHv2hWkHZAijA==
+
+is-path-in-cwd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-2.0.0.tgz#68e452a6eec260500cec21e029c0a44cc0dcd2ea"
+  integrity sha512-6Vz5Gc9s/sDA3JBVu0FzWufm8xaBsqy1zn8Q6gmvGP6nSDMw78aS4poBNeatWjaRpTpxxLn1WOndAiOlk+qY8A==
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
+  dependencies:
+    path-is-inside "^1.0.1"
 
 is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -6232,6 +6274,11 @@ p-locate@^3.0.0:
   dependencies:
     p-limit "^2.0.0"
 
+p-map@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -6382,7 +6429,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.2:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -7247,7 +7294,7 @@ rfdc@^1.1.2:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.1.2.tgz#e6e72d74f5dc39de8f538f65e00c36c18018e349"
   integrity sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA==
 
-rimraf@2, rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -8838,6 +8885,13 @@ vinyl-fs@^3.0.0, vinyl-fs@^3.0.3:
     value-or-function "^3.0.0"
     vinyl "^2.0.0"
     vinyl-sourcemap "^1.1.0"
+
+vinyl-paths@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/vinyl-paths/-/vinyl-paths-2.1.0.tgz#00820437cba38262cef8802d840f93e3392ee44b"
+  integrity sha1-AIIEN8ujgmLO+IAthA+T4zku5Es=
+  dependencies:
+    through2 "^2.0.0"
 
 vinyl-sourcemap@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
I've been playing with [git client hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) lately and I feel they are a pretty powerful to make sure some policies are reinforced before something is committed. The first thing I thought about is to run linter in the `pre-commit` phase. This hook will run the `lint` task before a commit is happening. If the linter exits with error then the commit is aborted. 

I know that we all run linter before we commit, and that `git commit --amend` is our best friend if we forget something 🤓. But on the other hand I feel this is another automation tool that can save some time for us and make sure that who contribute to this project is following proper guidelines. 

Also note that you can always bypass the check using `git commit --no-verify`. 

To test this feature: 
- Clone Sweetalert2
- Checkout this branch (`feat/git-client-hooks`)
- Run `npm` or `yarn` install. At the end of the install procedure you should see: 
```
> sweetalert2@8.8.3 postinstall 
> gulp install-git-client-hooks
```
- Change one of the file adding for example a `console.log()` statement
- Commit your changes. You should see
```
 git commit -am "Should be rejected"
(node:26515) ExperimentalWarning: The fs.promises API is experimental
[10:28:04] Using gulpfile ~/tmp/swal2/gulpfile.js
[10:28:04] Starting 'lint'...
...
  9:1  error  Unexpected console statement  no-console
```
And the commit is aborted (you can check the `git log` to make sure it's not there) 

This PR is not complete. TODO list: 

- [x] Tested on macOS with yarn and git version 2.6.4
- [x] Tested on macOS with npm and git version 2.6.4
- [x] Tested on win10 with npm and git version  2.18.0
- [x] Tested on win10 with yarn and git version  2.18.0
- [x] Tested on ubuntu 16.04 with npm and git version 2.7.4
- [ ] Tested on ubuntu 16.04 with yarn and git version 2.7.4
- [x] Remove the install hook task if executed in TravisCI and other CI / CD tools (I'm doing this PR to check what happens)
- [x] Add uninstall hooks task
- [x] Get the agreement from the maintainer and collaborators :smile:

Note: I decided to install the hook(s) in the `.git/hooks/` folder instead of using the `core.hooksPath` configuration. The reason is that this configuration is supported only by Git version >=2.9