### PR TITLE
Add npm audit check to AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,11 +20,15 @@ build: off
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - yarn
+  - npm i
 
 test_script:
-  - yarn run build
-  - yarn run check:qunit
+  - npm run build
+  - npm run check:qunit
+
+after_test:
+  - npm uninstall browser-sync # TODO(@limonte): https://github.com/BrowserSync/browser-sync/issues/1681
+  - npm audit # run audit to prevent adding vulnerable dependencies
 
 notifications:
   - provider: Email

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,15 @@
 const gulp = require('gulp')
 const noop = require('gulp-noop')
-const $ = require('gulp-load-plugins')()
+const rollup = require('gulp-rollup')
+const gulpif = require('gulp-if')
+const uglify = require('gulp-uglify')
+const rename = require('gulp-rename')
+const css2js = require('gulp-css2js')
+const concat = require('gulp-concat')
+const autoprefixer = require('gulp-autoprefixer')
+const cleanCss = require('gulp-clean-css')
+const typescript = require('gulp-typescript')
+const tslint = require('gulp-tslint')
 const eslint = require('gulp-eslint')
 const stylelint = require('gulp-stylelint')
 const babel = require('rollup-plugin-babel')
@@ -53,7 +62,7 @@ gulp.task('clean', () => {
 
 gulp.task('build:scripts', () => {
   return gulp.src(['package.json', ...srcScriptFiles])
-    .pipe($.rollup({
+    .pipe(rollup({
       plugins: [
         json(),
         babel({
@@ -79,9 +88,9 @@ if (typeof window !== 'undefined' && window.Sweetalert2){\
       }
     })
     .pipe(gulp.dest('dist'))
-    .pipe($.if(!skipMinification, $.uglify()))
-    .pipe($.if(!skipMinification, $.rename('sweetalert2.min.js')))
-    .pipe($.if(!skipMinification, gulp.dest('dist')))
+    .pipe(gulpif(!skipMinification, uglify()))
+    .pipe(gulpif(!skipMinification, rename('sweetalert2.min.js')))
+    .pipe(gulpif(!skipMinification, gulp.dest('dist')))
 })
 
 gulp.task('build:styles', () => {
@@ -89,11 +98,11 @@ gulp.task('build:styles', () => {
   fs.writeFileSync('dist/sweetalert2.css', result.css)
 
   return gulp.src('dist/sweetalert2.css')
-    .pipe($.autoprefixer())
+    .pipe(autoprefixer())
     .pipe(gulp.dest('dist'))
-    .pipe($.if(!skipMinification, $.cleanCss()))
-    .pipe($.if(!skipMinification, $.rename('sweetalert2.min.css')))
-    .pipe($.if(!skipMinification, gulp.dest('dist')))
+    .pipe(gulpif(!skipMinification, cleanCss()))
+    .pipe(gulpif(!skipMinification, rename('sweetalert2.min.css')))
+    .pipe(gulpif(!skipMinification, gulp.dest('dist')))
 })
 
 /**
@@ -102,18 +111,18 @@ gulp.task('build:styles', () => {
 gulp.task('build:standalone', () => {
   const prettyJs = gulp.src('dist/sweetalert2.js')
   const prettyCssAsJs = gulp.src('dist/sweetalert2.min.css')
-    .pipe($.css2js())
+    .pipe(css2js())
   const prettyStandalone = merge(prettyJs, prettyCssAsJs)
-    .pipe($.concat('sweetalert2.all.js'))
+    .pipe(concat('sweetalert2.all.js'))
     .pipe(gulp.dest('dist'))
   if (skipMinification) {
     return prettyStandalone
   } else {
     const uglyJs = gulp.src('dist/sweetalert2.min.js')
     const uglyCssAsJs = gulp.src('dist/sweetalert2.min.css')
-      .pipe($.css2js())
+      .pipe(css2js())
     const uglyStandalone = merge(uglyJs, uglyCssAsJs)
-      .pipe($.concat('sweetalert2.all.min.js'))
+      .pipe(concat('sweetalert2.all.min.js'))
       .pipe(gulp.dest('dist'))
     return merge([prettyStandalone, uglyStandalone])
   }
@@ -148,9 +157,9 @@ gulp.task('lint:styles', () => {
 
 gulp.task('lint:ts', () => {
   return gulp.src(tsFiles)
-    .pipe($.typescript({ lib: ['es6', 'dom'] }))
-    .pipe($.tslint({ formatter: 'verbose' }))
-    .pipe($.tslint.report({
+    .pipe(typescript({ lib: ['es6', 'dom'] }))
+    .pipe(tslint({ formatter: 'verbose' }))
+    .pipe(tslint.report({
       emitError: !continueOnError
     }))
 })

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "gulp-css2js": "^1.1.2",
     "gulp-eslint": "^5.0.0",
     "gulp-if": "^2.0.2",
-    "gulp-load-plugins": "^1.5.0",
     "gulp-noop": "^1.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-rollup": "^2.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2379,13 +2379,6 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-detect-file@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63"
-  integrity sha1-STXe39lIhkjgBrASlWbpOGcR6mM=
-  dependencies:
-    fs-exists-sync "^0.1.0"
-
 detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
@@ -2976,13 +2969,6 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expand-tilde@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-1.2.2.tgz#0b81eba897e5a3d31d1c3d102f8f01441e559449"
-  integrity sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=
-  dependencies:
-    os-homedir "^1.0.1"
-
 expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
@@ -3040,7 +3026,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-fancy-log@1.3.3, fancy-log@^1.2.0, fancy-log@^1.3.2, fancy-log@^1.3.3:
+fancy-log@1.3.3, fancy-log@^1.3.2, fancy-log@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.3.tgz#dbc19154f558690150a23953a0adbd035be45fc7"
   integrity sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==
@@ -3173,16 +3159,6 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-findup-sync@^0.4.0:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.3.tgz#40043929e7bc60adf0b7f4827c4c6e75a0deca12"
-  integrity sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=
-  dependencies:
-    detect-file "^0.1.0"
-    is-glob "^2.0.1"
-    micromatch "^2.3.7"
-    resolve-dir "^0.1.0"
-
 findup-sync@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
@@ -3298,11 +3274,6 @@ fs-access@^1.0.0:
   integrity sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=
   dependencies:
     null-check "^1.0.0"
-
-fs-exists-sync@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
-  integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
 fs-extra@3.0.1:
   version "3.0.1"
@@ -3495,14 +3466,6 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-modules@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
-  integrity sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=
-  dependencies:
-    global-prefix "^0.1.4"
-    is-windows "^0.2.0"
-
 global-modules@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
@@ -3518,16 +3481,6 @@ global-modules@^2.0.0:
   integrity sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==
   dependencies:
     global-prefix "^3.0.0"
-
-global-prefix@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
-  integrity sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=
-  dependencies:
-    homedir-polyfill "^1.0.0"
-    ini "^1.3.4"
-    is-windows "^0.2.0"
-    which "^1.2.12"
 
 global-prefix@^1.0.1:
   version "1.0.2"
@@ -3673,19 +3626,6 @@ gulp-if@^2.0.2:
     gulp-match "^1.0.3"
     ternary-stream "^2.0.1"
     through2 "^2.0.1"
-
-gulp-load-plugins@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/gulp-load-plugins/-/gulp-load-plugins-1.5.0.tgz#4c419f7e5764d9a0e33061bab9618f81b73d4171"
-  integrity sha1-TEGffldk2aDjMGG6uWGPgbc9QXE=
-  dependencies:
-    array-unique "^0.2.1"
-    fancy-log "^1.2.0"
-    findup-sync "^0.4.0"
-    gulplog "^1.0.0"
-    has-gulplog "^0.1.0"
-    micromatch "^2.3.8"
-    resolve "^1.1.7"
 
 gulp-match@^1.0.3:
   version "1.0.3"
@@ -3908,7 +3848,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
+homedir-polyfill@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
   integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
@@ -4474,11 +4414,6 @@ is-whitespace-character@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
   integrity sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==
-
-is-windows@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
-  integrity sha1-3hqm1j6indJIc3tp8f+LgALSEIw=
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -5182,7 +5117,7 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
 
-micromatch@2.3.11, micromatch@^2.3.7, micromatch@^2.3.8:
+micromatch@2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   integrity sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=
@@ -5779,7 +5714,7 @@ os-browserify@^0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
-os-homedir@^1.0.0, os-homedir@^1.0.1:
+os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
@@ -6775,14 +6710,6 @@ requires-port@1.x.x, requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
-
-resolve-dir@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
-  integrity sha1-shklmlYC+sXFxJatiUpujMQwJh4=
-  dependencies:
-    expand-tilde "^1.2.2"
-    global-modules "^0.2.3"
 
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"
@@ -8480,7 +8407,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.1.1, which@^1.2.1, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.1:
+which@^1.1.1, which@^1.2.1, which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
Not too many fucks are given about security and vulnerabilities in the JS ecosystem.

I understand that this check will bring a lot of pain because many dependencies e.g. `browser-sync` are vulnerable/unmaintained.

So it'll be needed to remove/replace those deps or just `npm uninstall` them before doing `npm audit`.

JS ecosystem is like democracy. It's crap, but it's the best of all craps we can have :)