### PR TITLE
Add SCSS variable to control buttons justification

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -304,8 +304,8 @@ body {
   flex-wrap: wrap;
   align-items: center;
   justify-content: $swal2-actions-justify;
-  margin: $swal2-actions-margin;
   width: 100%;
+  margin: $swal2-actions-margin;
 
   &:not(.swal2-loading) {
     .swal2-styled {

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -303,7 +303,7 @@ body {
   z-index: 1; // prevent sucess icon overlapping buttons
   flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
+  justify-content: $swal2-actions-justify;
   margin: $swal2-actions-margin;
 
   &:not(.swal2-loading) {

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -305,6 +305,7 @@ body {
   align-items: center;
   justify-content: $swal2-actions-justify;
   margin: $swal2-actions-margin;
+  width: 100%;
 
   &:not(.swal2-loading) {
     .swal2-styled {

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -303,7 +303,7 @@ body {
   z-index: 1; // prevent sucess icon overlapping buttons
   flex-wrap: wrap;
   align-items: center;
-  justify-content: $swal2-actions-justify;
+  justify-content: $swal2-actions-justify-content;
   width: 100%;
   margin: $swal2-actions-margin;
 

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -124,7 +124,7 @@ $swal2-close-button-hover-color: $swal2-error !default;
 $swal2-close-button-hover-background: transparent !default;
 
 // ACTIONS
-$swal2-actions-justify: center;
+$swal2-actions-justify-content: center;
 $swal2-actions-margin: 1.25em auto 0 !default;
 
 // CONFIRM BUTTON

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -124,6 +124,7 @@ $swal2-close-button-hover-color: $swal2-error !default;
 $swal2-close-button-hover-background: transparent !default;
 
 // ACTIONS
+$swal2-actions-justify: center;
 $swal2-actions-margin: 1.25em auto 0 !default;
 
 // CONFIRM BUTTON


### PR DESCRIPTION
* Added `$swal2-actions-justify`. Possible values: `center`, `flex-end`, `flex-start`
* Set `width` of `swal2-actions` class to 100%. This is needed otherwise setting `justify-content` doesn't work