### PR TITLE
fix for checkbox input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 package-lock.json
 dist
 coverage
+.idea

--- a/src/utils/dom/init.js
+++ b/src/utils/dom/init.js
@@ -68,12 +68,16 @@ const resetOldContainer = () => {
   )
 }
 
-let oldInputVal // IE11 workaround, see #1109 for details
+let oldInputVal = {}// IE11 workaround, see #1109 for details
 const resetValidationMessage = (e) => {
-  if (sweetAlert.isVisible() && oldInputVal !== e.target.value) {
+  if (sweetAlert.isVisible() && oldInputVal.data !== e.target.value) {
     sweetAlert.resetValidationMessage()
   }
-  oldInputVal = e.target.value
+  // fix checkbox, see #1594 for details. This allow to keep track of the checkbox state in "step" mode
+  oldInputVal.data = e.target.value
+  if(e.target.type === 'checkbox') {
+    oldInputVal.checked = !!e.target.checked
+  }
 }
 
 const addInputChangeListeners = () => {

--- a/src/utils/dom/renderers/renderInput.js
+++ b/src/utils/dom/renderers/renderInput.js
@@ -139,9 +139,11 @@ renderInputType.checkbox = (params) => {
   const checkbox = dom.getChildByClass(dom.getContent(), swalClasses.checkbox)
   const checkboxInput = dom.getInput(dom.getContent(), 'checkbox')
   checkboxInput.type = 'checkbox'
-  checkboxInput.value = 1
+  // if inputValue is set, use it, if not set to 1.
+  checkboxInput.value = params.inputValue ? params.inputValue : 1
   checkboxInput.id = swalClasses.checkbox
-  checkboxInput.checked = Boolean(params.inputValue)
+  // if the inputValue is a string, check the value of the attributes, if not use inputValue.
+  checkboxInput.checked = (typeof params.inputValue === 'string') ? params.inputAttributes.checked : Boolean(params.inputValue)
   let label = checkbox.querySelector('span')
   label.innerHTML = params.inputPlaceholder
   return checkbox


### PR DESCRIPTION
Hello, 

Following the issue [#1594](https://github.com/sweetalert2/sweetalert2/issues/1594) related to the checkbox. 

The first one is related to the `inputValue` and `checked` : 
```
checkboxInput.value = params.inputValue ? params.inputValue : 1
````
if inputValue is set, use it, if not set to 1. This will keep the default behavior. 

The second is related to the first one: 

```
checkboxInput.checked = (typeof params.inputValue === 'string') ? params.inputAttributes.checked : Boolean(params.inputValue)
```

if the inputValue was a string, then we fallback to `params.inputAttributes.checked`. If it's not a string, we use the value from `inputValue` . 

This is useful is we want to use an alternative value for the checkbox, it also keeps the the default behavior of the plugins 

The modification from 1 and 2 are also not impacting the validity from " HTMLSelect​Element​.check​Validity()" 

The third one is still related to the checkbox, but in a context where we are using the "Queues" to create "steps".  

Currently,  as `inputValue` is used to set the state of the checkbox, if `inputValue` is set to true, the checkbox will never be "unchecked". 

Same as for the others inputs, we keep track of the state in `oldInputVal`

```
oldInputVal.data = e.target.value
  if(e.target.type === 'checkbox') {
    oldInputVal.checked = !!e.target.checked
  }
```

Thanks.


