### PR TITLE
Revert the 'module' field, add the 'browser' field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "homepage": "https://sweetalert2.github.io/",
   "description": "A beautiful, responsive, customizable and accessible (WAI-ARIA) replacement for JavaScript's popup boxes, supported fork of sweetalert",
   "main": "dist/sweetalert2.all.js",
+  "browser": "dist/sweetalert2.all.js",
+  "module": "src/sweetalert2.js",
   "types": "sweetalert2.d.ts",
   "devDependencies": {
     "@babel/core": "^7.2.2",


### PR DESCRIPTION
Reverts #1392
Fixes #1390 (now properly)

Thanks to @ipavlic who mentioned the `"browser"` field of `package.json` in https://github.com/kenwheeler/cash/issues/268#issuecomment-495307124

The `"browser"` field will be prioritized over the `"module"`, https://github.com/webpack/webpack/blob/52184b897f40c75560b3630e43ca642fcac7e2cf/lib/WebpackOptionsDefaulter.js#L342 for the `"web"` target which is the default one.