### PR TITLE
Run swalCloseEventFinished only for animations on popup

### DIFF
--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -51,13 +51,6 @@ function removeBodyClasses () {
 }
 
 function swalCloseEventFinished (popup, container, isToast, onAfterClose) {
-  // TODO(@limonte): for some reason swalCloseEventFinished is triggered twice sometimes
-  // avoid double-executing
-  if (!globalState.keydownTarget) {
-    return
-  }
-
-  popup.removeEventListener(dom.animationEndEvent, swalCloseEventFinished)
   if (dom.hasClass(popup, swalClasses.hide)) {
     removePopupAndResetState(container, isToast, onAfterClose)
   }
@@ -85,7 +78,11 @@ export function close (resolveValue) {
 
   // If animation is supported, animate
   if (dom.animationEndEvent && dom.hasCssAnimation(popup)) {
-    popup.addEventListener(dom.animationEndEvent, swalCloseEventFinished.bind(null, popup, container, dom.isToast(), onAfterClose))
+    popup.addEventListener(dom.animationEndEvent, function (e) {
+      if (e.target === popup) {
+        swalCloseEventFinished(popup, container, dom.isToast(), onAfterClose)
+      }
+    })
   } else {
     // Otherwise, remove immediately
     removePopupAndResetState(container, dom.isToast(), onAfterClose)

--- a/test/qunit/toast.js
+++ b/test/qunit/toast.js
@@ -97,3 +97,18 @@ QUnit.test('toast click does not close if input option is specified', (assert) =
     done()
   })
 })
+
+QUnit.test('Body classes are removed after closing toats', (assert) => {
+  const done = assert.async()
+
+  Toast.fire({
+    onOpen: () => {
+      Toast.close()
+    },
+    onAfterClose: () => {
+      assert.notOk(document.body.classList.contains('swal2-shown'))
+      assert.notOk(document.body.classList.contains('swal2-toast-shown'))
+      done()
+    }
+  })
+})


### PR DESCRIPTION
Avoid calling it for elements other than a popup(e.g. when animations on icons are finished).

Fixes #1600 

