### PR TITLE
Bump browser-sync dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@sweetalert2/execute": "^1.0.0",
     "babel-loader": "^8.0.4",
     "babel-plugin-array-includes": "^2.0.3",
-    "browser-sync": "^2.26.3",
+    "browser-sync": "^2.26.7",
     "ci-info": "^2.0.0",
     "custom-event-polyfill": "^1.0.6",
     "eslint": "^5.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,7 +1446,7 @@ browser-sync-ui@^2.26.4:
     socket.io-client "^2.0.4"
     stream-throttle "^0.1.3"
 
-browser-sync@^2.26.3:
+browser-sync@^2.26.7:
   version "2.26.7"
   resolved "https://registry.yarnpkg.com/browser-sync/-/browser-sync-2.26.7.tgz#120287716eb405651a76cc74fe851c31350557f9"
   integrity sha512-lY3emme0OyvA2ujEMpRmyRy9LY6gHLuTr2/ABxhIm3lADOiRXzP4dgekvnDrQqZ/Ec2Fz19lEjm6kglSG5766w==


### PR DESCRIPTION
This version include the fixes for `axios` package vulnerability (through the `local-tunnel` dependency)