### PR TITLE
Remove style for element #swal2-content

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -464,11 +464,8 @@ body {
   font-size: $swal2-content-font-size;
   font-weight: 300;
   line-height: normal;
-  word-wrap: break-word;
-}
-
-#swal2-content {
   text-align: center;
+  word-wrap: break-word;
 }
 
 .swal2-input,


### PR DESCRIPTION
The `.swal2-content` contains a `div` element `#swal2-content`. A style is defined in the CSS for this latter element, which set the `text-align` to `center`. This prevent a custom `text-align` value to be applied to the `.swal2-content` using the `customClass.content` property of Swal2. 

Moving the `text-align` from `#swal2-content` to the `.swal2-content` is solving this problem. This is the only property set for `#swal2-content` so this element can be removed from the css. 

Fix #1623