### PR TITLE
Add $swal2-icon-font-family SCSS variable

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -648,6 +648,7 @@ body {
   zoom: $swal2-icon-zoom;
   border: .25em solid transparent;
   border-radius: 50%;
+  font-family: $swal2-icon-font-family;
   line-height: $swal2-icon-size;
   cursor: default;
   user-select: none;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -31,6 +31,7 @@ $swal2-error: #f27474 !default;
 $swal2-warning: #f8bb86 !default;
 $swal2-info: #3fc3ee !default;
 $swal2-question: #87adbd !default;
+$swal2-icon-font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
 
 // IMAGE
 $swal2-image-margin: 1.25em auto !default;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -31,7 +31,7 @@ $swal2-error: #f27474 !default;
 $swal2-warning: #f8bb86 !default;
 $swal2-info: #3fc3ee !default;
 $swal2-question: #87adbd !default;
-$swal2-icon-font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
+$swal2-icon-font-family: inherit !default;
 
 // IMAGE
 $swal2-image-margin: 1.25em auto !default;


### PR DESCRIPTION
This will set the default font style for the info, warning, and question icons as per the style in the documentation

Fix #1625 