### PR TITLE
Reduce method complexity of setParameters()

### DIFF
--- a/src/utils/setParameters.js
+++ b/src/utils/setParameters.js
@@ -54,14 +54,5 @@ export default function setParameters (params) {
   if (typeof params.title === 'string') {
     params.title = params.title.split('\n').join('<br />')
   }
-
-  const oldPopup = dom.getPopup()
-  let targetElement = (typeof params.target === 'string') ? document.querySelector(params.target) : params.target
-  if (
-    !oldPopup ||
-    // If the model target has changed, refresh the popup
-    (oldPopup && targetElement && oldPopup.parentNode !== targetElement.parentNode)
-  ) {
-    dom.init(params)
-  }
+  dom.init(params)
 }

--- a/src/utils/setParameters.js
+++ b/src/utils/setParameters.js
@@ -1,14 +1,11 @@
 import { warn, callIfFunction } from './utils.js'
 import * as dom from './dom/index.js'
 import defaultInputValidators from './defaultInputValidators.js'
+const loaderOnConfirmMessage = 'showLoaderOnConfirm is set to true, but preConfirm is not defined.\n' +
+                                'showLoaderOnConfirm should be used together with preConfirm, see usage example:\n' +
+                                'https://sweetalert2.github.io/#ajax-request'
 
-/**
- * Set type, text and actions on popup
- *
- * @param params
- * @returns {boolean}
- */
-export default function setParameters (params) {
+function setDefaultInputValidators (params) {
   // Use default `inputValidator` for supported input types if not provided
   if (!params.inputValidator) {
     Object.keys(defaultInputValidators).forEach((key) => {
@@ -17,22 +14,9 @@ export default function setParameters (params) {
       }
     })
   }
+}
 
-  // showLoaderOnConfirm && preConfirm
-  if (params.showLoaderOnConfirm && !params.preConfirm) {
-    warn(
-      'showLoaderOnConfirm is set to true, but preConfirm is not defined.\n' +
-      'showLoaderOnConfirm should be used together with preConfirm, see usage example:\n' +
-      'https://sweetalert2.github.io/#ajax-request'
-    )
-  }
-
-  // params.animation will be actually used in renderPopup.js
-  // but in case when params.animation is a function, we need to call that function
-  // before popup (re)initialization, so it'll be possible to check Swal.isVisible()
-  // inside the params.animation function
-  params.animation = callIfFunction(params.animation)
-
+function validateCustomTargetElement (params) {
   // Determine if the custom target element is valid
   if (
     !params.target ||
@@ -42,14 +26,37 @@ export default function setParameters (params) {
     warn('Target parameter is not valid, defaulting to "body"')
     params.target = 'body'
   }
+}
+
+/**
+ * Set type, text and actions on popup
+ *
+ * @param params
+ * @returns {boolean}
+ */
+export default function setParameters (params) {
+  setDefaultInputValidators(params)
+
+  // showLoaderOnConfirm && preConfirm
+  if (params.showLoaderOnConfirm && !params.preConfirm) {
+    warn(loaderOnConfirmMessage)
+  }
+
+  // params.animation will be actually used in renderPopup.js
+  // but in case when params.animation is a function, we need to call that function
+  // before popup (re)initialization, so it'll be possible to check Swal.isVisible()
+  // inside the params.animation function
+  params.animation = callIfFunction(params.animation)
+
+  validateCustomTargetElement(params)
 
   // Replace newlines with <br> in title
   if (typeof params.title === 'string') {
-    params.title = params.title.split('\n').join('<br />');
+    params.title = params.title.split('\n').join('<br />')
   }
 
   const oldPopup = dom.getPopup()
-  let targetElement = typeof params.target === 'string' ? document.querySelector(params.target) : params.target
+  let targetElement = (typeof params.target === 'string') ? document.querySelector(params.target) : params.target
   if (
     !oldPopup ||
     // If the model target has changed, refresh the popup
@@ -58,4 +65,3 @@ export default function setParameters (params) {
     dom.init(params)
   }
 }
-

--- a/src/utils/setParameters.js
+++ b/src/utils/setParameters.js
@@ -1,9 +1,6 @@
 import { warn, callIfFunction } from './utils.js'
 import * as dom from './dom/index.js'
 import defaultInputValidators from './defaultInputValidators.js'
-const loaderOnConfirmMessage = 'showLoaderOnConfirm is set to true, but preConfirm is not defined.\n' +
-                                'showLoaderOnConfirm should be used together with preConfirm, see usage example:\n' +
-                                'https://sweetalert2.github.io/#ajax-request'
 
 function setDefaultInputValidators (params) {
   // Use default `inputValidator` for supported input types if not provided
@@ -39,7 +36,11 @@ export default function setParameters (params) {
 
   // showLoaderOnConfirm && preConfirm
   if (params.showLoaderOnConfirm && !params.preConfirm) {
-    warn(loaderOnConfirmMessage)
+    warn(
+      'showLoaderOnConfirm is set to true, but preConfirm is not defined.\n' +
+      'showLoaderOnConfirm should be used together with preConfirm, see usage example:\n' +
+      'https://sweetalert2.github.io/#ajax-request'
+    )
   }
 
   // params.animation will be actually used in renderPopup.js
@@ -54,5 +55,6 @@ export default function setParameters (params) {
   if (typeof params.title === 'string') {
     params.title = params.title.split('\n').join('<br />')
   }
+
   dom.init(params)
 }


### PR DESCRIPTION
Created two functions:
* `setDefaultInputValidators()`: to assign default input  validators
* `validateCustomTargetElement()`: to check if the target element is a valid one

Also:
* Moved warning message to a constant outside of function
* Code clean-up

Fix #1490 