### PR TITLE
Change closing sequence to detect a closing swal

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,2 @@
 export const RESTORE_FOCUS_TIMEOUT = 100
+export const DISPOSE_SWAL_TIMEOUT = 36000

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -17,7 +17,7 @@ export function _main (userParams) {
   if (globalState.swalClosing) {
     delete globalState.swalClosing
     globalState.swalCloseEventFinishedCallback()
-    delete globalState.swalCloseEventFinishedCallback()
+    delete globalState.swalCloseEventFinishedCallback
   }
 
   // Check if there is a swal disposal defer timer

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -13,6 +13,19 @@ import { handleInputOptions, handleInputValue } from '../utils/dom/inputUtils.js
 export function _main (userParams) {
   showWarningsForParams(userParams)
 
+  // Check if there is another Swal closing
+  if (globalState.swalClosing) {
+    delete globalState.swalClosing
+    globalState.swalCloseEventFinishedCallback()
+    delete globalState.swalCloseEventFinishedCallback()
+  }
+
+  // Check if there is a swal disposal defer timer
+  if (globalState.deferDisposalTimer) {
+    clearTimeout(globalState.deferDisposalTimer)
+    delete globalState.deferDisposalTimer
+  }
+
   const innerParams = Object.assign({}, defaultParams, userParams)
   setParameters(innerParams)
   Object.freeze(innerParams)

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -50,16 +50,6 @@ function removeBodyClasses () {
   )
 }
 
-function swalCloseEventFinished (popup, container, isToast, onAfterClose) {
-  if (dom.hasClass(popup, swalClasses.hide)) {
-    removePopupAndResetState(container, isToast, onAfterClose)
-  }
-
-  // Unset WeakMaps so GC will be able to dispose them (#1569)
-  unsetWeakMaps(privateProps)
-  unsetWeakMaps(privateMethods)
-}
-
 export function close (resolveValue) {
   const popup = dom.getPopup()
 
@@ -101,10 +91,14 @@ const handlePopupAnimation = (popup, onAfterClose) => {
 }
 
 const animatePopup = (popup, container, onAfterClose) => {
+  globalState.swalClosing = true
+  globalState.swalCloseEventFinishedCallback = removePopupAndResetState.bind(null, container, dom.isToast(), onAfterClose)
   popup.addEventListener(dom.animationEndEvent, function (e) {
+    delete globalState.swalClosing
     if (e.target === popup) {
-      swalCloseEventFinished(popup, container, dom.isToast(), onAfterClose)
+      globalState.swalCloseEventFinishedCallback()
     }
+    delete globalState.swalCloseEventFinishedCallback
   })
 }
 

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -71,6 +71,7 @@ QUnit.test('should show the popup with OK button in case of empty object passed 
 })
 
 QUnit.test('the vertical scrollbar should be hidden and the according padding-right should be set', (assert) => {
+  const done = assert.async()
   const talltDiv = document.createElement('div')
   talltDiv.innerHTML = Array(100).join('<div>lorem ipsum</div>')
   document.body.appendChild(talltDiv)
@@ -83,6 +84,7 @@ QUnit.test('the vertical scrollbar should be hidden and the according padding-ri
     onAfterClose: () => {
       assert.equal(bodyStyles.paddingRight, '30px')
       document.body.removeChild(talltDiv)
+      done()
     }
   })
   const bodyStyles = window.getComputedStyle(document.body)

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -113,6 +113,31 @@ QUnit.test('scrollbarPadding disabled', (assert) => {
   Swal.clickConfirm()
 })
 
+QUnit.test('the vertical scrollbar should be restored before a toast is fired after a modal', (assert) => {
+  const done = assert.async()
+  const talltDiv = document.createElement('div')
+  talltDiv.innerHTML = Array(100).join('<div>lorem ipsum</div>')
+  document.body.appendChild(talltDiv)
+  document.body.style.paddingRight = '30px'
+
+  Swal.fire({
+    title: 'The body has visible scrollbar, I will hide it and adjust padding-right on body'
+  }).then(() => {
+    Swal.fire({
+      text: 'Body padding-right should be restored',
+      toast: true,
+      onOpen: () => {
+        assert.equal(bodyStyles.paddingRight, '30px')
+        document.body.removeChild(talltDiv)
+        done()
+      }
+    })
+  })
+
+  const bodyStyles = window.getComputedStyle(document.body)
+  Swal.clickConfirm()
+})
+
 QUnit.test('modal width', (assert) => {
   Swal.fire({ text: '300px', width: 300 })
   assert.equal($('.swal2-modal').style.width, '300px')


### PR DESCRIPTION
If a new Swal is fired while a previous Swal is closing (e.g. Swal `fire`s in `then`) then the first Swal doesn't get disposed properly (e.g. the `animationEndEvent` event never happens).

This can create some side effects: for example if a toast (or a modal with `scrollbarPadding` set to `false`) is `fire`d in the `then` of a modal, then the scrollbar is not restored until the toast closes (see #1640). 

To avoid that, two new variables are added to `globalState`: 
* `globalState.swalClosing`: if `true` means the Swal closing animation
has started but not completed yet (i.e. there is a Swal closing). This variable may seem redundant (since the one below can be checked instead) but I think is good to keep it for code readability
* `globalState.swalCloseEventFinishedCallback`: callback function to be called once the
Swal animation has completed. This is also called when a _closing_ Swal is detected while a new one is firing (in the `_main()`) . This callback is _just_ a wrapper around `removePopupAndResetState()`: this also make the closing sequence identical between the Swal with and without animation (see more below)

Also, this PR contains the following changes: 
* Remove `swalCloseEventFinished()`: the reason is that this function was called only when the Swal had animation. So the final state was different between a Swal with and without animation. Part of the code of this function have been moved to  `globalState.swalCloseEventFinishedCallback`
* Add `disposeSwal()`: All the _disposals_ of the Swal objects to allow GC to de-allocate them have been moved to a deferred function `disposeSwal()`. This executes after `DISPOSE_SWAL_TIMEOUT` ms (currently set at 60 seconds). The reason why it's deferred, is to allow all the Swal objects to be still accessed in the `then`. Currently after the animation is over (~150ms), the Swal objects are not accessible anymore (see [here](https://github.com/sweetalert2/sweetalert2/issues/1640#issuecomment-507383036)) So effectively this change will allow more time for accessing those objects (hence should be a non-breaking change)
* Add `globalState.deferDisposalTimer`: keep track of the timeout ID for the deferred disposal. This ID is needed in case the timeout should be stopped (e.g. a new Swal is `fire`d)

Fix #1640