### PR TITLE
Move `globalState` variables delete statements in closing callback

### DIFF
--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -102,8 +102,8 @@ const animatePopup = (popup, container, onAfterClose) => {
   globalState.swalClosing = true
   globalState.swalCloseEventFinishedCallback = removePopupAndResetState.bind(null, container, dom.isToast(), onAfterClose)
   popup.addEventListener(dom.animationEndEvent, function (e) {
-    delete globalState.swalClosing
-    if (e.target === popup) {
+    if (e.target === popup && globalState.swalClosing) {
+      delete globalState.swalClosing
       globalState.swalCloseEventFinishedCallback()
       delete globalState.swalCloseEventFinishedCallback
     }

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -105,8 +105,8 @@ const animatePopup = (popup, container, onAfterClose) => {
     delete globalState.swalClosing
     if (e.target === popup) {
       globalState.swalCloseEventFinishedCallback()
+      delete globalState.swalCloseEventFinishedCallback
     }
-    delete globalState.swalCloseEventFinishedCallback
   })
 }
 


### PR DESCRIPTION
In some circumstances (e.g. if the Swal is closed before the animation of the icon is over) the `animationEndEvent` event is triggered for elements other than the `popup` (e.g. the icon)

When this happens, the `globalState.swalCloseEventFinishedCallback` is deleted without being executed. To make the whole routine more robust: 

* `globalState.swalCloseEventFinishedCallback` is deleted only after is executed (i.e. when the `animationEndEvent` has `popup` as target)
* `globalState.swalClosing` is checked before invoking `globalState.swalCloseEventFinishedCallback()`

Fix #1646 