### PR TITLE
Perform removeBodyClasses() as the very last step

### DIFF
--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -25,7 +25,6 @@ function removePopupAndResetState (container, isToast, onAfterClose) {
   if (container.parentNode) {
     container.parentNode.removeChild(container)
   }
-  removeBodyClasses()
 
   if (dom.isModal()) {
     undoScrollbar()
@@ -33,6 +32,8 @@ function removePopupAndResetState (container, isToast, onAfterClose) {
     undoIEfix()
     unsetAriaHidden()
   }
+
+  removeBodyClasses()
 }
 
 function removeBodyClasses () {

--- a/test/qunit/a11y.js
+++ b/test/qunit/a11y.js
@@ -69,13 +69,23 @@ QUnit.test('should not set aria-hidden="true" when `backdrop: false`', (assert) 
 })
 
 QUnit.test('should not set aria-hidden="true" when `toast: true`', (assert) => {
+  const done = assert.async()
+
   const div = document.createElement('div')
   document.body.appendChild(div)
+  const divAriaHiddenTrue = document.createElement('div')
+  divAriaHiddenTrue.setAttribute('aria-hidden', 'true')
+  document.body.appendChild(divAriaHiddenTrue)
 
   SwalWithoutAnimation.fire({
-    toast: true
+    toast: true,
+    onAfterClose: () => {
+      assert.equal(divAriaHiddenTrue.getAttribute('aria-hidden'), 'true')
+      done()
+    }
   })
   assert.notOk(div.hasAttribute('aria-hidden'))
+  Swal.close()
 })
 
 QUnit.test('dialog aria attributes', (assert) => {


### PR DESCRIPTION
Because `dom.isModal()` depends on body classes.

Fix #1648
