### PR TITLE
Get rid of DISPOSE_SWAL_TIMEOUT

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,1 @@
 export const RESTORE_FOCUS_TIMEOUT = 100
-export const DISPOSE_SWAL_TIMEOUT = 36000

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -14,8 +14,7 @@ export function _main (userParams) {
   showWarningsForParams(userParams)
 
   // Check if there is another Swal closing
-  if (globalState.swalClosing) {
-    delete globalState.swalClosing
+  if (dom.getPopup() && globalState.swalCloseEventFinishedCallback) {
     globalState.swalCloseEventFinishedCallback()
     delete globalState.swalCloseEventFinishedCallback
   }

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -123,7 +123,9 @@ const triggerOnAfterCloseAndDispose = (instance, onAfterClose) => {
     if (onAfterClose !== null && typeof onAfterClose === 'function') {
       onAfterClose()
     }
-    disposeSwal(instance)
+    if (!dom.getPopup()) {
+      disposeSwal(instance)
+    }
   })
 }
 

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -101,11 +101,9 @@ const handlePopupAnimation = (instance, popup, innerParams) => {
 }
 
 const animatePopup = (instance, popup, container, onAfterClose) => {
-  globalState.swalClosing = true
   globalState.swalCloseEventFinishedCallback = removePopupAndResetState.bind(null, instance, container, dom.isToast(), onAfterClose)
   popup.addEventListener(dom.animationEndEvent, function (e) {
-    if (e.target === popup && globalState.swalClosing) {
-      delete globalState.swalClosing
+    if (e.target === popup) {
       globalState.swalCloseEventFinishedCallback()
       delete globalState.swalCloseEventFinishedCallback
     }

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -71,25 +71,26 @@ export function close (resolveValue) {
     return
   }
   const swalPromiseResolve = privateMethods.swalPromiseResolve.get(this)
-  const { onClose, onAfterClose } = innerParams
 
   dom.removeClass(popup, swalClasses.show)
   dom.addClass(popup, swalClasses.hide)
 
-  handlePopupAnimation(this, popup, onAfterClose)
-
-  if (onClose !== null && typeof onClose === 'function') {
-    onClose(popup)
-  }
+  handlePopupAnimation(this, popup, innerParams)
 
   // Resolve Swal promise
   swalPromiseResolve(resolveValue || {})
 }
 
-const handlePopupAnimation = (instance, popup, onAfterClose) => {
+const handlePopupAnimation = (instance, popup, innerParams) => {
   const container = dom.getContainer()
   // If animation is supported, animate
   const animationIsSupported = dom.animationEndEvent && dom.hasCssAnimation(popup)
+
+  const { onClose, onAfterClose } = innerParams
+
+  if (onClose !== null && typeof onClose === 'function') {
+    onClose(popup)
+  }
 
   if (animationIsSupported) {
     animatePopup(instance, popup, container, onAfterClose)

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -14,9 +14,9 @@ import privateMethods from '../privateMethods.js'
 
 function removePopupAndResetState (instance, container, isToast, onAfterClose) {
   if (isToast) {
-    triggerOnAfterClose(onAfterClose)
+    triggerOnAfterCloseAndDispose(instance, onAfterClose)
   } else {
-    restoreActiveElement().then(() => triggerOnAfterClose(onAfterClose))
+    restoreActiveElement().then(() => triggerOnAfterCloseAndDispose(instance, onAfterClose))
     globalState.keydownTarget.removeEventListener('keydown', globalState.keydownHandler, { capture: globalState.keydownListenerCapture })
     globalState.keydownHandlerAdded = false
   }
@@ -33,8 +33,6 @@ function removePopupAndResetState (instance, container, isToast, onAfterClose) {
   }
 
   removeBodyClasses()
-
-  disposeSwal(instance)
 }
 
 function removeBodyClasses () {
@@ -69,6 +67,9 @@ export function close (resolveValue) {
   }
 
   const innerParams = privateProps.innerParams.get(this)
+  if (!innerParams) {
+    return
+  }
   const swalPromiseResolve = privateMethods.swalPromiseResolve.get(this)
   const { onClose, onAfterClose } = innerParams
 
@@ -116,12 +117,13 @@ const unsetWeakMaps = (obj) => {
   }
 }
 
-const triggerOnAfterClose = (onAfterClose) => {
-  if (onAfterClose !== null && typeof onAfterClose === 'function') {
-    setTimeout(() => {
+const triggerOnAfterCloseAndDispose = (instance, onAfterClose) => {
+  setTimeout(() => {
+    if (onAfterClose !== null && typeof onAfterClose === 'function') {
       onAfterClose()
-    })
-  }
+    }
+    disposeSwal(instance)
+  })
 }
 
 export {

--- a/src/instanceMethods/getInput.js
+++ b/src/instanceMethods/getInput.js
@@ -5,5 +5,8 @@ import privateProps from '../privateProps.js'
 export function getInput (instance) {
   const innerParams = privateProps.innerParams.get(instance || this)
   const domCache = privateProps.domCache.get(instance || this)
+  if (!domCache) {
+    return null
+  }
   return dom.getInput(domCache.content, innerParams.input)
 }

--- a/test/qunit/methods/close.js
+++ b/test/qunit/methods/close.js
@@ -52,9 +52,14 @@ QUnit.test('Swal.fire() inside onAfterClose', (assert) => {
   SwalWithoutAnimation.fire({
     onAfterClose: () => {
       assert.notOk(Swal.isVisible())
-      SwalWithoutAnimation.fire()
+      SwalWithoutAnimation.fire({
+        input: 'text',
+        onOpen: () => {
+          assert.notDeepEqual(Swal.getInput(), null)
+          done()
+        }
+      })
       assert.ok(Swal.isVisible())
-      done()
     }
   })
 

--- a/test/qunit/methods/close.js
+++ b/test/qunit/methods/close.js
@@ -46,11 +46,11 @@ QUnit.test('onAfterClose using close() method', (assert) => {
   Swal.close()
 })
 
-QUnit.test('Swal.fire() inside onClose', (assert) => {
+QUnit.test('Swal.fire() inside onAfterClose', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation.fire({
-    onClose: () => {
+    onAfterClose: () => {
       assert.notOk(Swal.isVisible())
       SwalWithoutAnimation.fire()
       assert.ok(Swal.isVisible())

--- a/test/qunit/params/input.js
+++ b/test/qunit/params/input.js
@@ -204,16 +204,29 @@ QUnit.test('input radio', (assert) => {
   assert.equal($('.swal2-radio').querySelectorAll('input[type="radio"]').length, 2)
 })
 
-QUnit.test('Swal.getInput() should return null when a popup is disposed', (assert) => {
+QUnit.test('Swal.getInput() should be available in .then()', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation.fire({
     input: 'text',
   }).then(() => {
-    setTimeout(() => {
-      assert.equal(Swal.getInput(), null)
-      done()
-    }, TIMEOUT)
+    assert.ok(Swal.getInput())
+    done()
+  })
+  Swal.close()
+})
+
+QUnit.test('Swal.getInput() should return null when a popup is disposed', (assert) => {
+  const done = assert.async()
+
+  SwalWithoutAnimation.fire({
+    input: 'text',
+    onAfterClose: () => {
+      setTimeout(() => {
+        assert.notOk(Swal.getInput())
+        done()
+      }, TIMEOUT)
+    }
   })
   Swal.close()
 })

--- a/test/qunit/params/input.js
+++ b/test/qunit/params/input.js
@@ -203,3 +203,17 @@ QUnit.test('input radio', (assert) => {
   assert.equal($('.swal2-radio').querySelectorAll('label').length, 2)
   assert.equal($('.swal2-radio').querySelectorAll('input[type="radio"]').length, 2)
 })
+
+QUnit.test('Swal.getInput() should return null when a popup is disposed', (assert) => {
+  const done = assert.async()
+
+  SwalWithoutAnimation.fire({
+    input: 'text',
+  }).then(() => {
+    setTimeout(() => {
+      assert.equal(Swal.getInput(), null)
+      done()
+    }, TIMEOUT)
+  })
+  Swal.close()
+})

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -568,6 +568,27 @@ QUnit.test('onClose', (assert) => {
   $('.swal2-close').click()
 })
 
+QUnit.test('Swal.fire() in onClose', (assert) => {
+  const done = assert.async()
+
+  Swal.fire({
+    title: 'onClose test',
+    onClose: () => {
+      Swal.fire({
+        text: 'OnClose',
+        input: 'text',
+        inputClass: 'on-close-swal'
+      })
+    }
+  }).then(() => {
+    assert.ok(Swal.isVisible())
+    assert.ok(Swal.getInput().classList.contains('on-close-swal'))
+    done()
+  })
+
+  Swal.clickConfirm()
+})
+
 QUnit.test('esc key', (assert) => {
   const done = assert.async()
 


### PR DESCRIPTION
Fixes #1654

I moved `disposeSwal()` to `removePopupAndResetState()`. @gverni let me know if I'm missing some use-cases.

No tests are failing after removing `DISPOSE_SWAL_TIMEOUT` so either we don't have that functionality covered by tests or everything is well without `DISPOSE_SWAL_TIMEOUT`.

@gverni please take a look and let me know what do you think