### PR TITLE
Add iconHtml

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -653,15 +653,15 @@ body {
   cursor: default;
   user-select: none;
 
-  &::before {
+  .swal2-icon-content {
     display: flex;
     align-items: center;
-    height: 92%;
     font-size: 3.75em;
   }
 
   &.swal2-error {
     border-color: $swal2-error;
+    color: $swal2-error;
 
     .swal2-x-mark {
       position: relative;
@@ -692,36 +692,21 @@ body {
   &.swal2-warning {
     border-color: lighten($swal2-warning, 7);
     color: $swal2-warning;
-
-    &::before {
-      content: '!';
-    }
   }
 
   &.swal2-info {
     border-color: lighten($swal2-info, 20);
     color: $swal2-info;
-
-    &::before {
-      content: 'i';
-    }
   }
 
   &.swal2-question {
     border-color: lighten($swal2-question, 20);
     color: $swal2-question;
-
-    &::before {
-      content: '?';
-    }
-
-    &.swal2-arabic-question-mark::before {
-      content: '؟';
-    }
   }
 
   &.swal2-success {
     border-color: $swal2-success;
+    color: $swal2-success;
 
     [class^='swal2-success-circular-line'] { // Emulate moving circular line
       position: absolute;

--- a/src/utils/classes.js
+++ b/src/utils/classes.js
@@ -32,6 +32,7 @@ export const swalClasses = prefix([
   'cancel',
   'footer',
   'icon',
+  'icon-content',
   'image',
   'input',
   'file',

--- a/src/utils/dom/init.js
+++ b/src/utils/dom/init.js
@@ -9,18 +9,11 @@ const sweetHTML = `
  <div aria-labelledby="${swalClasses.title}" aria-describedby="${swalClasses.content}" class="${swalClasses.popup}" tabindex="-1">
    <div class="${swalClasses.header}">
      <ul class="${swalClasses['progress-steps']}"></ul>
-     <div class="${swalClasses.icon} ${iconTypes.error}">
-       <span class="swal2-x-mark"><span class="swal2-x-mark-line-left"></span><span class="swal2-x-mark-line-right"></span></span>
-     </div>
+     <div class="${swalClasses.icon} ${iconTypes.error}"></div>
      <div class="${swalClasses.icon} ${iconTypes.question}"></div>
      <div class="${swalClasses.icon} ${iconTypes.warning}"></div>
      <div class="${swalClasses.icon} ${iconTypes.info}"></div>
-     <div class="${swalClasses.icon} ${iconTypes.success}">
-       <div class="swal2-success-circular-line-left"></div>
-       <span class="swal2-success-line-tip"></span> <span class="swal2-success-line-long"></span>
-       <div class="swal2-success-ring"></div> <div class="swal2-success-fix"></div>
-       <div class="swal2-success-circular-line-right"></div>
-     </div>
+     <div class="${swalClasses.icon} ${iconTypes.success}"></div>
      <img class="${swalClasses.image}" />
      <h2 class="${swalClasses.title}" id="${swalClasses.title}"></h2>
      <button type="button" class="${swalClasses.close}"></button>

--- a/src/utils/dom/renderers/renderIcon.js
+++ b/src/utils/dom/renderers/renderIcon.js
@@ -19,11 +19,15 @@ export const renderIcon = (instance, params) => {
     return
   }
 
-  adjustSuccessIconBackgoundColor()
-
   if (Object.keys(iconTypes).indexOf(params.type) !== -1) {
     const icon = dom.elementBySelector(`.${swalClasses.icon}.${iconTypes[params.type]}`)
+
     dom.show(icon)
+
+    // Custom or default content
+    setContent(icon, params)
+
+    adjustSuccessIconBackgoundColor()
 
     // Custom class
     dom.applyCustomClass(icon, params.customClass, 'icon')
@@ -51,3 +55,34 @@ const adjustSuccessIconBackgoundColor = () => {
     successIconParts[i].style.backgroundColor = popupBackgroundColor
   }
 }
+
+const setContent = (icon, params) => {
+  icon.innerHTML = ''
+
+  if (params.iconHtml) {
+    icon.innerHTML = iconContent(params.iconHtml)
+  } else if (params.type === 'success') {
+    icon.innerHTML = `
+      <div class="swal2-success-circular-line-left"></div>
+      <span class="swal2-success-line-tip"></span> <span class="swal2-success-line-long"></span>
+      <div class="swal2-success-ring"></div> <div class="swal2-success-fix"></div>
+      <div class="swal2-success-circular-line-right"></div>
+    `
+  } else if (params.type === 'error') {
+    icon.innerHTML = `
+      <span class="swal2-x-mark">
+        <span class="swal2-x-mark-line-left"></span>
+        <span class="swal2-x-mark-line-right"></span>
+      </span>
+    `
+  } else {
+    const defaultIconHtml = {
+      question: '?',
+      warning: '!',
+      info: 'i'
+    }
+    icon.innerHTML = iconContent(defaultIconHtml[params.type])
+  }
+}
+
+const iconContent = (content) => `<div class="${swalClasses['icon-content']}">${content}</div>`

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -6,7 +6,8 @@ const defaultParams = {
   text: '',
   html: '',
   footer: '',
-  type: null,
+  type: null, // todo: deprecate in favor of 'icon'
+  iconHtml: null,
   toast: false,
   customClass: '',
   customContainerClass: '',

--- a/test/qunit/params/iconHtml.js
+++ b/test/qunit/params/iconHtml.js
@@ -1,0 +1,10 @@
+const { Swal } = require('../helpers')
+
+QUnit.test('Success icon with custom HTML', (assert) => {
+  Swal.fire({
+    type: 'success',
+    iconHtml: '<i class="fa fa-circle"></i>'
+  })
+
+  assert.equal(Swal.getIcon().innerHTML, '<div class="swal2-icon-content"><i class="fa fa-circle"></i></div>')
+})


### PR DESCRIPTION
This PR contains the breaking change: the documented `.swal2-arabic-question-mark` class is dropped, `iconHtml: '؟'` should be used instead. 

Merge for the upcoming major.

Closes #1532