### PR TITLE
Extract confirm and cancel buttons click handlers

### DIFF
--- a/src/instanceMethods/buttons-handlers.js
+++ b/src/instanceMethods/buttons-handlers.js
@@ -1,0 +1,92 @@
+import { isVisible } from '../utils/dom/domUtils.js'
+import { getValidationMessage } from '../utils/dom/getters.js'
+import { showLoading } from '../staticMethods/showLoading.js'
+import { DismissReason } from '../utils/DismissReason.js'
+
+export const handleConfirmButtonClick = (instance, innerParams) => {
+  instance.disableButtons()
+  if (innerParams.input) {
+    handleConfirmWithInput(instance, innerParams)
+  } else {
+    confirm(instance, innerParams, true)
+  }
+}
+
+export const handleCancelButtonClick = (instance, dismissWith) => {
+  instance.disableButtons()
+  dismissWith(DismissReason.cancel)
+}
+
+const handleConfirmWithInput = (instance, innerParams) => {
+  const inputValue = getInputValue(instance, innerParams)
+
+  if (innerParams.inputValidator) {
+    instance.disableInput()
+    const validationPromise = Promise.resolve().then(() => innerParams.inputValidator(inputValue, innerParams.validationMessage))
+    validationPromise.then(
+      (validationMessage) => {
+        instance.enableButtons()
+        instance.enableInput()
+        if (validationMessage) {
+          instance.showValidationMessage(validationMessage)
+        } else {
+          confirm(instance, innerParams, inputValue)
+        }
+      }
+    )
+  } else if (!instance.getInput().checkValidity()) {
+    instance.enableButtons()
+    instance.showValidationMessage(innerParams.validationMessage)
+  } else {
+    confirm(instance, innerParams, inputValue)
+  }
+}
+
+const succeedWith = (instance, value) => {
+  instance.closePopup({ value })
+}
+
+const confirm = (instance, innerParams, value) => {
+  if (innerParams.showLoaderOnConfirm) {
+    showLoading() // TODO: make showLoading an *instance* method
+  }
+
+  if (innerParams.preConfirm) {
+    instance.resetValidationMessage()
+    const preConfirmPromise = Promise.resolve().then(() => innerParams.preConfirm(value, innerParams.validationMessage))
+    preConfirmPromise.then(
+      (preConfirmValue) => {
+        if (isVisible(getValidationMessage()) || preConfirmValue === false) {
+          instance.hideLoading()
+        } else {
+          succeedWith(instance, typeof (preConfirmValue) === 'undefined' ? value : preConfirmValue)
+        }
+      }
+    )
+  } else {
+    succeedWith(instance, value)
+  }
+}
+
+const getInputValue = (instance, innerParams) => {
+  const input = instance.getInput()
+  if (!input) {
+    return null
+  }
+  switch (innerParams.input) {
+    case 'checkbox':
+      return getCheckboxValue(input)
+    case 'radio':
+      return getRadioValue(input)
+    case 'file':
+      return getFileValue(input)
+    default:
+      return innerParams.inputAutoTrim ? input.value.trim() : input.value
+  }
+}
+
+const getCheckboxValue = (input) => input.checked ? 1 : 0
+
+const getRadioValue = (input) => input.checked ? input.value : null
+
+const getFileValue = (input) => input.files.length ? input.files[0] : null


### PR DESCRIPTION
Towards #1540 

`onmouseover`, `onmouseout` and `onmousedown` handlers were legacy leftovers, not used anymore.

Fixed 4 codeclimate issues:

![image](https://user-images.githubusercontent.com/6059356/61576958-9c6cf900-aae9-11e9-8cde-508b11c20cb0.png)
