### PR TITLE
Use typescript-eslint instead of deprecated tslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,19 +1,28 @@
 module.exports = {
+  parser: '@typescript-eslint/parser',
   env: {
     browser: true,
     node: true,
     commonjs: true,
     es6: true
   },
-  extends: 'standard',
+  extends: [
+    'standard',
+    'plugin:@typescript-eslint/recommended'
+  ],
   plugins: [
     'import'
   ],
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 2018,
     sourceType: 'module'
   },
   rules: {
+    '@typescript-eslint/indent': ['error', 2],
+    '@typescript-eslint/no-use-before-define': 0,
+    '@typescript-eslint/no-var-requires': 0,
+    '@typescript-eslint/no-empty-interface': 0,
+    '@typescript-eslint/no-explicit-any': 0,
     'comma-dangle': 0,
     'complexity': ['error', { max: 10 }],
     'import/extensions': ['error', 'always'],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,8 +8,6 @@ const css2js = require('gulp-css2js')
 const concat = require('gulp-concat')
 const autoprefixer = require('gulp-autoprefixer')
 const cleanCss = require('gulp-clean-css')
-const typescript = require('gulp-typescript')
-const tslint = require('gulp-tslint')
 const eslint = require('gulp-eslint')
 const stylelint = require('gulp-stylelint')
 const babel = require('rollup-plugin-babel')
@@ -28,10 +26,9 @@ const banner = `/*!
 * Released under the ${packageJson.license} License.
 */`
 
-const allScriptFiles = ['**/*.js', '!dist/**', '!node_modules/**']
+const allScriptFiles = ['**/*.js', 'sweetalert2.d.ts', '!dist/**', '!node_modules/**']
 const srcScriptFiles = ['src/**/*.js']
 const srcStyleFiles = ['src/**/*.scss']
-const tsFiles = ['sweetalert2.d.ts']
 
 const continueOnError = process.argv.includes('--continue-on-error')
 const skipMinification = process.argv.includes('--skip-minification')
@@ -155,16 +152,7 @@ gulp.task('lint:styles', () => {
     }))
 })
 
-gulp.task('lint:ts', () => {
-  return gulp.src(tsFiles)
-    .pipe(typescript({ lib: ['es6', 'dom'] }))
-    .pipe(tslint({ formatter: 'verbose' }))
-    .pipe(tslint.report({
-      emitError: !continueOnError
-    }))
-})
-
-gulp.task('lint', gulp.parallel('lint:scripts', 'lint:styles', 'lint:ts'))
+gulp.task('lint', gulp.parallel('lint:scripts', 'lint:styles'))
 
 // ---
 
@@ -176,7 +164,6 @@ gulp.task('develop', gulp.series(
     gulp.watch(srcStyleFiles, gulp.parallel('build:styles'))
     gulp.watch(allScriptFiles, gulp.parallel('lint:scripts'))
     gulp.watch(srcStyleFiles, gulp.parallel('lint:styles'))
-    gulp.watch(tsFiles, gulp.parallel('lint:ts'))
   },
   async function sandbox () {
     browserSync.init({

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@babel/preset-env": "^7.3.1",
     "@sweetalert2/execute": "^1.0.0",
     "@sweetalert2/stylelint-config": "^1.1.5",
+    "@typescript-eslint/eslint-plugin": "^1.12.0",
+    "@typescript-eslint/parser": "^1.12.0",
     "babel-loader": "^8.0.4",
     "babel-plugin-array-includes": "^2.0.3",
     "browser-sync": "^2.26.3",
@@ -36,8 +38,6 @@
     "gulp-rename": "^1.2.2",
     "gulp-rollup": "^2.16.2",
     "gulp-stylelint": "^9.0.0",
-    "gulp-tslint": "^8.1.2",
-    "gulp-typescript": "^5.0.0",
     "gulp-uglify": "^3.0.0",
     "jquery": "^3.3.1",
     "karma": "^4.0.0",
@@ -60,8 +60,7 @@
     "sass": "^1.22.1",
     "sinon": "^7.2.3",
     "stylelint": "^10.0.0",
-    "tslint": "^5.12.1",
-    "typescript": "^3.2.4",
+    "typescript": "^3.5.0",
     "webpack": "^4.29.0"
   },
   "files": [

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -1,913 +1,911 @@
 declare module 'sweetalert2' {
+  /**
+   * A namespace inside the default function, containing utility function for controlling the currently-displayed
+   * modal.
+   *
+   * ex.
+   *   import Swal from 'sweetalert2';
+   *
+   *   Swal.fire('Hey user!', 'I don\'t like you.', 'warning');
+   *
+   *   if(Swal.isVisible()) { // instant regret
+   *     Swal.close();
+   *   }
+   */
+  namespace Swal {
     /**
-     * A namespace inside the default function, containing utility function for controlling the currently-displayed
-     * modal.
+     * Function to display a simple SweetAlert2 modal.
      *
      * ex.
      *   import Swal from 'sweetalert2';
-     *
-     *   Swal.fire('Hey user!', 'I don\'t like you.', 'warning');
-     *
-     *   if(Swal.isVisible()) { // instant regret
-     *     Swal.close();
-     *   }
+     *   Swal.fire('The Internet?', 'That thing is still around?', 'question');
      */
-    namespace Swal {
-        /**
-         * Function to display a simple SweetAlert2 modal.
-         *
-         * ex.
-         *   import Swal from 'sweetalert2';
-         *   Swal.fire('The Internet?', 'That thing is still around?', 'question');
-         */
-        function fire(title: string, message?: string, type?: SweetAlertType): Promise<SweetAlertResult>;
+    function fire(title: string, message?: string, type?: SweetAlertType): Promise<SweetAlertResult>;
 
-        /**
-         * Function to display a SweetAlert2 modal, with an object of options, all being optional.
-         * See the SweetAlertOptions interface for the list of accepted fields and values.
-         *
-         * ex.
-         *   import Swal from 'sweetalert2';
-         *   Swal.fire({
-         *     title: 'Auto close alert!',
-         *     text: 'I will close in 2 seconds.',
-         *     timer: 2000
-         *   })
-         */
-        function fire(settings: SweetAlertOptions): Promise<SweetAlertResult>;
+    /**
+     * Function to display a SweetAlert2 modal, with an object of options, all being optional.
+     * See the SweetAlertOptions interface for the list of accepted fields and values.
+     *
+     * ex.
+     *   import Swal from 'sweetalert2';
+     *   Swal.fire({
+     *     title: 'Auto close alert!',
+     *     text: 'I will close in 2 seconds.',
+     *     timer: 2000
+     *   })
+     */
+    function fire(settings: SweetAlertOptions): Promise<SweetAlertResult>;
 
-        /**
-         * Reuse configuration by creating a Swal instance.
-         *
-         * @param options the default options to set for this instance.
-         */
-        function mixin(options?: SweetAlertOptions): typeof Swal;
+    /**
+     * Reuse configuration by creating a Swal instance.
+     *
+     * @param options the default options to set for this instance.
+     */
+    function mixin(options?: SweetAlertOptions): typeof Swal;
 
-        /**
-         * Determines if a modal is shown.
-         * Be aware that the library returns a trueish or falsy value, not a real boolean.
-         */
-        function isVisible(): boolean;
+    /**
+     * Determines if a modal is shown.
+     * Be aware that the library returns a trueish or falsy value, not a real boolean.
+     */
+    function isVisible(): boolean;
 
-        /**
-         * Updates popup options.
-         * See the SweetAlertOptions interface for the list of accepted fields and values.
-         *
-         * ex.
-         *   swal.update({
-         *     type: 'error'
-         *   })
-         */
-        function update(newSettings: SweetAlertOptions): void;
+    /**
+     * Updates popup options.
+     * See the SweetAlertOptions interface for the list of accepted fields and values.
+     *
+     * ex.
+     *   swal.update({
+     *     type: 'error'
+     *   })
+     */
+    function update(newSettings: SweetAlertOptions): void;
 
-        /**
-         * Closes the currently open SweetAlert2 modal programmatically.
-         *
-         * @param onComplete An optional callback to be called when the alert has finished closing.
-         */
-        function close(onComplete?: (modalElement: HTMLElement) => void): void;
+    /**
+     * Closes the currently open SweetAlert2 modal programmatically.
+     *
+     * @param onComplete An optional callback to be called when the alert has finished closing.
+     */
+    function close(onComplete?: (modalElement: HTMLElement) => void): void;
 
-        /**
-         * Gets the modal title.
-         */
-        function getTitle(): HTMLElement;
+    /**
+     * Gets the modal title.
+     */
+    function getTitle(): HTMLElement;
 
-        /**
-         * Gets the modal content.
-         */
-        function getContent(): HTMLElement;
+    /**
+     * Gets the modal content.
+     */
+    function getContent(): HTMLElement;
 
-        /**
-         * Gets the image.
-         */
-        function getImage(): HTMLElement;
+    /**
+     * Gets the image.
+     */
+    function getImage(): HTMLElement;
 
-        /**
-         * Gets the close button.
-         */
-        function getCloseButton(): HTMLElement;
+    /**
+     * Gets the close button.
+     */
+    function getCloseButton(): HTMLElement;
 
-        /**
-         * Gets the current visible icon.
-         */
-        function getIcon(): HTMLElement | null;
+    /**
+     * Gets the current visible icon.
+     */
+    function getIcon(): HTMLElement | null;
 
-        /**
-         * Gets all icons. The current visible icon will have `style="display: flex"`,
-         * all other will be hidden by `style="display: none"`.
-         */
-        function getIcons(): Array<HTMLElement>;
+    /**
+     * Gets all icons. The current visible icon will have `style="display: flex"`,
+     * all other will be hidden by `style="display: none"`.
+     */
+    function getIcons(): HTMLElement[];
 
-        /**
-         * Gets the "Confirm" button.
-         */
-        function getConfirmButton(): HTMLElement;
+    /**
+     * Gets the "Confirm" button.
+     */
+    function getConfirmButton(): HTMLElement;
 
-        /**
-         * Gets the "Cancel" button.
-         */
-        function getCancelButton(): HTMLElement;
+    /**
+     * Gets the "Cancel" button.
+     */
+    function getCancelButton(): HTMLElement;
 
-        /**
-         * Gets actions (buttons) wrapper.
-         */
-        function getActions(): HTMLElement;
+    /**
+     * Gets actions (buttons) wrapper.
+     */
+    function getActions(): HTMLElement;
 
-        /**
-         * Gets the modal footer.
-         */
-        function getFooter(): HTMLElement;
+    /**
+     * Gets the modal footer.
+     */
+    function getFooter(): HTMLElement;
 
-        /**
-         * Gets all focusable elements in the popup.
-         */
-        function getFocusableElements(): Array<HTMLElement>;
+    /**
+     * Gets all focusable elements in the popup.
+     */
+    function getFocusableElements(): HTMLElement[];
 
-        /**
-         * Enables "Confirm" and "Cancel" buttons.
-         */
-        function enableButtons(): void;
+    /**
+     * Enables "Confirm" and "Cancel" buttons.
+     */
+    function enableButtons(): void;
 
-        /**
-         * Disables "Confirm" and "Cancel" buttons.
-         */
-        function disableButtons(): void;
+    /**
+     * Disables "Confirm" and "Cancel" buttons.
+     */
+    function disableButtons(): void;
 
-        /**
-         * @deprecated
-         * Enables the "Confirm"-button only.
-         */
-        function enableConfirmButton(): void;
+    /**
+     * @deprecated
+     * Enables the "Confirm"-button only.
+     */
+    function enableConfirmButton(): void;
 
-        /**
-         * @deprecated
-         * Disables the "Confirm"-button only.
-         */
-        function disableConfirmButton(): void;
+    /**
+     * @deprecated
+     * Disables the "Confirm"-button only.
+     */
+    function disableConfirmButton(): void;
 
-        /**
-         * Disables buttons and show loader. This is useful with AJAX requests.
-         */
-        function showLoading(): void;
+    /**
+     * Disables buttons and show loader. This is useful with AJAX requests.
+     */
+    function showLoading(): void;
 
-        /**
-         * Enables buttons and hide loader.
-         */
-        function hideLoading(): void;
+    /**
+     * Enables buttons and hide loader.
+     */
+    function hideLoading(): void;
 
-        /**
-         * Determines if modal is in the loading state.
-         */
-        function isLoading(): boolean;
+    /**
+     * Determines if modal is in the loading state.
+     */
+    function isLoading(): boolean;
 
-        /**
-         * Clicks the "Confirm"-button programmatically.
-         */
-        function clickConfirm(): void;
+    /**
+     * Clicks the "Confirm"-button programmatically.
+     */
+    function clickConfirm(): void;
 
-        /**
-         * Clicks the "Cancel"-button programmatically.
-         */
-        function clickCancel(): void;
+    /**
+     * Clicks the "Cancel"-button programmatically.
+     */
+    function clickCancel(): void;
 
-        /**
-         * Shows a validation message.
-         *
-         * @param validationMessage The validation message.
-         */
-        function showValidationMessage(validationMessage: string): void;
+    /**
+     * Shows a validation message.
+     *
+     * @param validationMessage The validation message.
+     */
+    function showValidationMessage(validationMessage: string): void;
 
-        /**
-         * Hides validation message.
-         */
-        function resetValidationMessage(): void;
+    /**
+     * Hides validation message.
+     */
+    function resetValidationMessage(): void;
 
-        /**
-         * Gets the input DOM node, this method works with input parameter.
-         */
-        function getInput(): HTMLElement;
+    /**
+     * Gets the input DOM node, this method works with input parameter.
+     */
+    function getInput(): HTMLElement;
 
-        /**
-         * Disables the modal input. A disabled input element is unusable and un-clickable.
-         */
-        function disableInput(): void;
+    /**
+     * Disables the modal input. A disabled input element is unusable and un-clickable.
+     */
+    function disableInput(): void;
 
-        /**
-         * Enables the modal input.
-         */
-        function enableInput(): void;
+    /**
+     * Enables the modal input.
+     */
+    function enableInput(): void;
 
-        /**
-         * Gets the validation message container.
-         */
-        function getValidationMessage(): HTMLElement;
+    /**
+     * Gets the validation message container.
+     */
+    function getValidationMessage(): HTMLElement;
 
-        /**
-         * If `timer` parameter is set, returns number of milliseconds of timer remained.
-         * Otherwise, returns undefined.
-         */
-        function getTimerLeft(): number | undefined;
+    /**
+     * If `timer` parameter is set, returns number of milliseconds of timer remained.
+     * Otherwise, returns undefined.
+     */
+    function getTimerLeft(): number | undefined;
 
-        /**
-         * Stop timer. Returns number of milliseconds of timer remained.
-         * If `timer` parameter isn't set, returns undefined.
-         */
-        function stopTimer(): number | undefined;
+    /**
+     * Stop timer. Returns number of milliseconds of timer remained.
+     * If `timer` parameter isn't set, returns undefined.
+     */
+    function stopTimer(): number | undefined;
 
-        /**
-         * Resume timer. Returns number of milliseconds of timer remained.
-         * If `timer` parameter isn't set, returns undefined.
-         */
-        function resumeTimer(): number | undefined;
+    /**
+     * Resume timer. Returns number of milliseconds of timer remained.
+     * If `timer` parameter isn't set, returns undefined.
+     */
+    function resumeTimer(): number | undefined;
 
-        /**
-         * Toggle timer. Returns number of milliseconds of timer remained.
-         * If `timer` parameter isn't set, returns undefined.
-         */
-        function toggleTimer(): number | undefined;
+    /**
+     * Toggle timer. Returns number of milliseconds of timer remained.
+     * If `timer` parameter isn't set, returns undefined.
+     */
+    function toggleTimer(): number | undefined;
 
-        /**
-         * Check if timer is running. Returns true if timer is running,
-         * and false is timer is paused / stopped.
-         * If `timer` parameter isn't set, returns undefined.
-         */
-        function isTimerRunning(): boolean | undefined;
+    /**
+     * Check if timer is running. Returns true if timer is running,
+     * and false is timer is paused / stopped.
+     * If `timer` parameter isn't set, returns undefined.
+     */
+    function isTimerRunning(): boolean | undefined;
 
-        /**
-         * Increase timer. Returns number of milliseconds of an updated timer.
-         * If `timer` parameter isn't set, returns undefined.
-         *
-         * @param n The number of milliseconds to add to the currect timer
-         */
-        function increaseTimer(n: number): number | undefined;
+    /**
+     * Increase timer. Returns number of milliseconds of an updated timer.
+     * If `timer` parameter isn't set, returns undefined.
+     *
+     * @param n The number of milliseconds to add to the currect timer
+     */
+    function increaseTimer(n: number): number | undefined;
 
-        /**
-         * Provide an array of SweetAlert2 parameters to show multiple modals, one modal after another.
-         *
-         * @param steps The steps' configuration.
-         */
-        function queue(steps: Array<SweetAlertOptions | string>): Promise<any>;
+    /**
+     * Provide an array of SweetAlert2 parameters to show multiple modals, one modal after another.
+     *
+     * @param steps The steps' configuration.
+     */
+    function queue(steps: (SweetAlertOptions | string)[]): Promise<any>;
 
-        /**
-         * Gets the index of current modal in queue. When there's no active queue, null will be returned.
-         */
-        function getQueueStep(): string | null;
+    /**
+     * Gets the index of current modal in queue. When there's no active queue, null will be returned.
+     */
+    function getQueueStep(): string | null;
 
-        /**
-         * Inserts a modal in the queue.
-         *
-         * @param step  The step configuration (same object as in the Swal.fire() call).
-         * @param index The index to insert the step at.
-         *              By default a modal will be added to the end of a queue.
-         */
-        function insertQueueStep(step: SweetAlertOptions, index?: number): number;
+    /**
+     * Inserts a modal in the queue.
+     *
+     * @param step  The step configuration (same object as in the Swal.fire() call).
+     * @param index The index to insert the step at.
+     *              By default a modal will be added to the end of a queue.
+     */
+    function insertQueueStep(step: SweetAlertOptions, index?: number): number;
 
-        /**
-         * Deletes the modal at the specified index in the queue.
-         *
-         * @param index The modal index in the queue.
-         */
-        function deleteQueueStep(index: number): void;
+    /**
+     * Deletes the modal at the specified index in the queue.
+     *
+     * @param index The modal index in the queue.
+     */
+    function deleteQueueStep(index: number): void;
 
-        /**
-         * @deprecated
-         * Gets progress steps.
-         */
-        function getProgressSteps(): string[];
+    /**
+     * @deprecated
+     * Gets progress steps.
+     */
+    function getProgressSteps(): string[];
 
-        /**
-         * @deprecated
-         * Sets progress steps.
-         *
-         * @param steps The modal steps
-         */
-        function setProgressSteps(steps: string[]): void;
+    /**
+     * @deprecated
+     * Sets progress steps.
+     *
+     * @param steps The modal steps
+     */
+    function setProgressSteps(steps: string[]): void;
 
-        /**
-         * Shows progress steps.
-         */
-        function showProgressSteps(): void;
+    /**
+     * Shows progress steps.
+     */
+    function showProgressSteps(): void;
 
-        /**
-         * Hides progress steps.
-         */
-        function hideProgressSteps(): void;
+    /**
+     * Hides progress steps.
+     */
+    function hideProgressSteps(): void;
 
-        /**
-         * Determines if a given parameter name is valid.
-         *
-         * @param paramName The parameter to check
-         */
-        function isValidParameter(paramName: string): boolean;
+    /**
+     * Determines if a given parameter name is valid.
+     *
+     * @param paramName The parameter to check
+     */
+    function isValidParameter(paramName: string): boolean;
 
-        /**
-         * Determines if a given parameter name is valid for Swal.update() method.
-         *
-         * @param paramName The parameter to check
-         */
-        function isUpdatableParameter(paramName: string): boolean;
+    /**
+     * Determines if a given parameter name is valid for Swal.update() method.
+     *
+     * @param paramName The parameter to check
+     */
+    function isUpdatableParameter(paramName: string): boolean;
 
-        /**
-         * Normalizes the arguments you can give to Swal.fire() in an object of type SweetAlertOptions.
-         * ex:
-         *     Swal.argsToParams(['title', 'text']); //=> { title: 'title', text: 'text' }
-         *     Swal.argsToParams({ title: 'title', text: 'text' }); //=> { title: 'title', text: 'text' }
-         *
-         * @param params The array of arguments to normalize.
-         */
-        function argsToParams(params: SweetAlertArrayOptions | [SweetAlertOptions]): SweetAlertOptions;
+    /**
+     * Normalizes the arguments you can give to Swal.fire() in an object of type SweetAlertOptions.
+     * ex:
+     *     Swal.argsToParams(['title', 'text']); //=> { title: 'title', text: 'text' }
+     *     Swal.argsToParams({ title: 'title', text: 'text' }); //=> { title: 'title', text: 'text' }
+     *
+     * @param params The array of arguments to normalize.
+     */
+    function argsToParams(params: SweetAlertArrayOptions | [SweetAlertOptions]): SweetAlertOptions;
 
-        /**
-         * An enum of possible reasons that can explain an alert dismissal.
-         */
-        enum DismissReason {
-            cancel, backdrop, close, esc, timer
-        }
+    /**
+     * An enum of possible reasons that can explain an alert dismissal.
+     */
+    enum DismissReason {
+      cancel, backdrop, close, esc, timer
     }
-
-    export type SweetAlertType = 'success' | 'error' | 'warning' | 'info' | 'question';
-
-    export interface SweetAlertResult {
-        value?: any;
-        dismiss?: Swal.DismissReason;
-    }
-
-    export interface SweetAlertCustomClass {
-        container?: string;
-        popup?: string;
-        header?: string;
-        title?: string;
-        closeButton?: string;
-        icon?: string;
-        image?: string;
-        content?: string;
-        input?: string;
-        actions?: string;
-        confirmButton?: string;
-        cancelButton?: string;
-        footer?: string;
-    }
-
-    type SyncOrAsync<T> = T | Promise<T>;
-
-    type ValueOrThunk<T> = T | (() => T);
-
-    export type SweetAlertArrayOptions = [string] | [string, string] | [string, string, string];
-
-    export interface SweetAlertOptions {
-        /**
-         * The title of the modal, as HTML.
-         * It can either be added to the object under the key "title" or passed as the first parameter of the function.
-         *
-         * @default null
-         */
-        title?: string;
-
-        /**
-         * The title of the modal, as text. Useful to avoid HTML injection.
-         *
-         * @default null
-         */
-        titleText?: string;
-
-        /**
-         * A description for the modal.
-         * It can either be added to the object under the key "text" or passed as the second parameter of the function.
-         *
-         * @default null
-         */
-        text?: string;
-
-        /**
-         * A HTML description for the modal.
-         * If "text" and "html" parameters are provided in the same time, "text" will be used.
-         *
-         * @default null
-         */
-        html?: string | HTMLElement | JQuery;
-
-        /**
-         * The footer of the modal, as HTML.
-         *
-         * @default null
-         */
-        footer?: string | JQuery;
-
-        /**
-         * The type of the modal.
-         * SweetAlert2 comes with 5 built-in types which will show a corresponding icon animation: 'warning', 'error',
-         * 'success', 'info' and 'question'.
-         * It can either be put in the array under the key "type" or passed as the third parameter of the function.
-         *
-         * @default null
-         */
-        type?: SweetAlertType;
-
-        /**
-         * Whether or not SweetAlert2 should show a full screen click-to-dismiss backdrop.
-         * Either a boolean value or a css background value (hex, rgb, rgba, url, etc.)
-         *
-         * @default true
-         */
-        backdrop?: boolean | string;
-
-        /**
-         * Whether or not an alert should be treated as a toast notification.
-         * This option is normally coupled with the `position` parameter and a timer.
-         * Toasts are NEVER autofocused.
-         *
-         * @default false
-         */
-        toast?: boolean;
-
-        /**
-         * The container element for adding modal into (query selector only).
-         *
-         * @default 'body'
-         */
-        target?: string | HTMLElement;
-
-        /**
-         * Input field type, can be text, email, password, number, tel, range, textarea, select, radio, checkbox, file
-         * and url.
-         *
-         * @default null
-         */
-        input?:
-            'text' | 'email' | 'password' | 'number' | 'tel' | 'range' | 'textarea' | 'select' | 'radio' | 'checkbox' |
-            'file' | 'url';
-
-        /**
-         * Modal window width, including paddings (box-sizing: border-box). Can be in px or %.
-         *
-         * @default null
-         */
-        width?: number | string;
-
-        /**
-         * Modal window padding.
-         *
-         * @default null
-         */
-        padding?: number | string;
-
-        /**
-         * Modal window background (CSS background property).
-         *
-         * @default '#fff'
-         */
-        background?: string;
-
-        /**
-         * Modal window position
-         *
-         * @default 'center'
-         */
-        position?:
-            'top' | 'top-start' | 'top-end' | 'top-left' | 'top-right' |
-            'center' | 'center-start' | 'center-end' | 'center-left' | 'center-right' |
-            'bottom' | 'bottom-start' | 'bottom-end' | 'bottom-left' | 'bottom-right';
-
-        /**
-         * Modal window grow direction
-         *
-         * @default false
-         */
-        grow?: 'row' | 'column' | 'fullscreen' | false;
-
-        /**
-         * A custom CSS class for the modal.
-         * If a string value is provided, the classname will be applied to the popup.
-         * If an object is provided, the classnames will be applied to the corresponding fields:
-         *
-         * ex.
-         *   Swal.fire({
-         *     customClass: {
-         *       container: 'container-class',
-         *       popup: 'popup-class',
-         *       header: 'header-class',
-         *       title: 'title-class',
-         *       closeButton: 'close-button-class',
-         *       icon: 'icon-class',
-         *       image: 'image-class',
-         *       content: 'content-class',
-         *       input: 'input-class',
-         *       actions: 'actions-class',
-         *       confirmButton: 'confirm-button-class',
-         *       cancelButton: 'cancel-button-class',
-         *       footer: 'footer-class'
-         *     }
-         *   })
-         *
-         * @default ''
-         */
-        customClass?: string | SweetAlertCustomClass;
-
-        /**
-         * @deprecated
-         * A custom CSS class for the container.
-         *
-         * @default ''
-         */
-        customContainerClass?: string;
-
-        /**
-         * Auto close timer of the modal. Set in ms (milliseconds).
-         *
-         * @default null
-         */
-        timer?: number;
-
-        /**
-         * If set to false, modal CSS animation will be disabled.
-         *
-         * @default true
-         */
-        animation?: ValueOrThunk<boolean>;
-
-        /**
-         * By default, SweetAlert2 sets html's and body's CSS height to auto !important.
-         * If this behavior isn't compatible with your project's layout, set heightAuto to false.
-         *
-         * @default true
-         */
-        heightAuto?: boolean;
-
-        /**
-         * If set to false, the user can't dismiss the modal by clicking outside it.
-         * You can also pass a custom function returning a boolean value, e.g. if you want
-         * to disable outside clicks for the loading state of a modal.
-         *
-         * @default true
-         */
-        allowOutsideClick?: ValueOrThunk<boolean>;
-
-        /**
-         * If set to false, the user can't dismiss the modal by pressing the Escape key.
-         * You can also pass a custom function returning a boolean value, e.g. if you want
-         * to disable the escape key for the loading state of a modal.
-         *
-         * @default true
-         */
-        allowEscapeKey?: ValueOrThunk<boolean>;
-
-        /**
-         * If set to false, the user can't confirm the modal by pressing the Enter or Space keys,
-         * unless they manually focus the confirm button.
-         * You can also pass a custom function returning a boolean value.
-         *
-         * @default true
-         */
-        allowEnterKey?: ValueOrThunk<boolean>;
-
-        /**
-         * If set to false, SweetAlert2 will allow keydown events propagation to the document.
-         *
-         * @default true
-         */
-        stopKeydownPropagation?: boolean;
-
-        /**
-         * Useful for those who are using SweetAlert2 along with Bootstrap modals.
-         * By default keydownListenerCapture is false which means when a user hits Esc,
-         * both SweetAlert2 and Bootstrap modals will be closed.
-         * Set keydownListenerCapture to true to fix that behavior.
-         *
-         * @default false
-         */
-        keydownListenerCapture?: boolean;
-
-        /**
-         * If set to false, a "Confirm"-button will not be shown.
-         * It can be useful when you're using custom HTML description.
-         *
-         * @default true
-         */
-        showConfirmButton?: boolean;
-
-        /**
-         * If set to true, a "Cancel"-button will be shown, which the user can click on to dismiss the modal.
-         *
-         * @default false
-         */
-        showCancelButton?: boolean;
-
-        /**
-         * Use this to change the text on the "Confirm"-button.
-         *
-         * @default 'OK'
-         */
-        confirmButtonText?: string;
-
-        /**
-         * Use this to change the text on the "Cancel"-button.
-         *
-         * @default 'Cancel'
-         */
-        cancelButtonText?: string;
-
-        /**
-         * Use this to change the background color of the "Confirm"-button (must be a HEX value).
-         *
-         * @default '#3085d6'
-         */
-        confirmButtonColor?: string;
-
-        /**
-         * Use this to change the background color of the "Cancel"-button (must be a HEX value).
-         *
-         * @default '#aaa'
-         */
-        cancelButtonColor?: string;
-
-        /**
-         * @deprecated
-         * A custom CSS class for the "Confirm"-button.
-         *
-         * @default ''
-         */
-        confirmButtonClass?: string;
-
-        /**
-         * @deprecated
-         * A custom CSS class for the "Cancel"-button.
-         *
-         * @default ''
-         */
-        cancelButtonClass?: string;
-
-        /**
-         * Use this to change the aria-label for the "Confirm"-button.
-         *
-         * @default ''
-         */
-        confirmButtonAriaLabel?: string;
-
-        /**
-         * Use this to change the aria-label for the "Cancel"-button.
-         *
-         * @default ''
-         */
-        cancelButtonAriaLabel?: string;
-
-        /**
-         * Whether to apply the default SweetAlert2 styling to buttons.
-         * If you want to use your own classes (e.g. Bootstrap classes) set this parameter to false.
-         *
-         * @default true
-         */
-        buttonsStyling?: boolean;
-
-        /**
-         * Set to true if you want to invert default buttons positions.
-         *
-         * @default false
-         */
-        reverseButtons?: boolean;
-
-        /**
-         * Set to false if you want to focus the first element in tab order instead of "Confirm"-button by default.
-         *
-         * @default true
-         */
-        focusConfirm?: boolean;
-
-        /**
-         * Set to true if you want to focus the "Cancel"-button by default.
-         *
-         * @default false
-         */
-        focusCancel?: boolean;
-
-        /**
-         * Set to true to show close button in top right corner of the modal.
-         *
-         * @default false
-         */
-        showCloseButton?: boolean;
-
-        /**
-         * Use this to change the content of the close button.
-         *
-         * @default '&times;'
-         */
-        closeButtonHtml?: string;
-
-        /**
-         * Use this to change the `aria-label` for the close button.
-         *
-         * @default 'Close this dialog'
-         */
-        closeButtonAriaLabel?: string;
-
-        /**
-         * Set to true to disable buttons and show that something is loading. Useful for AJAX requests.
-         *
-         * @default false
-         */
-        showLoaderOnConfirm?: boolean;
-
-        /**
-         * Function to execute before confirm, may be async (Promise-returning) or sync.
-         *
-         * ex.
-         *   Swal.fire({
-         *    title: 'Multiple inputs',
-         *    html:
-         *      '<input id="swal-input1" class="swal2-input">' +
-         *      '<input id="swal-input2" class="swal2-input">',
-         *    focusConfirm: false,
-         *    preConfirm: () => [
-         *      document.querySelector('#swal-input1').value,
-         *      document.querySelector('#swal-input2').value
-         *    ]
-         *  }).then(result => Swal.fire(JSON.stringify(result));
-         *
-         * @default null
-         */
-        preConfirm?: (inputValue: any) => SyncOrAsync<any | void>;
-
-        /**
-         * Add a customized icon for the modal. Should contain a string with the path or URL to the image.
-         *
-         * @default null
-         */
-        imageUrl?: string;
-
-        /**
-         * If imageUrl is set, you can specify imageWidth to describes image width in px.
-         *
-         * @default null
-         */
-        imageWidth?: number;
-
-        /**
-         * If imageUrl is set, you can specify imageHeight to describes image height in px.
-         *
-         * @default null
-         */
-        imageHeight?: number;
-
-        /**
-         * An alternative text for the custom image icon.
-         *
-         * @default ''
-         */
-        imageAlt?: string;
-
-        /**
-         * @deprecated
-         * A custom CSS class for the customized icon.
-         *
-         * @default ''
-         */
-        imageClass?: string;
-
-        /**
-         * Input field placeholder.
-         *
-         * @default ''
-         */
-        inputPlaceholder?: string;
-
-        /**
-         * Input field initial value.
-         *
-         * @default ''
-         */
-        inputValue?: SyncOrAsync<string>;
-
-        /**
-         * If input parameter is set to "select" or "radio", you can provide options.
-         * Object keys will represent options values, object values will represent options text values.
-         */
-        inputOptions?: SyncOrAsync<Map<string, string> | { [inputValue: string]: string }>;
-
-        /**
-         * Automatically remove whitespaces from both ends of a result string.
-         * Set this parameter to false to disable auto-trimming.
-         *
-         * @default true
-         */
-        inputAutoTrim?: boolean;
-
-        /**
-         * HTML input attributes (e.g. min, max, step, accept...), that are added to the input field.
-         *
-         * ex.
-         *   Swal.fire({
-         *     title: 'Select a file',
-         *     input: 'file',
-         *     inputAttributes: {
-         *       accept: 'image/*'
-         *     }
-         *   })
-         *
-         * @default null
-         */
-        inputAttributes?: { [attribute: string]: string; };
-
-        /**
-         * Validator for input field, may be async (Promise-returning) or sync.
-         *
-         * ex.
-         *   Swal.fire({
-         *     title: 'Select color',
-         *     input: 'radio',
-         *     inputValidator: result => !result && 'You need to select something!'
-         *   })
-         *
-         * @default null
-         */
-        inputValidator?: (inputValue: string) => SyncOrAsync<string | null>;
-
-        /**
-         * A custom validation message for default validators (email, url).
-         *
-         * ex.
-         *   Swal.fire({
-         *     input: 'email',
-         *     validationMessage: 'Adresse e-mail invalide'
-         *   })
-         *
-         * @default null
-         */
-        validationMessage?: string;
-
-        /**
-         * @deprecated
-         * A custom CSS class for the input field.
-         *
-         * @default ''
-         */
-        inputClass?: string;
-
-        /**
-         * Progress steps, useful for modal queues, see usage example.
-         *
-         * @default []
-         */
-        progressSteps?: string[];
-
-        /**
-         * Current active progress step.
-         *
-         * @default Swal.getQueueStep()
-         */
-        currentProgressStep?: string;
-
-        /**
-         * Distance between progress steps.
-         *
-         * @default null
-         */
-        progressStepsDistance?: string;
-
-        /**
-         * Function to run when modal built, but not shown yet. Provides modal DOM element as the first argument.
-         *
-         * @default null
-         */
-        onBeforeOpen?: (modalElement: HTMLElement) => void;
-
-        /**
-         * Function to run after modal has been disposed.
-         *
-         * @default null
-         */
-        onAfterClose?: () => void;
-
-        /**
-         * Function to run when modal opens, provides modal DOM element as the first argument.
-         *
-         * @default null
-         */
-        onOpen?: (modalElement: HTMLElement) => void;
-
-        /**
-         * Function to run when modal closes, provides modal DOM element as the first argument.
-         *
-         * @default null
-         */
-        onClose?: (modalElement: HTMLElement) => void;
-
-        /**
-         * Set to false to disable body padding adjustment when scrollbar is present.
-         *
-         * @default true
-         */
-        scrollbarPadding?: boolean;
-    }
-
-    export default Swal;
+  }
+
+  export type SweetAlertType = 'success' | 'error' | 'warning' | 'info' | 'question';
+
+  export interface SweetAlertResult {
+    value?: any;
+    dismiss?: Swal.DismissReason;
+  }
+
+  export interface SweetAlertCustomClass {
+    container?: string;
+    popup?: string;
+    header?: string;
+    title?: string;
+    closeButton?: string;
+    icon?: string;
+    image?: string;
+    content?: string;
+    input?: string;
+    actions?: string;
+    confirmButton?: string;
+    cancelButton?: string;
+    footer?: string;
+  }
+
+  type SyncOrAsync<T> = T | Promise<T>;
+
+  type ValueOrThunk<T> = T | (() => T);
+
+  export type SweetAlertArrayOptions = [string] | [string, string] | [string, string, string];
+
+  export interface SweetAlertOptions {
+    /**
+     * The title of the modal, as HTML.
+     * It can either be added to the object under the key "title" or passed as the first parameter of the function.
+     *
+     * @default null
+     */
+    title?: string;
+
+    /**
+     * The title of the modal, as text. Useful to avoid HTML injection.
+     *
+     * @default null
+     */
+    titleText?: string;
+
+    /**
+     * A description for the modal.
+     * It can either be added to the object under the key "text" or passed as the second parameter of the function.
+     *
+     * @default null
+     */
+    text?: string;
+
+    /**
+     * A HTML description for the modal.
+     * If "text" and "html" parameters are provided in the same time, "text" will be used.
+     *
+     * @default null
+     */
+    html?: string | HTMLElement | JQuery;
+
+    /**
+     * The footer of the modal, as HTML.
+     *
+     * @default null
+     */
+    footer?: string | JQuery;
+
+    /**
+     * The type of the modal.
+     * SweetAlert2 comes with 5 built-in types which will show a corresponding icon animation: 'warning', 'error',
+     * 'success', 'info' and 'question'.
+     * It can either be put in the array under the key "type" or passed as the third parameter of the function.
+     *
+     * @default null
+     */
+    type?: SweetAlertType;
+
+    /**
+     * Whether or not SweetAlert2 should show a full screen click-to-dismiss backdrop.
+     * Either a boolean value or a css background value (hex, rgb, rgba, url, etc.)
+     *
+     * @default true
+     */
+    backdrop?: boolean | string;
+
+    /**
+     * Whether or not an alert should be treated as a toast notification.
+     * This option is normally coupled with the `position` parameter and a timer.
+     * Toasts are NEVER autofocused.
+     *
+     * @default false
+     */
+    toast?: boolean;
+
+    /**
+     * The container element for adding modal into (query selector only).
+     *
+     * @default 'body'
+     */
+    target?: string | HTMLElement;
+
+    /**
+     * Input field type, can be text, email, password, number, tel, range, textarea, select, radio, checkbox, file
+     * and url.
+     *
+     * @default null
+     */
+    input?:
+    'text' | 'email' | 'password' | 'number' | 'tel' | 'range' | 'textarea' | 'select' | 'radio' | 'checkbox' |
+    'file' | 'url';
+
+    /**
+     * Modal window width, including paddings (box-sizing: border-box). Can be in px or %.
+     *
+     * @default null
+     */
+    width?: number | string;
+
+    /**
+     * Modal window padding.
+     *
+     * @default null
+     */
+    padding?: number | string;
+
+    /**
+     * Modal window background (CSS background property).
+     *
+     * @default '#fff'
+     */
+    background?: string;
+
+    /**
+     * Modal window position
+     *
+     * @default 'center'
+     */
+    position?:
+    'top' | 'top-start' | 'top-end' | 'top-left' | 'top-right' |
+    'center' | 'center-start' | 'center-end' | 'center-left' | 'center-right' |
+    'bottom' | 'bottom-start' | 'bottom-end' | 'bottom-left' | 'bottom-right';
+
+    /**
+     * Modal window grow direction
+     *
+     * @default false
+     */
+    grow?: 'row' | 'column' | 'fullscreen' | false;
+
+    /**
+     * A custom CSS class for the modal.
+     * If a string value is provided, the classname will be applied to the popup.
+     * If an object is provided, the classnames will be applied to the corresponding fields:
+     *
+     * ex.
+     *   Swal.fire({
+     *     customClass: {
+     *       container: 'container-class',
+     *       popup: 'popup-class',
+     *       header: 'header-class',
+     *       title: 'title-class',
+     *       closeButton: 'close-button-class',
+     *       icon: 'icon-class',
+     *       image: 'image-class',
+     *       content: 'content-class',
+     *       input: 'input-class',
+     *       actions: 'actions-class',
+     *       confirmButton: 'confirm-button-class',
+     *       cancelButton: 'cancel-button-class',
+     *       footer: 'footer-class'
+     *     }
+     *   })
+     *
+     * @default ''
+     */
+    customClass?: string | SweetAlertCustomClass;
+
+    /**
+     * @deprecated
+     * A custom CSS class for the container.
+     *
+     * @default ''
+     */
+    customContainerClass?: string;
+
+    /**
+     * Auto close timer of the modal. Set in ms (milliseconds).
+     *
+     * @default null
+     */
+    timer?: number;
+
+    /**
+     * If set to false, modal CSS animation will be disabled.
+     *
+     * @default true
+     */
+    animation?: ValueOrThunk<boolean>;
+
+    /**
+     * By default, SweetAlert2 sets html's and body's CSS height to auto !important.
+     * If this behavior isn't compatible with your project's layout, set heightAuto to false.
+     *
+     * @default true
+     */
+    heightAuto?: boolean;
+
+    /**
+     * If set to false, the user can't dismiss the modal by clicking outside it.
+     * You can also pass a custom function returning a boolean value, e.g. if you want
+     * to disable outside clicks for the loading state of a modal.
+     *
+     * @default true
+     */
+    allowOutsideClick?: ValueOrThunk<boolean>;
+
+    /**
+     * If set to false, the user can't dismiss the modal by pressing the Escape key.
+     * You can also pass a custom function returning a boolean value, e.g. if you want
+     * to disable the escape key for the loading state of a modal.
+     *
+     * @default true
+     */
+    allowEscapeKey?: ValueOrThunk<boolean>;
+
+    /**
+     * If set to false, the user can't confirm the modal by pressing the Enter or Space keys,
+     * unless they manually focus the confirm button.
+     * You can also pass a custom function returning a boolean value.
+     *
+     * @default true
+     */
+    allowEnterKey?: ValueOrThunk<boolean>;
+
+    /**
+     * If set to false, SweetAlert2 will allow keydown events propagation to the document.
+     *
+     * @default true
+     */
+    stopKeydownPropagation?: boolean;
+
+    /**
+     * Useful for those who are using SweetAlert2 along with Bootstrap modals.
+     * By default keydownListenerCapture is false which means when a user hits Esc,
+     * both SweetAlert2 and Bootstrap modals will be closed.
+     * Set keydownListenerCapture to true to fix that behavior.
+     *
+     * @default false
+     */
+    keydownListenerCapture?: boolean;
+
+    /**
+     * If set to false, a "Confirm"-button will not be shown.
+     * It can be useful when you're using custom HTML description.
+     *
+     * @default true
+     */
+    showConfirmButton?: boolean;
+
+    /**
+     * If set to true, a "Cancel"-button will be shown, which the user can click on to dismiss the modal.
+     *
+     * @default false
+     */
+    showCancelButton?: boolean;
+
+    /**
+     * Use this to change the text on the "Confirm"-button.
+     *
+     * @default 'OK'
+     */
+    confirmButtonText?: string;
+
+    /**
+     * Use this to change the text on the "Cancel"-button.
+     *
+     * @default 'Cancel'
+     */
+    cancelButtonText?: string;
+
+    /**
+     * Use this to change the background color of the "Confirm"-button (must be a HEX value).
+     *
+     * @default '#3085d6'
+     */
+    confirmButtonColor?: string;
+
+    /**
+     * Use this to change the background color of the "Cancel"-button (must be a HEX value).
+     *
+     * @default '#aaa'
+     */
+    cancelButtonColor?: string;
+
+    /**
+     * @deprecated
+     * A custom CSS class for the "Confirm"-button.
+     *
+     * @default ''
+     */
+    confirmButtonClass?: string;
+
+    /**
+     * @deprecated
+     * A custom CSS class for the "Cancel"-button.
+     *
+     * @default ''
+     */
+    cancelButtonClass?: string;
+
+    /**
+     * Use this to change the aria-label for the "Confirm"-button.
+     *
+     * @default ''
+     */
+    confirmButtonAriaLabel?: string;
+
+    /**
+     * Use this to change the aria-label for the "Cancel"-button.
+     *
+     * @default ''
+     */
+    cancelButtonAriaLabel?: string;
+
+    /**
+     * Whether to apply the default SweetAlert2 styling to buttons.
+     * If you want to use your own classes (e.g. Bootstrap classes) set this parameter to false.
+     *
+     * @default true
+     */
+    buttonsStyling?: boolean;
+
+    /**
+     * Set to true if you want to invert default buttons positions.
+     *
+     * @default false
+     */
+    reverseButtons?: boolean;
+
+    /**
+     * Set to false if you want to focus the first element in tab order instead of "Confirm"-button by default.
+     *
+     * @default true
+     */
+    focusConfirm?: boolean;
+
+    /**
+     * Set to true if you want to focus the "Cancel"-button by default.
+     *
+     * @default false
+     */
+    focusCancel?: boolean;
+
+    /**
+     * Set to true to show close button in top right corner of the modal.
+     *
+     * @default false
+     */
+    showCloseButton?: boolean;
+
+    /**
+     * Use this to change the content of the close button.
+     *
+     * @default '&times;'
+     */
+    closeButtonHtml?: string;
+
+    /**
+     * Use this to change the `aria-label` for the close button.
+     *
+     * @default 'Close this dialog'
+     */
+    closeButtonAriaLabel?: string;
+
+    /**
+     * Set to true to disable buttons and show that something is loading. Useful for AJAX requests.
+     *
+     * @default false
+     */
+    showLoaderOnConfirm?: boolean;
+
+    /**
+     * Function to execute before confirm, may be async (Promise-returning) or sync.
+     *
+     * ex.
+     *   Swal.fire({
+     *    title: 'Multiple inputs',
+     *    html:
+     *      '<input id="swal-input1" class="swal2-input">' +
+     *      '<input id="swal-input2" class="swal2-input">',
+     *    focusConfirm: false,
+     *    preConfirm: () => [
+     *      document.querySelector('#swal-input1').value,
+     *      document.querySelector('#swal-input2').value
+     *    ]
+     *  }).then(result => Swal.fire(JSON.stringify(result));
+     *
+     * @default null
+     */
+    preConfirm?: (inputValue: any) => SyncOrAsync<any | void>;
+
+    /**
+     * Add a customized icon for the modal. Should contain a string with the path or URL to the image.
+     *
+     * @default null
+     */
+    imageUrl?: string;
+
+    /**
+     * If imageUrl is set, you can specify imageWidth to describes image width in px.
+     *
+     * @default null
+     */
+    imageWidth?: number;
+
+    /**
+     * If imageUrl is set, you can specify imageHeight to describes image height in px.
+     *
+     * @default null
+     */
+    imageHeight?: number;
+
+    /**
+     * An alternative text for the custom image icon.
+     *
+     * @default ''
+     */
+    imageAlt?: string;
+
+    /**
+     * @deprecated
+     * A custom CSS class for the customized icon.
+     *
+     * @default ''
+     */
+    imageClass?: string;
+
+    /**
+     * Input field placeholder.
+     *
+     * @default ''
+     */
+    inputPlaceholder?: string;
+
+    /**
+     * Input field initial value.
+     *
+     * @default ''
+     */
+    inputValue?: SyncOrAsync<string>;
+
+    /**
+     * If input parameter is set to "select" or "radio", you can provide options.
+     * Object keys will represent options values, object values will represent options text values.
+     */
+    inputOptions?: SyncOrAsync<Map<string, string> | { [inputValue: string]: string }>;
+
+    /**
+     * Automatically remove whitespaces from both ends of a result string.
+     * Set this parameter to false to disable auto-trimming.
+     *
+     * @default true
+     */
+    inputAutoTrim?: boolean;
+
+    /**
+     * HTML input attributes (e.g. min, max, step, accept...), that are added to the input field.
+     *
+     * ex.
+     *   Swal.fire({
+     *     title: 'Select a file',
+     *     input: 'file',
+     *     inputAttributes: {
+     *       accept: 'image/*'
+     *     }
+     *   })
+     *
+     * @default null
+     */
+    inputAttributes?: { [attribute: string]: string };
+
+    /**
+     * Validator for input field, may be async (Promise-returning) or sync.
+     *
+     * ex.
+     *   Swal.fire({
+     *     title: 'Select color',
+     *     input: 'radio',
+     *     inputValidator: result => !result && 'You need to select something!'
+     *   })
+     *
+     * @default null
+     */
+    inputValidator?: (inputValue: string) => SyncOrAsync<string | null>;
+
+    /**
+     * A custom validation message for default validators (email, url).
+     *
+     * ex.
+     *   Swal.fire({
+     *     input: 'email',
+     *     validationMessage: 'Adresse e-mail invalide'
+     *   })
+     *
+     * @default null
+     */
+    validationMessage?: string;
+
+    /**
+     * @deprecated
+     * A custom CSS class for the input field.
+     *
+     * @default ''
+     */
+    inputClass?: string;
+
+    /**
+     * Progress steps, useful for modal queues, see usage example.
+     *
+     * @default []
+     */
+    progressSteps?: string[];
+
+    /**
+     * Current active progress step.
+     *
+     * @default Swal.getQueueStep()
+     */
+    currentProgressStep?: string;
+
+    /**
+     * Distance between progress steps.
+     *
+     * @default null
+     */
+    progressStepsDistance?: string;
+
+    /**
+     * Function to run when modal built, but not shown yet. Provides modal DOM element as the first argument.
+     *
+     * @default null
+     */
+    onBeforeOpen?: (modalElement: HTMLElement) => void;
+
+    /**
+     * Function to run after modal has been disposed.
+     *
+     * @default null
+     */
+    onAfterClose?: () => void;
+
+    /**
+     * Function to run when modal opens, provides modal DOM element as the first argument.
+     *
+     * @default null
+     */
+    onOpen?: (modalElement: HTMLElement) => void;
+
+    /**
+     * Function to run when modal closes, provides modal DOM element as the first argument.
+     *
+     * @default null
+     */
+    onClose?: (modalElement: HTMLElement) => void;
+
+    /**
+     * Set to false to disable body padding adjustment when scrollbar is present.
+     *
+     * @default true
+     */
+    scrollbarPadding?: boolean;
+  }
+
+  export default Swal
 }
 
 /**
  * These interfaces aren't provided by SweetAlert2, but its definitions use them.
  * They will be merged with 'true' definitions.
  */
-
-// tslint:disable:no-empty-interface
 
 interface JQuery {
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,9 +1,0 @@
-{
-    "defaultSeverity": "error",
-    "extends": ["tslint:recommended"],
-    "rules": {
-      "quotemark": false,
-      "interface-name": false,
-      "trailing-comma": false
-    }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,6 +704,11 @@
     stylelint-csstree-validator "^1.5.1"
     stylelint-scss "^3.9.0"
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -713,11 +718,6 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
-
-"@types/fancy-log@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/fancy-log/-/fancy-log-1.3.0.tgz#a61ab476e5e628cd07a846330df53b85e05c8ce0"
-  integrity sha512-mQjDxyOM1Cpocd+vm1kZBP7smwKZ4TNokFeds9LV7OZibmPJFEzY3+xZMrKfUdNT71lv8GoCPD6upKwHxubClw==
 
 "@types/glob@^7.1.1":
   version "7.1.1"
@@ -759,6 +759,43 @@
     "@types/node" "*"
     "@types/unist" "*"
     "@types/vfile-message" "*"
+
+"@typescript-eslint/eslint-plugin@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.12.0.tgz#96b4e08b5f998a198b8414508b1a289f9e8c549a"
+  integrity sha512-J/ZTZF+pLNqjXBGNfq5fahsoJ4vJOkYbitWPavA05IrZ7BXUaf4XWlhUB/ic1lpOGTRpLWF+PLAePjiHp6dz8g==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "1.12.0"
+    eslint-utils "^1.3.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^2.0.1"
+    tsutils "^3.7.0"
+
+"@typescript-eslint/experimental-utils@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.12.0.tgz#98417ee2e0c6fe8d1e50d934a6535d9c0f4277b6"
+  integrity sha512-s0soOTMJloytr9GbPteMLNiO2HvJ+qgQkRNplABXiVw6vq7uQRvidkby64Gqt/nA7pys74HksHwRULaB/QRVyw==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "1.12.0"
+    eslint-scope "^4.0.0"
+
+"@typescript-eslint/parser@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.12.0.tgz#9965895ec4745578185965d63f21510f93a3f35a"
+  integrity sha512-0uzbaa9ZLCA5yMWJywnJJ7YVENKGWVUhJDV5UrMoldC5HoI54W5kkdPhTfmtFKpPFp93MIwmJj0/61ztvmz5Dw==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "1.12.0"
+    "@typescript-eslint/typescript-estree" "1.12.0"
+    eslint-visitor-keys "^1.0.0"
+
+"@typescript-eslint/typescript-estree@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.12.0.tgz#d8dd0a7cffb5e3c0c3e98714042d83e316dfc9a9"
+  integrity sha512-nwN6yy//XcVhFs0ZyU+teJHB8tbCm7AIA8mu6E2r5hu6MajwYBY3Uwop7+rPZWUN/IUOHpL8C+iUPMDVYUU3og==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -993,7 +1030,7 @@ ansi-colors@^1.0.1:
   dependencies:
     ansi-wrap "^0.1.0"
 
-ansi-colors@^3.0.0, ansi-colors@^3.0.5:
+ansi-colors@^3.0.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
@@ -1652,11 +1689,6 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
-
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -1794,7 +1826,7 @@ chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2028,7 +2060,7 @@ commander@2.12.2:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
   integrity sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==
 
-commander@^2.12.1, commander@^2.2.0, commander@^2.20.0, commander@~2.20.0:
+commander@^2.2.0, commander@^2.20.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -2468,7 +2500,7 @@ di@^0.0.1:
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
 
-diff@^3.2.0, diff@^3.5.0:
+diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -3123,7 +3155,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-fancy-log@1.3.3, fancy-log@^1.3.2, fancy-log@^1.3.3:
+fancy-log@^1.3.2, fancy-log@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.3.tgz#dbc19154f558690150a23953a0adbd035be45fc7"
   integrity sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==
@@ -3754,30 +3786,6 @@ gulp-stylelint@^9.0.0:
     source-map "^0.7.3"
     strip-ansi "^5.2.0"
     through2 "^3.0.1"
-
-gulp-tslint@^8.1.2:
-  version "8.1.4"
-  resolved "https://registry.yarnpkg.com/gulp-tslint/-/gulp-tslint-8.1.4.tgz#8519ee25ff97aa749e691d4af0fdaccce5f01f7a"
-  integrity sha512-wBoZIEMJRz9urHwolsvQpngA9l931p6g/Liwz1b/KrsVP6jEBFZv/o0NS1TFCQZi/l8mXxz8+v3twhf4HOXxPQ==
-  dependencies:
-    "@types/fancy-log" "1.3.0"
-    ansi-colors "^1.0.1"
-    fancy-log "1.3.3"
-    map-stream "~0.0.7"
-    plugin-error "1.0.1"
-    through "~2.3.8"
-
-gulp-typescript@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/gulp-typescript/-/gulp-typescript-5.0.1.tgz#96c6565a6eb31e08c2aae1c857b1a079e6226d94"
-  integrity sha512-YuMMlylyJtUSHG1/wuSVTrZp60k1dMEFKYOvDf7OvbAJWrDtxxD4oZon4ancdWwzjj30ztiidhe4VXJniF0pIQ==
-  dependencies:
-    ansi-colors "^3.0.5"
-    plugin-error "^1.0.1"
-    source-map "^0.7.3"
-    through2 "^3.0.0"
-    vinyl "^2.1.0"
-    vinyl-fs "^3.0.3"
 
 gulp-uglify@^3.0.0:
   version "3.0.2"
@@ -4915,6 +4923,11 @@ lodash.isfinite@^3.3.2:
   resolved "https://registry.yarnpkg.com/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz#fb89b65a9a80281833f0b7478b3a5104f898ebb3"
   integrity sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=
 
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
 lodash@^4.16.6, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.6.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
@@ -5031,11 +5044,6 @@ map-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
   integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
-
-map-stream@~0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.0.7.tgz#8a1f07896d82b10926bd3744a2420009f88974a8"
-  integrity sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -6924,6 +6932,11 @@ semver-greatest-satisfied-range@^1.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
+
 semver@^6.1.0, semver@^6.1.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.2.0.tgz#4d813d9590aaf8a9192693d6c85b9344de5901db"
@@ -7735,7 +7748,7 @@ through2-filter@^3.0.0:
     through2 "~2.0.0"
     xtend "~4.0.0"
 
-through2@*, through2@3.0.1, through2@^3.0.0, through2@^3.0.1:
+through2@*, through2@3.0.1, through2@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.1.tgz#39276e713c3302edf9e388dd9c812dd3b825bd5a"
   integrity sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
@@ -7750,7 +7763,7 @@ through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@^2.3.6, through@~2.3.8:
+through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -7878,34 +7891,15 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.4.tgz#3b52b1f13924f460c3fbfd0df69b587dbcbc762e"
   integrity sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslint@^5.12.1:
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.18.0.tgz#f61a6ddcf372344ac5e41708095bbf043a147ac6"
-  integrity sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    builtin-modules "^1.1.1"
-    chalk "^2.3.0"
-    commander "^2.12.1"
-    diff "^3.2.0"
-    glob "^7.1.1"
-    js-yaml "^3.13.1"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tslib "^1.8.0"
-    tsutils "^2.29.0"
-
-tsutils@^2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
-  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+tsutils@^3.7.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.14.0.tgz#bf8d5a7bae5369331fa0f2b0a5a10bd7f7396c77"
+  integrity sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==
   dependencies:
     tslib "^1.8.1"
 
@@ -7944,7 +7938,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.2.4:
+typescript@^3.5.0:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
@@ -8239,7 +8233,7 @@ vfile@^3.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
-vinyl-fs@^3.0.0, vinyl-fs@^3.0.3:
+vinyl-fs@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-3.0.3.tgz#c85849405f67428feabbbd5c5dbdd64f47d31bc7"
   integrity sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==


### PR DESCRIPTION
TSLint has [recently been deprecated](https://typescript-weekly.us14.list-manage.com/track/click?u=809daf9442ece0a92a3d65f99&id=f58ad9e6cf&e=10d6eada39) in favor of ESLint.

`@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` still depend on ESLint 5, but despite those warnings everithyng works fine. The project is actively developed, I believe they'll add ESLint 6 support soon. 

![image](https://user-images.githubusercontent.com/6059356/61589443-71021100-abb2-11e9-85f5-1cecf5b99417.png)
