### PR TITLE
swap enable/disable deprecation warnings

### DIFF
--- a/src/instanceMethods/enable-disable-elements.js
+++ b/src/instanceMethods/enable-disable-elements.js
@@ -33,13 +33,13 @@ export function disableButtons () {
 
 // @deprecated
 export function enableConfirmButton () {
-  warnAboutDepreation('Swal.disableConfirmButton()', `Swal.getConfirmButton().removeAttribute('disabled')`)
+  warnAboutDepreation('Swal.enableConfirmButton()', `Swal.getConfirmButton().removeAttribute('disabled')`)
   setButtonsDisabled(this, ['confirmButton'], false)
 }
 
 // @deprecated
 export function disableConfirmButton () {
-  warnAboutDepreation('Swal.enableConfirmButton()', `Swal.getConfirmButton().setAttribute('disabled', '')`)
+  warnAboutDepreation('Swal.disableConfirmButton()', `Swal.getConfirmButton().setAttribute('disabled', '')`)
   setButtonsDisabled(this, ['confirmButton'], true)
 }
 


### PR DESCRIPTION
These warnings were mentioning the opposite method call.

> SweetAlert2: "Swal.enableConfirmButton()" is deprecated and will be removed in the next major release. Please use "Swal.getConfirmButton().setAttribute('disabled', '')" instead.