### PR TITLE
Add onRender lifecycle hook (closes #1728)

### DIFF
--- a/src/utils/dom/renderers/render.js
+++ b/src/utils/dom/renderers/render.js
@@ -1,4 +1,4 @@
-import { getPopup } from '../getters';
+import { getPopup } from '../getters.js'
 import { renderActions } from './renderActions.js'
 import { renderContainer } from './renderContainer.js'
 import { renderContent } from './renderContent.js'

--- a/src/utils/dom/renderers/render.js
+++ b/src/utils/dom/renderers/render.js
@@ -1,3 +1,4 @@
+import { getPopup } from '../getters';
 import { renderActions } from './renderActions.js'
 import { renderContainer } from './renderContainer.js'
 import { renderContent } from './renderContent.js'
@@ -13,4 +14,8 @@ export const render = (instance, params) => {
   renderContent(instance, params)
   renderActions(instance, params)
   renderFooter(instance, params)
+
+  if (typeof params.onRender === 'function') {
+    params.onRender(getPopup())
+  }
 }

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -62,9 +62,10 @@ const defaultParams = {
   currentProgressStep: null,
   progressStepsDistance: null,
   onBeforeOpen: null,
-  onAfterClose: null,
   onOpen: null,
+  onRender: null,
   onClose: null,
+  onAfterClose: null,
   scrollbarPadding: true
 }
 

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -877,13 +877,6 @@ declare module 'sweetalert2' {
     onBeforeOpen?: (modalElement: HTMLElement) => void;
 
     /**
-     * Function to run after modal has been disposed.
-     *
-     * @default null
-     */
-    onAfterClose?: () => void;
-
-    /**
      * Function to run when modal opens, provides modal DOM element as the first argument.
      *
      * @default null
@@ -891,11 +884,27 @@ declare module 'sweetalert2' {
     onOpen?: (modalElement: HTMLElement) => void;
 
     /**
+     * Function to run after modal DOM has been updated.
+     * Typically, this will happen after Swal.fire() or Swal.update().
+     * If you want to perform changes in the modal's DOM, that survive Swal.update(), onRender is a good place for that.
+     *
+     * @default null
+     */
+    onRender?: (modalElement: HTMLElement) => void;
+
+    /**
      * Function to run when modal closes, provides modal DOM element as the first argument.
      *
      * @default null
      */
     onClose?: (modalElement: HTMLElement) => void;
+
+    /**
+     * Function to run after modal has been disposed.
+     *
+     * @default null
+     */
+    onAfterClose?: () => void;
 
     /**
      * Set to false to disable body padding adjustment when scrollbar is present.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -252,7 +252,7 @@ declare module 'sweetalert2' {
      *
      * @param steps The steps' configuration.
      */
-    function queue(steps: (SweetAlertOptions | string)[]): Promise<any>;
+    function queue(steps: Array<SweetAlertOptions | string>): Promise<any>;
 
     /**
      * Gets the index of current modal in queue. When there's no active queue, null will be returned.
@@ -731,7 +731,7 @@ declare module 'sweetalert2' {
      *
      * @default null
      */
-    preConfirm?: (inputValue: any) => SyncOrAsync<any | void>;
+    preConfirm?(inputValue: any): SyncOrAsync<any | void>;
 
     /**
      * Add a customized icon for the modal. Should contain a string with the path or URL to the image.
@@ -825,7 +825,7 @@ declare module 'sweetalert2' {
      *
      * @default null
      */
-    inputValidator?: (inputValue: string) => SyncOrAsync<string | null>;
+    inputValidator?(inputValue: string): SyncOrAsync<string | null>;
 
     /**
      * A custom validation message for default validators (email, url).
@@ -874,14 +874,14 @@ declare module 'sweetalert2' {
      *
      * @default null
      */
-    onBeforeOpen?: (modalElement: HTMLElement) => void;
+    onBeforeOpen?(modalElement: HTMLElement): void;
 
     /**
      * Function to run when modal opens, provides modal DOM element as the first argument.
      *
      * @default null
      */
-    onOpen?: (modalElement: HTMLElement) => void;
+    onOpen?(modalElement: HTMLElement): void;
 
     /**
      * Function to run after modal DOM has been updated.
@@ -890,21 +890,21 @@ declare module 'sweetalert2' {
      *
      * @default null
      */
-    onRender?: (modalElement: HTMLElement) => void;
+    onRender?(modalElement: HTMLElement): void;
 
     /**
      * Function to run when modal closes, provides modal DOM element as the first argument.
      *
      * @default null
      */
-    onClose?: (modalElement: HTMLElement) => void;
+    onClose?(modalElement: HTMLElement): void;
 
     /**
      * Function to run after modal has been disposed.
      *
      * @default null
      */
-    onAfterClose?: () => void;
+    onAfterClose?(): void;
 
     /**
      * Set to false to disable body padding adjustment when scrollbar is present.

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -531,6 +531,28 @@ QUnit.test('onBeforeOpen', (assert) => {
   })
 })
 
+QUnit.test('onRender', (assert) => {
+  const onRender = sinon.fake()
+
+  // create a modal with an onRender callback
+  // the onRender hook should be called once here
+  Swal.fire({
+    title: 'onRender test',
+    onRender
+  })
+
+  assert.ok(onRender.calledOnce)
+
+  // update the modal, causing a new render
+  // the onRender hook should be called once again
+  Swal.update({})
+
+  assert.ok(onRender.calledTwice)
+
+  // the modal element must always be passed to the onRender hook
+  assert.ok(onRender.alwaysCalledWithExactly($('.swal2-modal')))
+})
+
 QUnit.test('onAfterClose', (assert) => {
   const done = assert.async()
   let onCloseFinished = false


### PR DESCRIPTION
Closes #1728.

For the tests, I only added one that, I think, tests the expected behaviour of onRender and no more:

- We don't actually care at which moment it triggers compared to other hooks (unlike onBeforeOpen/onOpen or onClose/onAfterClose) ;
- The test is synchronous, as onRender should be.

But let me know if I miss something!