### PR TITLE
Update README: Razor.SweetAlert2 Community Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Related community projects
 
 - [avil13/vue-sweetalert2](https://github.com/avil13/vue-sweetalert2) - Vue.js wrapper
 - [realrashid/sweet-alert](https://github.com/realrashid/sweet-alert) - Laravel 5 Package
+- [Basaingeal/Razor.SweetAlert2](https://github.com/Basaingeal/Razor.SweetAlert2) - Blazor Wrapper
 
 
 Collaborators


### PR DESCRIPTION
Closes https://github.com/sweetalert2/sweetalert2/issues/1749

Adds a link to https://github.com/sweetalert2/sweetalert2#related-community-projects for [Razor.SweetAlert2](https://github.com/Basaingeal/Razor.SweetAlert2), a Razor Class Library bringing sweetalert2 functionality to Microsoft's new Blazor framework.