### PR TITLE
set SweetAlertArrayOptions as a type of array

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -20,7 +20,7 @@ declare module 'sweetalert2' {
      *   import Swal from 'sweetalert2';
      *   Swal.fire('The Internet?', 'That thing is still around?', 'question');
      */
-    function fire(...options: SweetAlertArrayOptions): Promise<SweetAlertResult>;
+    function fire(...options: SweetAlertArrayOptions[]): Promise<SweetAlertResult>;
 
     /**
      * Function to display a SweetAlert2 modal, with an object of options, all being optional.


### PR DESCRIPTION
ERROR in node_modules/sweetalert2/sweetalert2.d.ts(23,19): error TS2370: A rest parameter must be of an array type.