### PR TITLE
Css/change zoom default

### DIFF
--- a/src/variables.scss
+++ b/src/variables.scss
@@ -24,7 +24,7 @@ $swal2-backdrop-transition: background-color .1s !default;
 // ICONS
 $swal2-icon-size: 5em !default;
 $swal2-icon-margin: 1.25em auto 1.875em !default;
-$swal2-icon-zoom: normal !default;
+$swal2-icon-zoom: null !default;
 $swal2-success: #a5dc86 !default;
 $swal2-success-border: rgba($swal2-success, .3) !default;
 $swal2-error: #f27474 !default;
@@ -80,7 +80,7 @@ $swal2-validation-message-font-size: 1em !default;
 $swal2-validation-message-font-weight: 300 !default;
 $swal2-validation-message-icon-background: $swal2-error !default;
 $swal2-validation-message-icon-color: $swal2-white !default;
-$swal2-validation-message-icon-zoom: normal !default;
+$swal2-validation-message-icon-zoom: null !default;;
 
 // PROGRESS STEPS
 $swal2-progress-steps-background: inherit !default;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -80,7 +80,7 @@ $swal2-validation-message-font-size: 1em !default;
 $swal2-validation-message-font-weight: 300 !default;
 $swal2-validation-message-icon-background: $swal2-error !default;
 $swal2-validation-message-icon-color: $swal2-white !default;
-$swal2-validation-message-icon-zoom: null !default;;
+$swal2-validation-message-icon-zoom: null !default;
 
 // PROGRESS STEPS
 $swal2-progress-steps-background: inherit !default;


### PR DESCRIPTION
This is related to #1782 

CSS `zoom` property is a non standard one (see disclaimer at the top of [this page](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom)). To avoid using non-standard properties but still make them available as CSS variable, we could change the default value of the related SCSS variable to `null`. Using this keyword the property doesn't get compiled to CSS unless it gets overridden. I think it's a win-win situation, but I'd really want you opinion on this @limonte 