### PR TITLE
Simplify Swal.fire(title, message, icon) back to (string, string, SweetAlertIcon)

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -20,7 +20,7 @@ declare module 'sweetalert2' {
      *   import Swal from 'sweetalert2';
      *   Swal.fire('The Internet?', 'That thing is still around?', 'question');
      */
-    function fire(title?: string | HTMLElement | JQuery, message?: string | HTMLElement | JQuery, icon?: SweetAlertIcon): Promise<SweetAlertResult>;
+    function fire(title?: string, message?: string, icon?: SweetAlertIcon): Promise<SweetAlertResult>;
 
     /**
      * Function to display a SweetAlert2 modal, with an object of options, all being optional.


### PR DESCRIPTION
Fixes #1822 

Reopens https://github.com/sweetalert2/sweetalert2-react-content/issues/102