### PR TITLE
Make icon classes op popup different from classes on icons

### DIFF
--- a/src/utils/classes.js
+++ b/src/utils/classes.js
@@ -70,6 +70,11 @@ export const swalClasses = prefix([
   'rtl',
   'timer-progress-bar',
   'scrollbar-measure',
+  'icon-success',
+  'icon-warning',
+  'icon-info',
+  'icon-question',
+  'icon-error',
 ])
 
 export const iconTypes = prefix([

--- a/src/utils/dom/renderers/renderPopup.js
+++ b/src/utils/dom/renderers/renderPopup.js
@@ -1,4 +1,4 @@
-import { swalClasses, iconTypes } from '../../classes.js'
+import { swalClasses } from '../../classes.js'
 import * as dom from '../../dom/index.js'
 
 export const renderPopup = (instance, params) => {
@@ -37,7 +37,7 @@ const addClasses = (popup, params) => {
 
   // Icon class (#1842)
   if (params.icon) {
-    dom.addClass(popup, iconTypes[params.icon])
+    dom.addClass(popup, swalClasses[`icon-${params.icon}`])
   }
 
   // Add showClass when updating Swal.update({})

--- a/test/qunit/methods/getIcon.js
+++ b/test/qunit/methods/getIcon.js
@@ -2,5 +2,5 @@ import { $, Swal } from '../helpers.js'
 
 QUnit.test('getIcon() method', (assert) => {
   Swal.fire({ icon: 'success' })
-  assert.equal(Swal.getIcon(), $('.swal2-icon.swal2-success'))
+  assert.equal(Swal.getIcon(), $('.swal2-success'))
 })

--- a/test/qunit/methods/update.js
+++ b/test/qunit/methods/update.js
@@ -32,7 +32,7 @@ QUnit.test('update() method', (assert) => {
   assert.equal(Swal.getContent().textContent, 'New content')
 
   assert.ok(isVisible(Swal.getIcon()))
-  assert.equal(Swal.getIcon(), $('.swal2-icon.swal2-success'))
+  assert.equal(Swal.getIcon(), $('.swal2-success'))
 
   assert.ok(isVisible(Swal.getImage()))
   assert.ok(Swal.getImage().src.indexOf('/assets/swal2-logo.png') > 0)

--- a/test/qunit/params/icon.js
+++ b/test/qunit/params/icon.js
@@ -1,9 +1,9 @@
 const { Swal, SwalWithoutAnimation } = require('../helpers')
-const { iconTypes } = require('../../../src/utils/classes')
+const { iconTypes, swalClasses } = require('../../../src/utils/classes')
 
 QUnit.test('The popup should have the icon class', (assert) => {
   for (const icon in iconTypes) {
     SwalWithoutAnimation.fire({ icon })
-    assert.ok(Swal.getPopup().classList.contains(iconTypes[icon]))
+    assert.ok(Swal.getPopup().classList.contains(swalClasses[`icon-${icon}`]))
   }
 })


### PR DESCRIPTION
This is the fix for my previous PR #1842 

I realized that some people might've been using `.swal2-success`, `.swal2-error` etc. classes for styling and to avoid issues for those people, let's make popup classnames different from icon classnames.