### PR TITLE
Handle objects better

### DIFF
--- a/cypress/integration/params/html.spec.js
+++ b/cypress/integration/params/html.spec.js
@@ -13,4 +13,14 @@ describe('html', () => {
     })
     expect(Swal.getHtmlContainer().innerHTML).to.equal('<form><div><label></label><input></div></form>')
   })
+
+  it('Error as html', () => {
+    const error = new Error()
+    error.message = 'something is broken'
+
+    Swal.fire({
+      html: error
+    })
+    expect(Swal.getHtmlContainer().innerHTML).to.equal('Error: something is broken')
+  })
 })

--- a/src/utils/dom/parseHtmlToContainer.js
+++ b/src/utils/dom/parseHtmlToContainer.js
@@ -5,18 +5,22 @@ export const parseHtmlToContainer = (param, target) => {
 
   // Object
   } else if (typeof param === 'object') {
-    // JQuery element(s)
-    if (param.jquery) {
-      handleJqueryElem(target, param)
-
-    // For other objects use their string representation
-    } else {
-      target.innerHTML = param.toString()
-    }
+    handleObject(param, target)
 
   // Plain string
   } else if (param) {
     target.innerHTML = param
+  }
+}
+
+const handleObject = (param, target) => {
+  // JQuery element(s)
+  if (param.jquery) {
+    handleJqueryElem(target, param)
+
+  // For other objects use their string representation
+  } else {
+    target.innerHTML = param.toString()
   }
 }
 

--- a/src/utils/dom/parseHtmlToContainer.js
+++ b/src/utils/dom/parseHtmlToContainer.js
@@ -3,9 +3,16 @@ export const parseHtmlToContainer = (param, target) => {
   if (param instanceof HTMLElement) {
     target.appendChild(param)
 
-  // JQuery element(s)
+  // Object
   } else if (typeof param === 'object') {
-    handleJqueryElem(target, param)
+    // JQuery element(s)
+    if (param.jquery) {
+      handleJqueryElem(target, param)
+
+    // For other objects use their string representation
+    } else {
+      target.innerHTML = param.toString()
+    }
 
   // Plain string
   } else if (param) {

--- a/test/qunit/params/html.js
+++ b/test/qunit/params/html.js
@@ -12,3 +12,13 @@ QUnit.test('HTMLElement as html', (assert) => {
   })
   assert.equal(Swal.getHtmlContainer().innerHTML, '<form><div><label></label><input></div></form>')
 })
+
+QUnit.test('Error as html', (assert) => {
+  const error = new Error()
+  error.message = 'something is broken'
+
+  Swal.fire({
+    html: error
+  })
+  assert.equal(Swal.getHtmlContainer().innerHTML, 'Error: something is broken')
+})


### PR DESCRIPTION
Fixes #1870 

Previously we were assuming that passed objects are jQuery elements :man_facepalming: Of course that's wrong.

This PR checks if an object has the `.jquery` property, if so we're assuming jQuery element, otherwise the `.toString()` method will be used