### PR TITLE
fix(types): Adding getHeader() types.

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -77,6 +77,11 @@ declare module 'sweetalert2' {
      * Gets the modal title.
      */
     function getTitle(): HTMLElement;
+      
+    /**
+     * Gets the modal header.
+     */
+    function getHeader(): HTMLElement;
 
     /**
      * Gets progress steps.


### PR DESCRIPTION
Doc's have the `getHeader` method, but no associated typescript types. https://sweetalert2.github.io/#methods