### PR TITLE
Disable popup animation in more convinient way

### DIFF
--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -53,8 +53,8 @@ const prepareParams = (userParams) => {
   // @deprecated
   if (userParams.animation === false) {
     params.showClass = {
-      popup: '',
-      backdrop: 'swal2-backdrop-show swal2-noanimation'
+      popup: 'swal2-noanimation',
+      backdrop: 'swal2-noanimation'
     }
     params.hideClass = {}
   }

--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -17,7 +17,8 @@
   // sweetalert2/issues/905
   -webkit-overflow-scrolling: touch;
 
-  &.swal2-backdrop-show {
+  &.swal2-backdrop-show,
+  &.swal2-noanimation {
     background: $swal2-backdrop;
   }
 
@@ -345,9 +346,7 @@
 
 .swal2-close {
   position: $swal2-close-button-position;
-  z-index: 2;
-
-  /* 1617 */
+  z-index: 2; // sweetalert2/issues/1617
   top: $swal2-close-button-gap;
   right: $swal2-close-button-gap;
   align-items: $swal2-close-button-align-items;


### PR DESCRIPTION
Disable popup animation in more convinient way by using the `.swal2-noanimation` class.

So, the replacement for deprecated `animation: false` would be

```js
Swal.fire({
  showClass: {
    popup: 'swal2-noanimation',
    backdrop: 'swal2-noanimation'
  },
  hideClass: {
    popup: '',
    backdrop: ''
  }
})
```