### PR TITLE
Take <head> into account when parsing html with DOMParser

### DIFF
--- a/cypress/integration/tests.spec.js
+++ b/cypress/integration/tests.spec.js
@@ -130,11 +130,12 @@ describe('Miscellaneous tests', function () {
   it('content/title is set (html)', () => {
     Swal.fire({
       title: '<strong>Strong</strong>, <em>Emphasis</em>',
-      html: '<p>Paragraph</p><img /><button></button>'
+      html: '<style>p { font-size: 10px; }</style><p>Paragraph</p><img /><button style="width:10px"></button>'
     })
 
     expect(Swal.getTitle().querySelectorAll('strong, em').length).to.equal(2)
-    expect(Swal.getContent().querySelectorAll('p, img, button').length).to.equal(3)
+    expect(Swal.getContent().querySelectorAll('style, p, img, button').length).to.equal(4)
+    expect(Swal.getContent().querySelector('button').style.width).to.equal('10px')
   })
 
   it('content/title is set (text)', () => {

--- a/src/utils/dom/domUtils.js
+++ b/src/utils/dom/domUtils.js
@@ -12,6 +12,9 @@ export const setInnerHtml = (elem, html) => { // #1926
   if (html) {
     const parser = new DOMParser()
     const parsed = parser.parseFromString(html, `text/html`)
+    toArray(parsed.querySelector('head').childNodes).forEach((child) => {
+      elem.appendChild(child)
+    })
     toArray(parsed.querySelector('body').childNodes).forEach((child) => {
       elem.appendChild(child)
     })

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -220,11 +220,12 @@ QUnit.test('getters', (assert) => {
 QUnit.test('content/title is set (html)', (assert) => {
   Swal.fire({
     title: '<strong>Strong</strong>, <em>Emphasis</em>',
-    html: '<p>Paragraph</p><img /><button></button>'
+    html: '<style>p { font-size: 10px; }</style><p>Paragraph</p><img /><button style="width:10px"></button>'
   })
 
   assert.equal(Swal.getTitle().querySelectorAll('strong, em').length, 2)
-  assert.equal(Swal.getContent().querySelectorAll('p, img, button').length, 3)
+  assert.equal(Swal.getContent().querySelectorAll('style, p, img, button').length, 4)
+  assert.equal(Swal.getContent().querySelector('button').style.width, '10px')
 })
 
 QUnit.test('content/title is set (text)', (assert) => {


### PR DESCRIPTION
Fixes #1933 