### PR TITLE
Do not set style="display: flex" on image

### DIFF
--- a/src/utils/dom/renderers/renderImage.js
+++ b/src/utils/dom/renderers/renderImage.js
@@ -8,7 +8,7 @@ export const renderImage = (instance, params) => {
     return dom.hide(image)
   }
 
-  dom.show(image)
+  dom.show(image, '')
 
   // Src, alt
   image.setAttribute('src', params.imageUrl)


### PR DESCRIPTION
Adresses https://stackoverflow.com/q/61897435

> `<img class="swal2-image hidden md:flex" src="..." style="display: flex;">`
>
> Due to the `hidden` and `md:flex` classes, I expect the image to be hidden in small resolution and become visible for md breakpoint, but the inline `style="display: flex;"` disables my hidden classes