### PR TITLE
Add bottom padding to container for iOS Safari

### DIFF
--- a/src/utils/iosFix.js
+++ b/src/utils/iosFix.js
@@ -16,7 +16,7 @@ export const iOSfix = () => {
 }
 
 const addBottomPaddingForTallPopups = () => {
-  const safari = !navigator.userAgent.match(/CriOS/i)
+  const safari = !navigator.userAgent.match(/(CriOS|FxiOS|EdgiOS|YaBrowser|UCBrowser)/i)
   if (safari) {
     const bottomPanelHeight = 44
     if (dom.getPopup().scrollHeight > window.innerHeight - bottomPanelHeight) {

--- a/src/utils/iosFix.js
+++ b/src/utils/iosFix.js
@@ -11,6 +11,17 @@ export const iOSfix = () => {
     document.body.style.top = `${offset * -1}px`
     dom.addClass(document.body, swalClasses.iosfix)
     lockBodyScroll()
+    addBottomPaddingForTallPopups() // #1948
+  }
+}
+
+const addBottomPaddingForTallPopups = () => {
+  const safari = !navigator.userAgent.match(/CriOS/i)
+  if (safari) {
+    const bottomPanelHeight = 44
+    if (dom.getPopup().scrollHeight > window.innerHeight - bottomPanelHeight) {
+      dom.getContainer().style.paddingBottom = `${bottomPanelHeight}px`
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1948

Bottom padding is only added in case of tall popups.

Live demo for testing in real devices: https://deploy-preview-1993--sweetalert2.netlify.app/