### PR TITLE
refactor(types): minor changes

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -337,6 +337,16 @@ declare module 'sweetalert2' {
     const version: string
   }
 
+  type Awaited<T> = T extends Promise<infer U> ? U : T;
+
+  type SyncOrAsync<T> = T | Promise<T>;
+
+  type ValueOrThunk<T> = T | (() => T);
+
+  export type SweetAlertArrayOptions = [string?, string?, SweetAlertIcon?];
+
+  export type SweetAlertGrow = 'row' | 'column' | 'fullscreen' | false;
+
   export type SweetAlertIcon = 'success' | 'error' | 'warning' | 'info' | 'question';
 
   export type SweetAlertInput =
@@ -348,7 +358,36 @@ declare module 'sweetalert2' {
     'center' | 'center-start' | 'center-end' | 'center-left' | 'center-right' |
     'bottom' | 'bottom-start' | 'bottom-end' | 'bottom-left' | 'bottom-right';
 
-  export type SweetAlertGrow = 'row' | 'column' | 'fullscreen' | false;
+  export type SweetAlertUpdatableParameters =
+    | 'allowEscapeKey'
+    | 'allowOutsideClick'
+    | 'buttonsStyling'
+    | 'cancelButtonAriaLabel'
+    | 'cancelButtonColor'
+    | 'cancelButtonText'
+    | 'confirmButtonAriaLabel'
+    | 'confirmButtonColor'
+    | 'confirmButtonText'
+    | 'currentProgressStep'
+    | 'customClass'
+    | 'footer'
+    | 'hideClass'
+    | 'html'
+    | 'icon'
+    | 'imageAlt'
+    | 'imageHeight'
+    | 'imageUrl'
+    | 'imageWidth'
+    | 'onAfterClose'
+    | 'onClose'
+    | 'onDestroy'
+    | 'progressSteps'
+    | 'reverseButtons'
+    | 'showCancelButton'
+    | 'showConfirmButton'
+    | 'text'
+    | 'title'
+    | 'titleText';
 
   export interface SweetAlertResult<T = any> {
     value?: T;
@@ -384,45 +423,6 @@ declare module 'sweetalert2' {
     cancelButton?: string;
     footer?: string;
   }
-
-  type Awaited<T> = T extends Promise<infer U> ? U : T;
-
-  type SyncOrAsync<T> = T | Promise<T>;
-
-  type ValueOrThunk<T> = T | (() => T);
-
-  export type SweetAlertUpdatableParameters =
-    | 'allowEscapeKey'
-    | 'allowOutsideClick'
-    | 'buttonsStyling'
-    | 'cancelButtonAriaLabel'
-    | 'cancelButtonColor'
-    | 'cancelButtonText'
-    | 'confirmButtonAriaLabel'
-    | 'confirmButtonColor'
-    | 'confirmButtonText'
-    | 'currentProgressStep'
-    | 'customClass'
-    | 'footer'
-    | 'hideClass'
-    | 'html'
-    | 'icon'
-    | 'imageAlt'
-    | 'imageHeight'
-    | 'imageUrl'
-    | 'imageWidth'
-    | 'onAfterClose'
-    | 'onClose'
-    | 'onDestroy'
-    | 'progressSteps'
-    | 'reverseButtons'
-    | 'showCancelButton'
-    | 'showConfirmButton'
-    | 'text'
-    | 'title'
-    | 'titleText';
-
-  export type SweetAlertArrayOptions = [string?, string?, SweetAlertIcon?];
 
   export interface SweetAlertOptions<PreConfirmResult = any, PreConfirmCallbackValue = any> {
     /**

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -131,7 +131,7 @@ declare module 'sweetalert2' {
      * Gets all icons. The current visible icon will have `style="display: flex"`,
      * all other will be hidden by `style="display: none"`.
      */
-    function getIcons(): HTMLElement[];
+    function getIcons(): readonly HTMLElement[];
 
     /**
      * Gets the "Confirm" button.
@@ -161,7 +161,7 @@ declare module 'sweetalert2' {
     /**
      * Gets all focusable elements in the popup.
      */
-    function getFocusableElements(): HTMLElement[];
+    function getFocusableElements(): readonly HTMLElement[];
 
     /**
      * Enables "Confirm" and "Cancel" buttons.
@@ -322,7 +322,7 @@ declare module 'sweetalert2' {
      *
      * @param params The array of arguments to normalize.
      */
-    function argsToParams<T>(params: SweetAlertArrayOptions | [SweetAlertOptions<T>]): SweetAlertOptions<T>;
+    function argsToParams<T>(params: SweetAlertArrayOptions | readonly [SweetAlertOptions<T>]): SweetAlertOptions<T>;
 
     /**
      * An enum of possible reasons that can explain an alert dismissal.
@@ -349,7 +349,7 @@ declare module 'sweetalert2' {
 
   type ValueOrThunk<T> = T | (() => T);
 
-  export type SweetAlertArrayOptions = [string?, string?, SweetAlertIcon?];
+  export type SweetAlertArrayOptions = readonly [string?, string?, SweetAlertIcon?];
 
   export type SweetAlertGrow = 'row' | 'column' | 'fullscreen' | false;
 
@@ -917,7 +917,7 @@ declare module 'sweetalert2' {
      *
      * @default []
      */
-    progressSteps?: string[];
+    progressSteps?: readonly string[];
 
     /**
      * Current active progress step.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -337,6 +337,12 @@ declare module 'sweetalert2' {
     const version: string
   }
 
+  interface SweetAlertHideShowClass {
+    backdrop?: string;
+    icon?: string;
+    popup?: string;
+  }
+
   type Awaited<T> = T extends Promise<infer U> ? U : T;
 
   type SyncOrAsync<T> = T | Promise<T>;
@@ -346,6 +352,10 @@ declare module 'sweetalert2' {
   export type SweetAlertArrayOptions = [string?, string?, SweetAlertIcon?];
 
   export type SweetAlertGrow = 'row' | 'column' | 'fullscreen' | false;
+
+  export type SweetAlertHideClass = SweetAlertHideShowClass;
+
+  export type SweetAlertShowClass = Readonly<SweetAlertHideShowClass>;
 
   export type SweetAlertIcon = 'success' | 'error' | 'warning' | 'info' | 'question';
 
@@ -388,25 +398,6 @@ declare module 'sweetalert2' {
     | 'text'
     | 'title'
     | 'titleText';
-
-  export interface SweetAlertResult<T = any> {
-    value?: T;
-    dismiss?: Swal.DismissReason;
-    isConfirmed: boolean;
-    isDismissed: boolean;
-  }
-
-  export interface SweetAlertShowClass {
-    popup?: string;
-    backdrop?: string;
-    icon?: string;
-  }
-
-  export interface SweetAlertHideClass {
-    popup?: string;
-    backdrop?: string;
-    icon?: string;
-  }
 
   export interface SweetAlertCustomClass {
     container?: string;

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -415,6 +415,13 @@ declare module 'sweetalert2' {
     footer?: string;
   }
 
+  export interface SweetAlertResult<T = any> {
+    readonly dismiss?: Swal.DismissReason;
+    readonly isConfirmed: boolean;
+    readonly isDismissed: boolean;
+    readonly value?: T;
+  }
+
   export interface SweetAlertOptions<PreConfirmResult = any, PreConfirmCallbackValue = any> {
     /**
      * The title of the popup, as HTML.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -302,14 +302,14 @@ declare module 'sweetalert2' {
      *
      * @param paramName The parameter to check
      */
-    function isValidParameter(paramName: keyof SweetAlertOptions): boolean;
+    function isValidParameter(paramName: string): paramName is keyof SweetAlertOptions;
 
     /**
      * Determines if a given parameter name is valid for `Swal.update()` method.
      *
      * @param paramName The parameter to check
      */
-    function isUpdatableParameter(paramName: SweetAlertUpdatableParameters): boolean;
+    function isUpdatableParameter(paramName: string): paramName is SweetAlertUpdatableParameters;
 
     /**
      * Normalizes the arguments you can give to Swal.fire() in an object of type SweetAlertOptions.


### PR DESCRIPTION
Some minor changes to the types. I've separate it in multiple commits to make the reviewer's life easier :)

1st. commit: I've grouped types and interfaces separately in hope of improving readability. As a contributor, it caused some confusion for me in this when I read at the initial times, so I'm proposing this change.
2nd. commit: I saw that `hideClass` and `showClass` are exactly the same, so I created a separated interface to reuse it in them.
3rd. commit: Make `SweetAlertResult` members readonly to represent that they're immutable.
4th. commit: Some leftovers from #1983 (support readonly user inputs).
~5th. commit: Make **non** updatable parameters readonly. Refer to https://github.com/sweetalert2/sweetalert2/pull/1996#issuecomment-640766402 and previous discussions.~
6th. commit: Change the signature of `isUpdatableParam` and `isValidParameter` to be user-defined type guards, so we can properly check any string as ngx-sweetalert2 currently does in `SwalComponent`.

Note that:

1. The fact that there are multiple commits doesn't imply that you have to merge them all. I'm also fine with squash.
2. if any of the changes are not desirable I can remove it without problems.

cc @limonte @toverux