### PR TITLE
Consistent hook names

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,3 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.d.ts]
-indent_size = 4

--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -104,7 +104,7 @@ describe('should trap focus in modals', () => {
       showDenyButton: true,
       showCancelButton: true,
       showCloseButton: true,
-      onOpen: () => {
+      didOpen: () => {
         expect(document.activeElement).to.equal(Swal.getInput())
         triggerKeydownEvent(document.activeElement, 'Tab')
         expect(document.activeElement).to.equal(Swal.getConfirmButton())
@@ -127,7 +127,7 @@ describe('should trap focus in modals', () => {
       showDenyButton: true,
       showCancelButton: true,
       showCloseButton: true,
-      onOpen: () => {
+      didOpen: () => {
         expect(document.activeElement).to.equal(Swal.getInput())
         triggerKeydownEvent(document.activeElement, 'Tab', { shiftKey: true })
         expect(document.activeElement).to.equal(Swal.getCloseButton())
@@ -148,7 +148,7 @@ describe('should trap focus in modals', () => {
     Swal.fire({
       showDenyButton: true,
       showCancelButton: true,
-      onOpen: () => {
+      didOpen: () => {
         triggerKeydownEvent(document.activeElement, 'ArrowRight')
         expect(document.activeElement).to.equal(Swal.getDenyButton())
         triggerKeydownEvent(document.activeElement, 'ArrowRight')
@@ -180,7 +180,7 @@ describe('Focus', () => {
     SwalWithoutAnimation.fire({
       text: 'Modal with an input',
       input: 'text',
-      onOpen: () => {
+      didOpen: () => {
         expect(document.activeElement).to.equal(document.querySelector('.swal2-input'))
         done()
       }

--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -73,7 +73,7 @@ describe('Accessibility:', () => {
     document.body.appendChild(divAriaHiddenTrue)
     SwalWithoutAnimation.fire({
       toast: true,
-      onAfterClose: () => {
+      didClose: () => {
         expect(divAriaHiddenTrue.getAttribute('aria-hidden')).to.equal('true')
         done()
       }

--- a/cypress/integration/api.spec.js
+++ b/cypress/integration/api.spec.js
@@ -14,7 +14,7 @@ describe('API', () => {
     assertConsistent('before first swal')
     Swal.fire({
       title: 'test',
-      onOpen: () => {
+      didOpen: () => {
         assertConsistent('after opening first swal')
         Swal.clickConfirm()
       }
@@ -49,7 +49,7 @@ describe('API', () => {
         return super._main({
           input: 'text',
           inputValue: 'inputValue',
-          onOpen: () => MySwal.clickConfirm()
+          didOpen: () => MySwal.clickConfirm()
         }).then(result => {
           expect(result).to.be.eql({
             value: 'inputValue',

--- a/cypress/integration/methods/close.spec.js
+++ b/cypress/integration/methods/close.spec.js
@@ -4,7 +4,7 @@ describe('close()', () => {
   it('should add .swal2-hide to popup', (done) => {
     Swal.fire({
       title: 'Swal.close() test',
-      onClose: () => {
+      willClose: () => {
         expect(Swal.getPopup().classList.contains('swal2-hide')).to.be.true
         done()
       }
@@ -24,9 +24,9 @@ describe('close()', () => {
     Swal.close()
   })
 
-  it('should trigger onClose', (done) => {
+  it('should trigger willClose', (done) => {
     Swal.fire({
-      onClose: () => {
+      willClose: () => {
         expect(Swal.isVisible()).to.be.true
         done()
       }
@@ -34,9 +34,9 @@ describe('close()', () => {
     Swal.close()
   })
 
-  it('should trigger onAfterClose', (done) => {
+  it('should trigger didClose', (done) => {
     SwalWithoutAnimation.fire({
-      onAfterClose: () => {
+      didClose: () => {
         expect(Swal.isVisible()).to.be.false
         done()
       }
@@ -44,9 +44,9 @@ describe('close()', () => {
     Swal.close()
   })
 
-  it('should not fail when calling Swal.fire() inside onAfterClose', (done) => {
+  it('should not fail when calling Swal.fire() inside didClose', (done) => {
     SwalWithoutAnimation.fire({
-      onAfterClose: () => {
+      didClose: () => {
         expect(Swal.isVisible()).to.be.false
         SwalWithoutAnimation.fire({
           input: 'text',
@@ -61,9 +61,9 @@ describe('close()', () => {
     Swal.close()
   })
 
-  it('should not fail inside onAfterClose', (done) => {
+  it('should not fail inside didClose', (done) => {
     Swal.fire({
-      onAfterClose: () => {
+      didClose: () => {
         Swal.close()
         expect(Swal.isVisible()).to.be.false
         done()

--- a/cypress/integration/methods/close.spec.js
+++ b/cypress/integration/methods/close.spec.js
@@ -50,7 +50,7 @@ describe('close()', () => {
         expect(Swal.isVisible()).to.be.false
         SwalWithoutAnimation.fire({
           input: 'text',
-          onOpen: () => {
+          didOpen: () => {
             expect(Swal.getInput()).to.not.be.null
             done()
           }

--- a/cypress/integration/methods/getInput.spec.js
+++ b/cypress/integration/methods/getInput.spec.js
@@ -4,7 +4,7 @@ describe('getInput()', () => {
   it('Swal.getInput() should return null when a popup is disposed', (done) => {
     SwalWithoutAnimation.fire({
       input: 'text',
-      onAfterClose: () => {
+      didClose: () => {
         setTimeout(() => {
           expect(Swal.getInput()).to.be.null
           done()

--- a/cypress/integration/methods/input.spec.js
+++ b/cypress/integration/methods/input.spec.js
@@ -136,7 +136,7 @@ describe('Input', () => {
     Swal.fire({
       input: 'select',
       inputOptions: Promise.resolve({ one: 1, two: 2 }),
-      onOpen: () => {
+      didOpen: () => {
         setTimeout(() => {
           Swal.getInput().value = 'one'
           expect(Swal.getInput().value).to.equal('one')
@@ -152,7 +152,7 @@ describe('Input', () => {
       inputOptions: {
         toPromise: () => Promise.resolve({ three: 3, four: 4 })
       },
-      onOpen: () => {
+      didOpen: () => {
         setTimeout(() => {
           Swal.getInput().value = 'three'
           expect(Swal.getInput().value).to.equal('three')

--- a/cypress/integration/methods/showLoading.spec.js
+++ b/cypress/integration/methods/showLoading.spec.js
@@ -41,7 +41,7 @@ describe('showLoading() and hideLoading()', () => {
     Swal.fire({
       showConfirmButton: false,
       loaderHtml: '<i>hi</i>',
-      onOpen: () => {
+      didOpen: () => {
         expect(isHidden(Swal.getActions())).to.be.true
         Swal.showLoading()
         expect(isVisible(Swal.getActions())).to.be.true

--- a/cypress/integration/methods/timer.spec.js
+++ b/cypress/integration/methods/timer.spec.js
@@ -165,11 +165,11 @@ describe('timerProgressBar', () => {
     }, 20)
   })
 
-  it('should stop the animation of timer progress bar when timer is stopped in onOpen', (done) => {
+  it('should stop the animation of timer progress bar when timer is stopped in didOpen', (done) => {
     SwalWithoutAnimation.fire({
       timer: 100,
       timerProgressBar: true,
-      onOpen: Swal.stopTimer
+      didOpen: Swal.stopTimer
     })
     setTimeout(() => {
       expect(Swal.getTimerProgressBar().style.transition).to.equal('')

--- a/cypress/integration/methods/update.spec.js
+++ b/cypress/integration/methods/update.spec.js
@@ -161,7 +161,7 @@ describe('update()', () => {
   it('should not affect showClass', (done) => {
     Swal.fire({
       icon: 'success',
-      onOpen: () => {
+      didOpen: () => {
         Swal.update({})
         expect(Swal.getContainer().classList.contains('swal2-backdrop-show')).to.be.true
         expect(Swal.getPopup().classList.contains('swal2-show')).to.be.true

--- a/cypress/integration/params/inputValue.spec.js
+++ b/cypress/integration/params/inputValue.spec.js
@@ -12,7 +12,7 @@ describe('inputValue', () => {
       inputValue: {
         toPromise: () => Promise.resolve('test')
       },
-      onOpen: () => {
+      didOpen: () => {
         setTimeout(() => {
           expect(Swal.getInput().value).to.equal('test')
           done()
@@ -34,7 +34,7 @@ describe('inputValue', () => {
       SwalWithoutAnimation.fire({
         input,
         inputValue,
-        onOpen: () => {
+        didOpen: () => {
           setTimeout(() => {
             expect(Swal.getInput().value).to.equal(input === 'number' ? parseFloat(value).toString() : value)
             if (inputTypes.length) {
@@ -57,7 +57,7 @@ describe('inputValue', () => {
       inputValue: new Promise((resolve, reject) => {
         reject(new Error('input promise rejected'))
       }),
-      onOpen: () => {
+      didOpen: () => {
         setTimeout(() => {
           expect(spy.calledWith('SweetAlert2: Error in inputValue promise: Error: input promise rejected')).to.be.true
           done()

--- a/cypress/integration/params/progressSteps.spec.js
+++ b/cypress/integration/params/progressSteps.spec.js
@@ -4,7 +4,7 @@ describe('progressSteps', () => {
   it('first .swal2-progress-step is active by default', (done) => {
     SwalWithoutAnimation.queue([{
       progressSteps: ['1', '2', '3'],
-      onOpen: () => {
+      didOpen: () => {
         expect(Swal.getProgressSteps().querySelector('.swal2-progress-step').classList.contains('swal2-active-progress-step')).to.be.true
         done()
       }

--- a/cypress/integration/params/showClass.spec.js
+++ b/cypress/integration/params/showClass.spec.js
@@ -10,7 +10,7 @@ describe('showClass', () => {
       hideClass: {
         popup: 'animated fadeOutUp faster'
       },
-      onAfterClose: () => {
+      didClose: () => {
         expect(Swal.isVisible()).to.be.false
         done()
       }

--- a/cypress/integration/params/stopKeydownPropagation.spec.js
+++ b/cypress/integration/params/stopKeydownPropagation.spec.js
@@ -9,7 +9,7 @@ describe('progressSteps', () => {
 
     SwalWithoutAnimation.fire({
       title: 'Esc me and I will propagate keydown',
-      onOpen: () => triggerKeydownEvent(SwalWithoutAnimation.getPopup(), 'Escape'),
+      didOpen: () => triggerKeydownEvent(SwalWithoutAnimation.getPopup(), 'Escape'),
       stopKeydownPropagation: false
     })
   })

--- a/cypress/integration/scrollbar.spec.js
+++ b/cypress/integration/scrollbar.spec.js
@@ -27,7 +27,7 @@ describe('Vertical scrollbar', () => {
 
     SwalWithoutAnimation.fire({
       title: 'The body has visible scrollbar, I will hide it and adjust padding-right on body',
-      onAfterClose: () => {
+      didClose: () => {
         expect(bodyStyles.paddingRight).to.equal('30px')
         document.body.removeChild(talltDiv)
         done()
@@ -49,7 +49,7 @@ describe('Vertical scrollbar', () => {
     SwalWithoutAnimation.fire({
       title: 'Padding right adjustment disabled',
       scrollbarPadding: false,
-      onAfterClose: () => {
+      didClose: () => {
         document.body.removeChild(talltDiv)
       }
     })

--- a/cypress/integration/scrollbar.spec.js
+++ b/cypress/integration/scrollbar.spec.js
@@ -7,7 +7,7 @@ describe('Vertical scrollbar', () => {
       imageUrl: 'https://placeholder.pics/svg/300x1500',
       imageHeight: 1500,
       imageAlt: 'A tall image',
-      onOpen: () => {
+      didOpen: () => {
         expect(Swal.getContainer().scrollTop).to.equal(0)
         expect(Swal.getContainer().style.overflowY).to.equal('auto')
         Swal.close()
@@ -71,7 +71,7 @@ describe('Vertical scrollbar', () => {
       Swal.fire({
         text: 'Body padding-right should be restored',
         toast: true,
-        onOpen: () => {
+        didOpen: () => {
           expect(bodyStyles.paddingRight).to.equal('30px')
           document.body.removeChild(talltDiv)
           done()

--- a/cypress/integration/tests.spec.js
+++ b/cypress/integration/tests.spec.js
@@ -214,35 +214,35 @@ describe('Miscellaneous tests', function () {
     })
   })
 
-  it('onOpen', (done) => {
-    // create a modal with an onOpen callback
+  it('didOpen', (done) => {
+    // create a modal with an didOpen callback
     Swal.fire({
-      title: 'onOpen test',
-      onOpen: (modal) => {
+      title: 'didOpen test',
+      didOpen: (modal) => {
         expect(Swal.getPopup()).to.equal(modal)
         done()
       }
     })
   })
 
-  it('onBeforeOpen', (done) => {
-    // create a modal with an onBeforeOpen callback
+  it('willOpen', (done) => {
+    // create a modal with an willOpen callback
     Swal.fire({
-      title: 'onBeforeOpen test',
-      onBeforeOpen: (modal) => {
+      title: 'willOpen test',
+      willOpen: (modal) => {
         expect(Swal.isVisible()).to.be.false
         expect(Swal.getPopup()).to.equal(modal)
       }
     })
 
-    // check that onBeforeOpen calls properly
-    const dynamicTitle = 'Set onBeforeOpen title'
+    // check that willOpen calls properly
+    const dynamicTitle = 'Set willOpen title'
     Swal.fire({
-      title: 'onBeforeOpen test',
-      onBeforeOpen: () => {
+      title: 'willOpen test',
+      willOpen: () => {
         Swal.getTitle().innerHTML = dynamicTitle
       },
-      onOpen: () => {
+      didOpen: () => {
         expect(Swal.getTitle().innerHTML).to.equal(dynamicTitle)
         done()
       }
@@ -351,7 +351,7 @@ describe('Miscellaneous tests', function () {
 
     SwalWithoutAnimation.fire({
       title: 'Esc me',
-      onOpen: () => triggerKeydownEvent(Swal.getPopup(), 'Escape')
+      didOpen: () => triggerKeydownEvent(Swal.getPopup(), 'Escape')
     }).then((result) => {
       expect(result).to.eql({
         dismiss: Swal.DismissReason.esc,
@@ -372,7 +372,7 @@ describe('Miscellaneous tests', function () {
         functionWasCalled = true
         return false
       },
-      onOpen: () => {
+      didOpen: () => {
         expect(functionWasCalled).to.equal(false)
 
         triggerKeydownEvent(Swal.getPopup(), 'Escape')
@@ -540,7 +540,7 @@ describe('Miscellaneous tests', function () {
   it('Custom content', (done) => {
     Swal.fire({
       showCancelButton: true,
-      onOpen: () => {
+      didOpen: () => {
         Swal.getContent().textContent = 'Custom content'
         Swal.clickConfirm()
       },
@@ -553,7 +553,7 @@ describe('Miscellaneous tests', function () {
 
   it('preConfirm returns 0', (done) => {
     SwalWithoutAnimation.fire({
-      onOpen: () => Swal.clickConfirm(),
+      didOpen: () => Swal.clickConfirm(),
       preConfirm: () => 0,
     }).then(result => {
       expect(result.value).to.equal(0)
@@ -563,7 +563,7 @@ describe('Miscellaneous tests', function () {
 
   it('preConfirm returns object containing toPromise', (done) => {
     SwalWithoutAnimation.fire({
-      onOpen: () => Swal.clickConfirm(),
+      didOpen: () => Swal.clickConfirm(),
       preConfirm: () => ({
         toPromise: () => Promise.resolve(0)
       })

--- a/cypress/integration/tests.spec.js
+++ b/cypress/integration/tests.spec.js
@@ -271,17 +271,17 @@ describe('Miscellaneous tests', function () {
     expect(didRender.alwaysCalledWithExactly(Swal.getPopup())).to.be.true
   })
 
-  it('onAfterClose', (done) => {
-    let onCloseFinished = false
+  it('didClose', (done) => {
+    let willCloseFinished = false
 
-    // create a modal with an onAfterClose callback
+    // create a modal with an didClose callback
     Swal.fire({
-      title: 'onAfterClose test',
-      onClose: () => {
-        onCloseFinished = true
+      title: 'didClose test',
+      willClose: () => {
+        willCloseFinished = true
       },
-      onAfterClose: () => {
-        expect(onCloseFinished).to.be.true
+      didClose: () => {
+        expect(willCloseFinished).to.be.true
         expect(Swal.getContainer()).to.be.null
         done()
       }
@@ -308,11 +308,11 @@ describe('Miscellaneous tests', function () {
     Swal.getConfirmButton().click()
   })
 
-  it('onClose', (done) => {
-    // create a modal with an onClose callback
+  it('willClose', (done) => {
+    // create a modal with an willClose callback
     Swal.fire({
-      title: 'onClose test',
-      onClose: (_modal) => {
+      title: 'willClose test',
+      willClose: (_modal) => {
         expect(modal).to.equal(_modal)
         expect(Swal.getContainer()).to.equal($('.swal2-container'))
         done()
@@ -323,12 +323,12 @@ describe('Miscellaneous tests', function () {
     Swal.getCloseButton().click()
   })
 
-  it('Swal.fire() in onClose', (done) => {
+  it('Swal.fire() in willClose', (done) => {
     Swal.fire({
-      title: 'onClose test',
-      onClose: () => {
+      title: 'willClose test',
+      willClose: () => {
         Swal.fire({
-          text: 'OnClose',
+          text: 'WillClose',
           input: 'text',
           customClass: {
             input: 'on-close-swal'
@@ -627,15 +627,15 @@ describe('Outside click', () => {
   })
 
   it('double backdrop click', (done) => {
-    const onAfterClose = cy.spy()
+    const didClose = cy.spy()
     Swal.fire({
-      title: 'onAfterClose should be triggered once',
-      onAfterClose
+      title: 'didClose should be triggered once',
+      didClose
     })
     Swal.getContainer().click()
     Swal.getContainer().click()
     setTimeout(() => {
-      expect(onAfterClose.calledOnce).to.be.true
+      expect(didClose.calledOnce).to.be.true
       done()
     }, 500)
   })

--- a/cypress/integration/tests.spec.js
+++ b/cypress/integration/tests.spec.js
@@ -290,17 +290,17 @@ describe('Miscellaneous tests', function () {
     Swal.getCloseButton().click()
   })
 
-  it('onDestroy', (done) => {
+  it('didDestroy', (done) => {
     let firstPopupDestroyed = false
     Swal.fire({
       title: '1',
-      onDestroy: () => {
+      didDestroy: () => {
         firstPopupDestroyed = true
       }
     })
     Swal.fire({
       title: '2',
-      onDestroy: () => {
+      didDestroy: () => {
         done()
       }
     })

--- a/cypress/integration/tests.spec.js
+++ b/cypress/integration/tests.spec.js
@@ -249,26 +249,26 @@ describe('Miscellaneous tests', function () {
     })
   })
 
-  it('onRender', () => {
-    const onRender = cy.spy()
+  it('didRender', () => {
+    const didRender = cy.spy()
 
-    // create a modal with an onRender callback
-    // the onRender hook should be called once here
+    // create a modal with an didRender callback
+    // the didRender hook should be called once here
     Swal.fire({
-      title: 'onRender test',
-      onRender
+      title: 'didRender test',
+      didRender
     })
 
-    expect(onRender.calledOnce).to.be.true
+    expect(didRender.calledOnce).to.be.true
 
     // update the modal, causing a new render
-    // the onRender hook should be called once again
+    // the didRender hook should be called once again
     Swal.update({})
 
-    expect(onRender.calledTwice).to.be.true
+    expect(didRender.calledTwice).to.be.true
 
-    // the modal element must always be passed to the onRender hook
-    expect(onRender.alwaysCalledWithExactly(Swal.getPopup())).to.be.true
+    // the modal element must always be passed to the didRender hook
+    expect(didRender.alwaysCalledWithExactly(Swal.getPopup())).to.be.true
   })
 
   it('onAfterClose', (done) => {

--- a/cypress/integration/toast.spec.js
+++ b/cypress/integration/toast.spec.js
@@ -98,7 +98,7 @@ describe('Toast', () => {
       didOpen: () => {
         Toast.close()
       },
-      onAfterClose: () => {
+      didClose: () => {
         expect(document.body.classList.contains('swal2-shown')).to.be.false
         expect(document.body.classList.contains('swal2-toast-shown')).to.be.false
         done()

--- a/cypress/integration/toast.spec.js
+++ b/cypress/integration/toast.spec.js
@@ -95,7 +95,7 @@ describe('Toast', () => {
 
   it('Body classes are removed after closing toats', (done) => {
     Toast.fire({
-      onOpen: () => {
+      didOpen: () => {
         Toast.close()
       },
       onAfterClose: () => {

--- a/src/instanceMethods/_destroy.js
+++ b/src/instanceMethods/_destroy.js
@@ -22,9 +22,12 @@ export function _destroy () {
     delete globalState.deferDisposalTimer
   }
 
-  if (typeof innerParams.onDestroy === 'function') {
-    innerParams.onDestroy()
+  if (typeof innerParams.didDestroy === 'function') {
+    innerParams.didDestroy()
+  } else if (typeof innerParams.onDestroy === 'function') {
+    innerParams.onDestroy() // @deprecated
   }
+
   disposeSwal(this)
 }
 

--- a/src/utils/dom/renderers/render.js
+++ b/src/utils/dom/renderers/render.js
@@ -15,7 +15,9 @@ export const render = (instance, params) => {
   renderActions(instance, params)
   renderFooter(instance, params)
 
-  if (typeof params.onRender === 'function') {
-    params.onRender(getPopup())
+  if (typeof params.didRender === 'function') {
+    params.didRender(getPopup())
+  } else if (typeof params.onRender === 'function') {
+    params.onRender(getPopup()) // @deprecated
   }
 }

--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -9,14 +9,16 @@ import globalState from '../globalState.js'
 /**
  * Open popup, add necessary classes and styles, fix scrollbar
  *
- * @param {Array} params
+ * @param params
  */
 export const openPopup = (params) => {
   const container = dom.getContainer()
   const popup = dom.getPopup()
 
-  if (typeof params.onBeforeOpen === 'function') {
-    params.onBeforeOpen(popup)
+  if (typeof params.willOpen === 'function') {
+    params.willOpen(popup)
+  } else if (typeof params.onBeforeOpen === 'function') {
+    params.onBeforeOpen(popup) // @deprecated
   }
 
   const bodyStyles = window.getComputedStyle(document.body)
@@ -34,9 +36,13 @@ export const openPopup = (params) => {
   if (!dom.isToast() && !globalState.previousActiveElement) {
     globalState.previousActiveElement = document.activeElement
   }
-  if (typeof params.onOpen === 'function') {
-    setTimeout(() => params.onOpen(popup))
+
+  if (typeof params.didOpen === 'function') {
+    setTimeout(() => params.didOpen(popup))
+  } else if (typeof params.onOpen === 'function') {
+    setTimeout(() => params.onOpen(popup)) // @deprecated
   }
+
   dom.removeClass(container, swalClasses['no-transition'])
 }
 

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -83,6 +83,8 @@ export const defaultParams = {
   didRender: undefined,
   onClose: undefined,
   onAfterClose: undefined,
+  willClose: undefined,
+  didClose: undefined,
   onDestroy: undefined,
   scrollbarPadding: true
 }
@@ -105,6 +107,7 @@ export const updatableParams = [
   'denyButtonAriaLabel',
   'denyButtonColor',
   'denyButtonText',
+  'didClose',
   'footer',
   'hideClass',
   'html',
@@ -126,12 +129,16 @@ export const updatableParams = [
   'text',
   'title',
   'titleText',
+  'willClose',
 ]
 
 export const deprecatedParams = {
   animation: 'showClass" and "hideClass',
   onBeforeOpen: 'willOpen',
   onOpen: 'didOpen',
+  onRender: 'didRender',
+  onClose: 'willClose',
+  onAfterClose: 'didClose',
 }
 
 const toastIncompatibleParams = [

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -86,6 +86,7 @@ export const defaultParams = {
   willClose: undefined,
   didClose: undefined,
   onDestroy: undefined,
+  didDestroy: undefined,
   scrollbarPadding: true
 }
 
@@ -108,6 +109,7 @@ export const updatableParams = [
   'denyButtonColor',
   'denyButtonText',
   'didClose',
+  'didDestroy',
   'footer',
   'hideClass',
   'html',
@@ -139,6 +141,7 @@ export const deprecatedParams = {
   onRender: 'didRender',
   onClose: 'willClose',
   onAfterClose: 'didClose',
+  onDestroy: 'didDestroy',
 }
 
 const toastIncompatibleParams = [

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -80,6 +80,7 @@ export const defaultParams = {
   willOpen: undefined,
   didOpen: undefined,
   onRender: undefined,
+  didRender: undefined,
   onClose: undefined,
   onAfterClose: undefined,
   onDestroy: undefined,

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -77,6 +77,8 @@ export const defaultParams = {
   progressStepsDistance: undefined,
   onBeforeOpen: undefined,
   onOpen: undefined,
+  willOpen: undefined,
+  didOpen: undefined,
   onRender: undefined,
   onClose: undefined,
   onAfterClose: undefined,
@@ -127,6 +129,8 @@ export const updatableParams = [
 
 export const deprecatedParams = {
   animation: 'showClass" and "hideClass',
+  onBeforeOpen: 'willOpen',
+  onOpen: 'didOpen',
 }
 
 const toastIncompatibleParams = [

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -1,4 +1,4 @@
-import { warn, warnAboutDepreation } from '../utils/utils.js'
+import { warn, warnAboutDeprecation } from '../utils/utils.js'
 
 export const defaultParams = {
   title: '',
@@ -193,7 +193,7 @@ const checkIfToastParamIsValid = (param) => {
 
 const checkIfParamIsDeprecated = (param) => {
   if (isDeprecatedParameter(param)) {
-    warnAboutDepreation(param, isDeprecatedParameter(param))
+    warnAboutDeprecation(param, isDeprecatedParameter(param))
   }
 }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -69,7 +69,7 @@ export const warnOnce = (message) => {
 /**
  * Show a one-time console warning about deprecated params/methods
  */
-export const warnAboutDepreation = (deprecatedParam, useInstead) => {
+export const warnAboutDeprecation = (deprecatedParam, useInstead) => {
   warnOnce(`"${deprecatedParam}" is deprecated and will be removed in the next major release. Please use "${useInstead}" instead.`)
 }
 

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -1015,7 +1015,7 @@ declare module 'sweetalert2' {
     onOpen?(popup: HTMLElement): void;
 
     /**
-     * Modal lifecycle hook. Runs before the modal is shown on screen.
+     * Modal lifecycle hook. Synchronously runs before the modal is shown on screen.
      *
      * @default undefined
      * @param popup The modal DOM element.
@@ -1023,7 +1023,7 @@ declare module 'sweetalert2' {
     willOpen?(popup: HTMLElement): void;
 
     /**
-     * Modal lifecycle hook. Runs after the modal has been shown on screen.
+     * Modal lifecycle hook. Asynchronously runs after the modal has been shown on screen.
      *
      * @default undefined
      * @param popup The modal DOM element.
@@ -1031,13 +1031,21 @@ declare module 'sweetalert2' {
     didOpen?(popup: HTMLElement): void;
 
     /**
-     * Function to run after popup DOM has been updated.
-     * Typically, this will happen after `Swal.fire()` or `Swal.update()`.
-     * If you want to perform changes in the popup's DOM, that survive `Swal.update()`, `onRender` is a good place.
-     *
+     * @deprecated Use drop-in replacement {@link didRender} instead.
      * @default undefined
      */
     onRender?(popup: HTMLElement): void;
+
+    /**
+     * Modal lifecycle hook. Synchronously runs after the popup DOM has been updated (ie. just before the modal is
+     * repainted on the screen).
+     * Typically, this will happen after `Swal.fire()` or `Swal.update()`.
+     * If you want to perform changes in the popup's DOM, that survive `Swal.update()`, you want to use
+     * {@link didRender} rather than {@link willOpen}.
+     *
+     * @default undefined
+     */
+    didRender?(popup: HTMLElement): void;
 
     /**
      * Function to run when popup closes by user interaction (and not by another popup), provides popup DOM element

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -396,6 +396,7 @@ declare module 'sweetalert2' {
     | 'denyButtonColor'
     | 'denyButtonText'
     | 'didClose'
+    | 'didDestroy'
     | 'footer'
     | 'hideClass'
     | 'html'
@@ -1042,8 +1043,8 @@ declare module 'sweetalert2' {
      * Modal lifecycle hook. Synchronously runs after the popup DOM has been updated (ie. just before the modal is
      * repainted on the screen).
      * Typically, this will happen after `Swal.fire()` or `Swal.update()`.
-     * If you want to perform changes in the popup's DOM, that survive `Swal.update()`, you want to use
-     * {@link didRender} rather than {@link willOpen}.
+     * If you want to perform changes in the popup's DOM, that survive `Swal.update()`, prefer {@link didRender} over
+     * {@link willOpen}.
      *
      * @default undefined
      * @param popup The modal DOM element.
@@ -1080,11 +1081,20 @@ declare module 'sweetalert2' {
     didClose?(): void;
 
     /**
-     * Function to run after popup has been destroyed either by user interaction or by another popup.
-     *
+     * @deprecated Use drop-in replacement {@link didDestroy} instead.
      * @default undefined
      */
     onDestroy?(): void;
+
+    /**
+     * Modal lifecycle hook. Synchronously runs after popup has been destroyed either by user interaction or by another
+     * popup.
+     * If you have cleanup operations that you need to reliably execute each time a modal is closed, prefer
+     * {@link didDestroy} over {@link didClose}.
+     *
+     * @default undefined
+     */
+    didDestroy?(): void;
 
     /**
      * Set to `false` to disable body padding adjustment when scrollbar is present.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -638,9 +638,9 @@ declare module 'sweetalert2' {
     timerProgressBar?: boolean;
 
     /**
-     * @deprecated
      * If set to `false`, popup CSS animation will be disabled.
      *
+     * @deprecated
      * @default true
      */
     animation?: ValueOrThunk<boolean>;
@@ -1003,18 +1003,32 @@ declare module 'sweetalert2' {
     progressStepsDistance?: string;
 
     /**
-     * Function to run when popup built, but not shown yet. Provides popup DOM element as the first argument.
-     *
+     * @deprecated Use drop-in replacement {@link willOpen} instead.
      * @default undefined
      */
     onBeforeOpen?(popup: HTMLElement): void;
 
     /**
-     * Function to run when popup opens, provides popup DOM element as the first argument.
-     *
+     * @deprecated Use drop-in replacement {@link didOpen} instead.
      * @default undefined
      */
     onOpen?(popup: HTMLElement): void;
+
+    /**
+     * Modal lifecycle hook. Runs before the modal is shown on screen.
+     *
+     * @default undefined
+     * @param popup The modal DOM element.
+     */
+    willOpen?(popup: HTMLElement): void;
+
+    /**
+     * Modal lifecycle hook. Runs after the modal has been shown on screen.
+     *
+     * @default undefined
+     * @param popup The modal DOM element.
+     */
+    didOpen?(popup: HTMLElement): void;
 
     /**
      * Function to run after popup DOM has been updated.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -395,6 +395,7 @@ declare module 'sweetalert2' {
     | 'denyButtonAriaLabel'
     | 'denyButtonColor'
     | 'denyButtonText'
+    | 'didClose'
     | 'footer'
     | 'hideClass'
     | 'html'
@@ -414,7 +415,8 @@ declare module 'sweetalert2' {
     | 'showDenyButton'
     | 'text'
     | 'title'
-    | 'titleText';
+    | 'titleText'
+    | 'willClose';
 
   export interface SweetAlertCustomClass {
     container?: string;
@@ -1044,23 +1046,38 @@ declare module 'sweetalert2' {
      * {@link didRender} rather than {@link willOpen}.
      *
      * @default undefined
+     * @param popup The modal DOM element.
      */
     didRender?(popup: HTMLElement): void;
 
     /**
-     * Function to run when popup closes by user interaction (and not by another popup), provides popup DOM element
-     * as the first argument.
-     *
+     * @deprecated Use drop-in replacement {@link willClose} instead.
      * @default undefined
      */
     onClose?(popup: HTMLElement): void;
 
     /**
-     * Function to run after popup has been disposed by user interaction (and not by another popup).
-     *
+     * @deprecated Use drop-in replacement {@link didClose} instead.
      * @default undefined
      */
     onAfterClose?(): void;
+
+    /**
+     * Modal lifecycle hook. Synchronously runs when the popup closes by user interaction (and not due to another popup
+     * being fired).
+     *
+     * @default undefined
+     * @param popup The modal DOM element.
+     */
+    willClose?(popup: HTMLElement): void;
+
+    /**
+     * Modal lifecycle hook. Asynchronously runs after the popup has been disposed by user interaction (and not due to
+     * another popup being fired).
+     *
+     * @default undefined
+     */
+    didClose?(): void;
 
     /**
      * Function to run after popup has been destroyed either by user interaction or by another popup.

--- a/test/jest/jest.test.js
+++ b/test/jest/jest.test.js
@@ -15,7 +15,7 @@ describe('sweetalert2', () => {
             popup: '',
             container: ''
           },
-          onOpen: () => {
+          didOpen: () => {
             Swal.clickConfirm()
           }
         })

--- a/test/qunit/a11y.js
+++ b/test/qunit/a11y.js
@@ -79,7 +79,7 @@ QUnit.test('should not set aria-hidden="true" when `toast: true`', (assert) => {
 
   SwalWithoutAnimation.fire({
     toast: true,
-    onAfterClose: () => {
+    didClose: () => {
       assert.equal(divAriaHiddenTrue.getAttribute('aria-hidden'), 'true')
       done()
     }

--- a/test/qunit/api/api.js
+++ b/test/qunit/api/api.js
@@ -14,7 +14,7 @@ QUnit.test('properties of `Swal` class are consistent', (assert) => {
   assertConsistent('before first swal')
   Swal.fire({
     title: 'test',
-    onOpen: () => {
+    didOpen: () => {
       assertConsistent('after opening first swal')
       Swal.clickConfirm()
     }
@@ -50,7 +50,7 @@ QUnit.test('extending swal', (assert) => {
       return super._main({
         input: 'text',
         inputValue: 'inputValue',
-        onOpen: () => MySwal.clickConfirm()
+        didOpen: () => MySwal.clickConfirm()
       }).then(result => {
         assert.deepEqual(result, {
           value: 'inputValue',

--- a/test/qunit/api/mixins.js
+++ b/test/qunit/api/mixins.js
@@ -4,7 +4,7 @@ QUnit.test('basic mixin', (assert) => {
   const done = assert.async()
   const MySwal = Swal.mixin({ title: '1_title' })
   const swal = MySwal.fire({
-    onOpen: () => {
+    didOpen: () => {
       assert.equal(MySwal.getTitle().textContent, '1_title')
       MySwal.clickConfirm()
     }
@@ -27,7 +27,7 @@ QUnit.test('mixins and shorthand calls', (assert) => {
   const MySwal = Swal.mixin({
     title: 'no effect',
     html: 'no effect',
-    onOpen: () => {
+    didOpen: () => {
       assert.equal(MySwal.getTitle().textContent, '2_title')
       assert.equal(MySwal.getContent().textContent, '2_html')
       MySwal.clickConfirm()

--- a/test/qunit/focus-trap.js
+++ b/test/qunit/focus-trap.js
@@ -7,7 +7,7 @@ QUnit.test('focus trap forward', (assert) => {
     showCancelButton: true,
     showDenyButton: true,
     showCloseButton: true,
-    onOpen: () => {
+    didOpen: () => {
       assert.equal(document.activeElement, Swal.getInput())
       triggerKeydownEvent(document.activeElement, 'Tab')
       assert.equal(document.activeElement, Swal.getConfirmButton())
@@ -31,7 +31,7 @@ QUnit.test('focus trap backward', (assert) => {
     showDenyButton: true,
     showCancelButton: true,
     showCloseButton: true,
-    onOpen: () => {
+    didOpen: () => {
       assert.equal(document.activeElement, Swal.getInput())
       triggerKeydownEvent(document.activeElement, 'Tab', { shiftKey: true })
       assert.equal(document.activeElement, Swal.getCloseButton())
@@ -53,7 +53,7 @@ QUnit.test('arrow keys', (assert) => {
   Swal.fire({
     showDenyButton: true,
     showCancelButton: true,
-    onOpen: () => {
+    didOpen: () => {
       triggerKeydownEvent(document.activeElement, isIE ? 'Right' : 'ArrowRight')
       assert.equal(document.activeElement, Swal.getDenyButton())
       triggerKeydownEvent(document.activeElement, isIE ? 'Right' : 'ArrowRight')

--- a/test/qunit/focus.js
+++ b/test/qunit/focus.js
@@ -83,7 +83,7 @@ QUnit.test('focusDeny', (assert) => {
 //       text: 'I should not touch previousActiveElement',
 //       toast: true,
 //       timer: 1,
-//       onAfterClose: () => {
+//       didClose: () => {
 //         buttonModal.focus()
 //         buttonModal.click()
 //       }
@@ -94,7 +94,7 @@ QUnit.test('focusDeny', (assert) => {
 //     SwalWithoutAnimation.fire({
 //       text: 'I should trap focus inside myself and restore previousActiveElement when I\'m closed',
 //       timer: 1,
-//       onAfterClose: () => {
+//       didClose: () => {
 //         assert.equal(document.activeElement, buttonModal)
 //         done()
 //       }

--- a/test/qunit/focus.js
+++ b/test/qunit/focus.js
@@ -21,7 +21,7 @@ QUnit.test('default focus', (assert) => {
   SwalWithoutAnimation.fire({
     text: 'Modal with an input',
     input: 'text',
-    onOpen: () => {
+    didOpen: () => {
       assert.equal(document.activeElement, document.querySelector('.swal2-input'))
       done()
     }

--- a/test/qunit/methods/close.js
+++ b/test/qunit/methods/close.js
@@ -58,7 +58,7 @@ QUnit.test('Swal.fire() inside onAfterClose', (assert) => {
       assert.notOk(Swal.isVisible())
       SwalWithoutAnimation.fire({
         input: 'text',
-        onOpen: () => {
+        didOpen: () => {
           assert.notDeepEqual(Swal.getInput(), null)
           done()
         }

--- a/test/qunit/methods/close.js
+++ b/test/qunit/methods/close.js
@@ -24,11 +24,11 @@ QUnit.test('Swal.close() resolves', (assert) => {
   Swal.close()
 })
 
-QUnit.test('onClose using close() method', (assert) => {
+QUnit.test('willClose using close() method', (assert) => {
   const done = assert.async()
 
   Swal.fire({
-    onClose: () => {
+    willClose: () => {
       assert.ok(Swal.isVisible())
       done()
     }
@@ -37,11 +37,11 @@ QUnit.test('onClose using close() method', (assert) => {
   Swal.close()
 })
 
-QUnit.test('onAfterClose using close() method', (assert) => {
+QUnit.test('didClose using close() method', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation.fire({
-    onAfterClose: () => {
+    didClose: () => {
       assert.notOk(Swal.isVisible())
       done()
     }
@@ -50,11 +50,11 @@ QUnit.test('onAfterClose using close() method', (assert) => {
   Swal.close()
 })
 
-QUnit.test('Swal.fire() inside onAfterClose', (assert) => {
+QUnit.test('Swal.fire() inside didClose', (assert) => {
   const done = assert.async()
 
   SwalWithoutAnimation.fire({
-    onAfterClose: () => {
+    didClose: () => {
       assert.notOk(Swal.isVisible())
       SwalWithoutAnimation.fire({
         input: 'text',
@@ -70,11 +70,11 @@ QUnit.test('Swal.fire() inside onAfterClose', (assert) => {
   Swal.close()
 })
 
-QUnit.test('Swal.close() inside onAfterClose', (assert) => {
+QUnit.test('Swal.close() inside didClose', (assert) => {
   const done = assert.async()
 
   Swal.fire({
-    onAfterClose: () => {
+    didClose: () => {
       Swal.close()
       assert.notOk(Swal.isVisible())
       done()

--- a/test/qunit/methods/showLoading.js
+++ b/test/qunit/methods/showLoading.js
@@ -14,7 +14,7 @@ QUnit.test('showConfirmButton: false + showLoading()', (assert) => {
   Swal.fire({
     showConfirmButton: false,
     loaderHtml: '<i>hi</i>',
-    onOpen: () => {
+    didOpen: () => {
       assert.ok(isHidden(Swal.getActions()))
       Swal.showLoading()
       assert.ok(isVisible(Swal.getActions()))

--- a/test/qunit/methods/update.js
+++ b/test/qunit/methods/update.js
@@ -162,7 +162,7 @@ QUnit.test('should not affect showClass', (assert) => {
   const done = assert.async()
   Swal.fire({
     icon: 'success',
-    onOpen: () => {
+    didOpen: () => {
       Swal.update({})
       assert.ok(Swal.getContainer().classList.contains('swal2-backdrop-show'))
       assert.ok(Swal.getPopup().classList.contains('swal2-show'))

--- a/test/qunit/outside-click.js
+++ b/test/qunit/outside-click.js
@@ -27,18 +27,18 @@ QUnit.test('backdrop click', (assert) => {
 
 QUnit.test('double backdrop click', (assert) => {
   const done = assert.async()
-  const onAfterClose = sinon.fake()
+  const didClose = sinon.fake()
 
   Swal.fire({
-    title: 'onAfterClose should be triggered once',
-    onAfterClose
+    title: 'didClose should be triggered once',
+    didClose
   })
 
   Swal.getContainer().click()
   Swal.getContainer().click()
 
   setTimeout(() => {
-    assert.ok(onAfterClose.calledOnce)
+    assert.ok(didClose.calledOnce)
     done()
   }, 500)
 })

--- a/test/qunit/params/input.js
+++ b/test/qunit/params/input.js
@@ -360,7 +360,7 @@ QUnit.test('Swal.getInput() should return null when a popup is disposed', (asser
 
   SwalWithoutAnimation.fire({
     input: 'text',
-    onAfterClose: () => {
+    didClose: () => {
       setTimeout(() => {
         assert.notOk(Swal.getInput())
         done()

--- a/test/qunit/params/input.js
+++ b/test/qunit/params/input.js
@@ -156,7 +156,7 @@ QUnit.test('input select with inputOptions as Promise', (assert) => {
   Swal.fire({
     input: 'select',
     inputOptions: Promise.resolve({ one: 1, two: 2 }),
-    onOpen: () => {
+    didOpen: () => {
       setTimeout(() => {
         Swal.getInput().value = 'one'
         assert.equal(Swal.getInput().value, 'one')
@@ -174,7 +174,7 @@ QUnit.test('input select with inputOptions as object containing toPromise', (ass
     inputOptions: {
       toPromise: () => Promise.resolve({ three: 3, four: 4 })
     },
-    onOpen: () => {
+    didOpen: () => {
       setTimeout(() => {
         Swal.getInput().value = 'three'
         assert.equal(Swal.getInput().value, 'three')

--- a/test/qunit/params/inputValue.js
+++ b/test/qunit/params/inputValue.js
@@ -14,7 +14,7 @@ QUnit.test('inputValue with object containing toPromise', (assert) => {
     inputValue: {
       toPromise: () => Promise.resolve('test')
     },
-    onOpen: () => {
+    didOpen: () => {
       setTimeout(() => {
         assert.equal(Swal.getInput().value, 'test')
         done()
@@ -39,7 +39,7 @@ QUnit.test('inputValue as a Promise', (assert) => {
     SwalWithoutAnimation.fire({
       input,
       inputValue,
-      onOpen: () => {
+      didOpen: () => {
         setTimeout(() => {
           assert.equal(Swal.getInput().value, input === 'number' ? parseFloat(value) : value)
           if (inputTypes.length) {
@@ -67,7 +67,7 @@ QUnit.test('should throw console error when inputValue as a Promise rejects', (a
     inputValue: new Promise((resolve, reject) => {
       reject(new Error('input promise rejected'))
     }),
-    onOpen: () => {
+    didOpen: () => {
       setTimeout(() => {
         console.error = _consoleError
         assert.ok(spy.calledWith('SweetAlert2: Error in inputValue promise: Error: input promise rejected'))

--- a/test/qunit/params/progressSteps.js
+++ b/test/qunit/params/progressSteps.js
@@ -5,7 +5,7 @@ QUnit.test('first .swal2-progress-step is active by default', (assert) => {
 
   SwalWithoutAnimation.queue([{
     progressSteps: ['1', '2', '3'],
-    onOpen: () => {
+    didOpen: () => {
       assert.ok(Swal.getProgressSteps().querySelector('.swal2-progress-step').classList.contains('swal2-active-progress-step'))
       done()
     }

--- a/test/qunit/params/showClass.js
+++ b/test/qunit/params/showClass.js
@@ -11,7 +11,7 @@ QUnit.test('showClass + hideClass', (assert) => {
     hideClass: {
       popup: 'animated fadeOutUp faster'
     },
-    onAfterClose: () => {
+    didClose: () => {
       assert.notOk(Swal.isVisible())
       done()
     }

--- a/test/qunit/params/stopKeydownPropagation.js
+++ b/test/qunit/params/stopKeydownPropagation.js
@@ -10,7 +10,7 @@ QUnit.test('stopKeydownPropagation', (assert) => {
 
   SwalWithoutAnimation.fire({
     title: 'Esc me and I will propagate keydown',
-    onOpen: () => triggerKeydownEvent(SwalWithoutAnimation.getPopup(), 'Escape'),
+    didOpen: () => triggerKeydownEvent(SwalWithoutAnimation.getPopup(), 'Escape'),
     stopKeydownPropagation: false
   })
 })

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -23,7 +23,7 @@ QUnit.test('container scrolled to top and has scrollbar on open', (assert) => {
     imageUrl: 'https://placeholder.pics/svg/300x1500',
     imageHeight: 1500,
     imageAlt: 'A tall image',
-    onOpen: () => {
+    didOpen: () => {
       assert.equal(Swal.getContainer().scrollTop, 0)
       assert.equal(Swal.getContainer().style.overflowY, 'auto')
       done()
@@ -142,7 +142,7 @@ QUnit.test('the vertical scrollbar should be restored before a toast is fired af
     Swal.fire({
       text: 'Body padding-right should be restored',
       toast: true,
-      onOpen: () => {
+      didOpen: () => {
         assert.equal(bodyStyles.paddingRight, '30px')
         document.body.removeChild(talltDiv)
         done()
@@ -433,39 +433,39 @@ QUnit.test('modal vertical offset', (assert) => {
   })
 })
 
-QUnit.test('onOpen', (assert) => {
+QUnit.test('didOpen', (assert) => {
   const done = assert.async()
 
-  // create a modal with an onOpen callback
+  // create a modal with an didOpen callback
   Swal.fire({
-    title: 'onOpen test',
-    onOpen: (modal) => {
+    title: 'didOpen test',
+    didOpen: (modal) => {
       assert.equal(Swal.getPopup(), modal)
       done()
     }
   })
 })
 
-QUnit.test('onBeforeOpen', (assert) => {
+QUnit.test('willOpen', (assert) => {
   const done = assert.async()
 
-  // create a modal with an onBeforeOpen callback
+  // create a modal with an willOpen callback
   Swal.fire({
-    title: 'onBeforeOpen test',
-    onBeforeOpen: (modal) => {
+    title: 'willOpen test',
+    willOpen: (modal) => {
       assert.notOk(Swal.isVisible())
       assert.equal(Swal.getPopup(), modal)
     }
   })
 
-  // check that onBeforeOpen calls properly
-  const dynamicTitle = 'Set onBeforeOpen title'
+  // check that willOpen calls properly
+  const dynamicTitle = 'Set willOpen title'
   Swal.fire({
-    title: 'onBeforeOpen test',
-    onBeforeOpen: () => {
+    title: 'willOpen test',
+    willOpen: () => {
       Swal.getTitle().innerHTML = dynamicTitle
     },
-    onOpen: () => {
+    didOpen: () => {
       assert.equal(Swal.getTitle().innerHTML, dynamicTitle)
       done()
     }
@@ -582,7 +582,7 @@ QUnit.test('esc key', (assert) => {
 
   SwalWithoutAnimation.fire({
     title: 'Esc me',
-    onOpen: () => triggerKeydownEvent(Swal.getPopup(), 'Escape')
+    didOpen: () => triggerKeydownEvent(Swal.getPopup(), 'Escape')
   }).then((result) => {
     assert.deepEqual(result, {
       dismiss: Swal.DismissReason.esc,
@@ -605,7 +605,7 @@ QUnit.test('allowEscapeKey as a function', (assert) => {
       functionWasCalled = true
       return false
     },
-    onOpen: () => {
+    didOpen: () => {
       assert.equal(functionWasCalled, false)
 
       triggerKeydownEvent(Swal.getPopup(), 'Escape')
@@ -729,12 +729,12 @@ QUnit.test('should stop the animation of timer progress bar when timer is stoppe
   }, 20)
 })
 
-QUnit.test('should stop the animation of timer progress bar when timer is stopped in onOpen', (assert) => {
+QUnit.test('should stop the animation of timer progress bar when timer is stopped in didOpen', (assert) => {
   const done = assert.async()
   SwalWithoutAnimation.fire({
     timer: 100,
     timerProgressBar: true,
-    onOpen: Swal.stopTimer
+    didOpen: Swal.stopTimer
   })
   setTimeout(() => {
     assert.equal(Swal.getTimerProgressBar().style.transition, '')
@@ -818,7 +818,7 @@ QUnit.test('Custom content', (assert) => {
   const done = assert.async()
   Swal.fire({
     showCancelButton: true,
-    onOpen: () => {
+    didOpen: () => {
       Swal.getContent().textContent = 'Custom content'
       Swal.clickConfirm()
     },
@@ -832,7 +832,7 @@ QUnit.test('Custom content', (assert) => {
 QUnit.test('preConfirm returns 0', (assert) => {
   const done = assert.async()
   SwalWithoutAnimation.fire({
-    onOpen: () => Swal.clickConfirm(),
+    didOpen: () => Swal.clickConfirm(),
     preConfirm: () => 0
   }).then(result => {
     assert.equal(result.value, 0)
@@ -843,7 +843,7 @@ QUnit.test('preConfirm returns 0', (assert) => {
 QUnit.test('preConfirm returns object containing toPromise', (assert) => {
   const done = assert.async()
   SwalWithoutAnimation.fire({
-    onOpen: () => Swal.clickConfirm(),
+    didOpen: () => Swal.clickConfirm(),
     preConfirm: () => ({
       toPromise: () => Promise.resolve(0)
     })

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -472,26 +472,26 @@ QUnit.test('willOpen', (assert) => {
   })
 })
 
-QUnit.test('onRender', (assert) => {
-  const onRender = sinon.fake()
+QUnit.test('didRender', (assert) => {
+  const didRender = sinon.fake()
 
-  // create a modal with an onRender callback
-  // the onRender hook should be called once here
+  // create a modal with an didRender callback
+  // the didRender hook should be called once here
   Swal.fire({
-    title: 'onRender test',
-    onRender
+    title: 'didRender test',
+    didRender
   })
 
-  assert.ok(onRender.calledOnce)
+  assert.ok(didRender.calledOnce)
 
   // update the modal, causing a new render
-  // the onRender hook should be called once again
+  // the didRender hook should be called once again
   Swal.update({})
 
-  assert.ok(onRender.calledTwice)
+  assert.ok(didRender.calledTwice)
 
-  // the modal element must always be passed to the onRender hook
-  assert.ok(onRender.alwaysCalledWithExactly(Swal.getPopup()))
+  // the modal element must always be passed to the didRender hook
+  assert.ok(didRender.alwaysCalledWithExactly(Swal.getPopup()))
 })
 
 QUnit.test('onAfterClose', (assert) => {

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -531,18 +531,18 @@ QUnit.test('willClose', (assert) => {
   Swal.getCloseButton().click()
 })
 
-QUnit.test('onDestroy', (assert) => {
+QUnit.test('didDestroy', (assert) => {
   const done = assert.async()
   let firstPopupDestroyed = false
   Swal.fire({
     title: '1',
-    onDestroy: () => {
+    didDestroy: () => {
       firstPopupDestroyed = true
     }
   })
   Swal.fire({
     title: '2',
-    onDestroy: () => {
+    didDestroy: () => {
       done()
     }
   })

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -97,7 +97,7 @@ QUnit.test('the vertical scrollbar should be hidden and the according padding-ri
 
   Swal.fire({
     title: 'The body has visible scrollbar, I will hide it and adjust padding-right on body',
-    onAfterClose: () => {
+    didClose: () => {
       assert.equal(bodyStyles.paddingRight, '30px')
       document.body.removeChild(talltDiv)
       done()
@@ -119,7 +119,7 @@ QUnit.test('scrollbarPadding disabled', (assert) => {
   Swal.fire({
     title: 'Padding right adjustment disabled',
     scrollbarPadding: false,
-    onAfterClose: () => {
+    didClose: () => {
       document.body.removeChild(talltDiv)
     }
   })
@@ -494,18 +494,18 @@ QUnit.test('didRender', (assert) => {
   assert.ok(didRender.alwaysCalledWithExactly(Swal.getPopup()))
 })
 
-QUnit.test('onAfterClose', (assert) => {
+QUnit.test('didClose', (assert) => {
   const done = assert.async()
-  let onCloseFinished = false
+  let willCloseFinished = false
 
-  // create a modal with an onAfterClose callback
+  // create a modal with an didClose callback
   Swal.fire({
-    title: 'onAfterClose test',
-    onClose: () => {
-      onCloseFinished = true
+    title: 'didClose test',
+    willClose: () => {
+      willCloseFinished = true
     },
-    onAfterClose: () => {
-      assert.ok(onCloseFinished)
+    didClose: () => {
+      assert.ok(willCloseFinished)
       assert.notOk(Swal.getContainer())
       done()
     }
@@ -514,13 +514,13 @@ QUnit.test('onAfterClose', (assert) => {
   Swal.getCloseButton().click()
 })
 
-QUnit.test('onClose', (assert) => {
+QUnit.test('willClose', (assert) => {
   const done = assert.async()
 
-  // create a modal with an onClose callback
+  // create a modal with an willClose callback
   Swal.fire({
-    title: 'onClose test',
-    onClose: (_modal) => {
+    title: 'willClose test',
+    willClose: (_modal) => {
       assert.ok(modal, _modal)
       assert.ok(Swal.getContainer())
       done()
@@ -550,14 +550,14 @@ QUnit.test('onDestroy', (assert) => {
   Swal.getConfirmButton().click()
 })
 
-QUnit.test('Swal.fire() in onClose', (assert) => {
+QUnit.test('Swal.fire() in willClose', (assert) => {
   const done = assert.async()
 
   Swal.fire({
-    title: 'onClose test',
-    onClose: () => {
+    title: 'willClose test',
+    willClose: () => {
       Swal.fire({
-        text: 'OnClose',
+        text: 'WillClose',
         input: 'text',
         customClass: {
           input: 'on-close-swal'

--- a/test/qunit/toast.js
+++ b/test/qunit/toast.js
@@ -110,7 +110,7 @@ QUnit.test('Body classes are removed after closing toats', (assert) => {
     didOpen: () => {
       Toast.close()
     },
-    onAfterClose: () => {
+    didClose: () => {
       assert.notOk(document.body.classList.contains('swal2-shown'))
       assert.notOk(document.body.classList.contains('swal2-toast-shown'))
       done()

--- a/test/qunit/toast.js
+++ b/test/qunit/toast.js
@@ -107,7 +107,7 @@ QUnit.test('Body classes are removed after closing toats', (assert) => {
   const done = assert.async()
 
   Toast.fire({
-    onOpen: () => {
+    didOpen: () => {
       Toast.close()
     },
     onAfterClose: () => {

--- a/test/sandbox.html
+++ b/test/sandbox.html
@@ -26,7 +26,7 @@
           Swal.showValidationMessage('Should not be empty!')
         }
       },
-      onOpen: function (modal) {
+      didOpen: function (modal) {
         console.log(modal)
       }
     }).then(function (result) {


### PR DESCRIPTION
As discussed in #2055.

Hooks were previously named as follows:

| Before hook | After hook |
|-------------|------------|
| onBeforeOpen  | onOpen       |
|             | onRender     |
| onClose       | onAfterClose |
|             | onDestroy    |

All have been deprecated and renamed according to the convention used by frameworks like UIKit or React:

| Before hook | After hook |
|-------------|------------|
| willOpen  | didOpen       |
|             | didRender     |
| willClose       | didClose |
|             | didDestroy    |

- Old hooks are still called if defined, **but only if the new name is not used simultaneously**,
- .d.ts doc blocks for the new hooks have been improved,
- Old hooks are still present in the .d.ts file but have been marked as `@deprecated`, and a warning is printed if they're used in runtime.