### PR TITLE
fire method position changed to improve dev exp

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -13,15 +13,6 @@ declare module 'sweetalert2' {
    * ```
    */
   namespace Swal {
-    /**
-     * Function to display a simple SweetAlert2 popup.
-     *
-     * Example:
-     * ```
-     * Swal.fire('The Internet?', 'That thing is still around?', 'question');
-     * ```
-     */
-    function fire<T>(title?: string, html?: string, icon?: SweetAlertIcon): Promise<SweetAlertResult<Awaited<T>>>;
 
     /**
      * Function to display a SweetAlert2 popup, with an object of options, all being optional.
@@ -36,7 +27,17 @@ declare module 'sweetalert2' {
      * })
      * ```
      */
-    function fire<T>(options: SweetAlertOptions<T>): Promise<SweetAlertResult<Awaited<T>>>;
+    function fire<T = any>(options: SweetAlertOptions<T>): Promise<SweetAlertResult<Awaited<T>>>;
+
+    /**
+     * Function to display a simple SweetAlert2 popup.
+     *
+     * Example:
+     * ```
+     * Swal.fire('The Internet?', 'That thing is still around?', 'question');
+     * ```
+     */
+    function fire<T = any>(title?: string, html?: string, icon?: SweetAlertIcon): Promise<SweetAlertResult<Awaited<T>>>;
 
     /**
      * Reuse configuration by creating a `Swal` instance.


### PR DESCRIPTION
It seems that VS code prioritize the first definition even though
bracket are passed through the method. I've change the position of the
fire method and looks like it fixes #2050