### PR TITLE
Feature: add ability to provide input `label`

### DIFF
--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -484,6 +484,12 @@
   }
 }
 
+.swal2-label {
+  display: block;
+  margin: $swal2-label-margin;
+  text-align: $swal2-label-align;
+}
+
 .swal2-validation-message {
   display: none;
   align-items: center;

--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -484,10 +484,10 @@
   }
 }
 
-.swal2-label {
-  display: block;
-  margin: $swal2-label-margin;
-  text-align: $swal2-label-align;
+.swal2-input-label {
+  display: flex;
+  justify-content: $swal2-input-label-justify-content;
+  margin: $swal2-input-label-margin;
 }
 
 .swal2-validation-message {

--- a/src/staticMethods/dom.js
+++ b/src/staticMethods/dom.js
@@ -10,7 +10,7 @@ export {
   getImage,
   getIcon,
   getIcons,
-  getLabel,
+  getInputLabel,
   getCloseButton,
   getActions,
   getConfirmButton,

--- a/src/staticMethods/dom.js
+++ b/src/staticMethods/dom.js
@@ -10,6 +10,7 @@ export {
   getImage,
   getIcon,
   getIcons,
+  getLabel,
   getCloseButton,
   getActions,
   getConfirmButton,

--- a/src/utils/classes.js
+++ b/src/utils/classes.js
@@ -44,6 +44,7 @@ export const swalClasses = prefix([
   'label',
   'textarea',
   'inputerror',
+  'input-label',
   'validation-message',
   'progress-steps',
   'active-progress-step',

--- a/src/utils/dom/getters.js
+++ b/src/utils/dom/getters.js
@@ -41,6 +41,8 @@ export const getConfirmButton = () => elementBySelector(`.${swalClasses.actions}
 
 export const getDenyButton = () => elementBySelector(`.${swalClasses.actions} .${swalClasses.deny}`)
 
+export const getLabel = () => elementByClass(swalClasses.label)
+
 export const getLoader = () => elementBySelector(`.${swalClasses.loader}`)
 
 export const getCancelButton = () => elementBySelector(`.${swalClasses.actions} .${swalClasses.cancel}`)

--- a/src/utils/dom/getters.js
+++ b/src/utils/dom/getters.js
@@ -41,7 +41,7 @@ export const getConfirmButton = () => elementBySelector(`.${swalClasses.actions}
 
 export const getDenyButton = () => elementBySelector(`.${swalClasses.actions} .${swalClasses.deny}`)
 
-export const getLabel = () => elementByClass(swalClasses.label)
+export const getInputLabel = () => elementByClass(swalClasses['input-label'])
 
 export const getLoader = () => elementBySelector(`.${swalClasses.loader}`)
 

--- a/src/utils/dom/renderers/renderInput.js
+++ b/src/utils/dom/renderers/renderInput.js
@@ -97,7 +97,7 @@ const setInputLabel = (input, params) => {
     input.id = id
 
     const label = document.createElement('label')
-    const labelClass = swalClasses.label
+    const labelClass = swalClasses['input-label']
     label.setAttribute('for', id)
     label.className = labelClass
     label.innerText = params.inputLabel

--- a/src/utils/dom/renderers/renderInput.js
+++ b/src/utils/dom/renderers/renderInput.js
@@ -1,4 +1,5 @@
 import { swalClasses } from '../../classes.js'
+import { swalId } from '../../id.js'
 import { warn, error, isPromise } from '../../utils.js'
 import * as dom from '../../dom/index.js'
 import privateProps from '../../../privateProps.js'
@@ -90,6 +91,20 @@ const setInputPlaceholder = (input, params) => {
   }
 }
 
+const setInputLabel = (input, params) => {
+  if (params.inputLabel) {
+    const id = input.id || swalId()
+    input.id = id
+
+    const label = document.createElement('label')
+    const labelClass = swalClasses.label
+    label.setAttribute('for', id)
+    label.className = labelClass
+    label.innerText = params.inputLabel
+    input.insertAdjacentElement('beforebegin', label)
+  }
+}
+
 const getInputContainer = (inputType) => {
   const inputClass = swalClasses[inputType] ? swalClasses[inputType] : swalClasses.input
   return dom.getChildByClass(dom.getContent(), inputClass)
@@ -108,12 +123,14 @@ renderInputType.url = (input, params) => {
   } else if (!isPromise(params.inputValue)) {
     warn(`Unexpected type of inputValue! Expected "string", "number" or "Promise", got "${typeof params.inputValue}"`)
   }
+  setInputLabel(input, params)
   setInputPlaceholder(input, params)
   input.type = params.input
   return input
 }
 
 renderInputType.file = (input, params) => {
+  setInputLabel(input, params)
   setInputPlaceholder(input, params)
   return input
 }
@@ -124,6 +141,7 @@ renderInputType.range = (range, params) => {
   rangeInput.value = params.inputValue
   rangeInput.type = params.input
   rangeOutput.value = params.inputValue
+  setInputLabel(rangeInput, params)
   return range
 }
 
@@ -137,6 +155,7 @@ renderInputType.select = (select, params) => {
     placeholder.selected = true
     select.appendChild(placeholder)
   }
+  setInputLabel(select, params)
   return select
 }
 
@@ -158,6 +177,7 @@ renderInputType.checkbox = (checkboxContainer, params) => {
 renderInputType.textarea = (textarea, params) => {
   textarea.value = params.inputValue
   setInputPlaceholder(textarea, params)
+  setInputLabel(textarea, params)
 
   if ('MutationObserver' in window) { // #1699
     const initialPopupWidth = parseInt(window.getComputedStyle(dom.getPopup()).width)

--- a/src/utils/id.js
+++ b/src/utils/id.js
@@ -1,0 +1,5 @@
+export const swalPrefix = 'swal2-'
+
+export const swalId = () => {
+  return Math.random().toString(36).replace('0.', swalPrefix)
+}

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -64,6 +64,7 @@ export const defaultParams = {
   background: undefined,
   input: undefined,
   inputPlaceholder: '',
+  inputLabel: '',
   inputValue: '',
   inputOptions: {},
   inputAutoTrim: true,

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -82,9 +82,9 @@ $swal2-input-transition: border-color .3s, box-shadow .3s !default;
 $swal2-textarea-height: 6.75em !default;
 $swal2-textarea-padding: .75em !default;
 
-// LABEL
-$swal2-label-margin: 1em auto !default;
-$swal2-label-align: left !default;
+// INPUT LABEL
+$swal2-input-label-margin: 1em auto !default;
+$swal2-input-label-justify-content: center !default;
 
 // VALIDATION MESSAGE
 $swal2-validation-message-justify-content: center !default;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -82,6 +82,10 @@ $swal2-input-transition: border-color .3s, box-shadow .3s !default;
 $swal2-textarea-height: 6.75em !default;
 $swal2-textarea-padding: .75em !default;
 
+// LABEL
+$swal2-label-margin: 1em auto !default;
+$swal2-label-align: left !default;
+
 // VALIDATION MESSAGE
 $swal2-validation-message-justify-content: center !default;
 $swal2-validation-message-padding: .625em !default;

--- a/test/qunit/params/inputLabel.js
+++ b/test/qunit/params/inputLabel.js
@@ -10,7 +10,7 @@ QUnit.test('inputLabel: text input with label', (assert) => {
   })
 
   const input = Swal.getInput()
-  const label = Swal.getLabel()
+  const label = Swal.getInputLabel()
   assert.equal(input.id, label.htmlFor)
   assert.equal(label.innerText, inputLabel)
 
@@ -27,7 +27,7 @@ QUnit.test('inputLabel: password input with label', (assert) => {
   })
 
   const input = Swal.getInput()
-  const label = Swal.getLabel()
+  const label = Swal.getInputLabel()
   assert.equal(input.id, label.htmlFor)
   assert.equal(label.innerText, inputLabel)
 
@@ -90,7 +90,7 @@ QUnit.test('inputLabel: range input with label', (assert) => {
   })
 
   const input = Swal.getInput()
-  const label = Swal.getLabel()
+  const label = Swal.getInputLabel()
   assert.equal(input.id, label.htmlFor)
   assert.equal(label.innerText, inputLabel)
 

--- a/test/qunit/params/inputLabel.js
+++ b/test/qunit/params/inputLabel.js
@@ -1,0 +1,98 @@
+const { Swal } = require('../helpers')
+
+QUnit.test('inputLabel: text input with label', (assert) => {
+  const done = assert.async()
+  const inputLabel = 'My Text Input Label'
+
+  Swal.fire({
+    input: 'text',
+    inputLabel
+  })
+
+  const input = Swal.getInput()
+  const label = Swal.getLabel()
+  assert.equal(input.id, label.htmlFor)
+  assert.equal(label.innerText, inputLabel)
+
+  done()
+})
+
+QUnit.test('inputLabel: password input with label', (assert) => {
+  const done = assert.async()
+  const inputLabel = 'My Password Label'
+
+  Swal.fire({
+    input: 'password',
+    inputLabel
+  })
+
+  const input = Swal.getInput()
+  const label = Swal.getLabel()
+  assert.equal(input.id, label.htmlFor)
+  assert.equal(label.innerText, inputLabel)
+
+  done()
+})
+
+QUnit.test('inputLabel: textarea input with label', (assert) => {
+  const done = assert.async()
+  const inputLabel = 'My Text Area Label'
+
+  Swal.fire({
+    input: 'textarea',
+    inputLabel,
+    inputPlaceholder: 'Type your message here...',
+    inputAttributes: {
+      'aria-label': 'Type your message here'
+    }
+  })
+
+  const input = Swal.getInput()
+  const label = Swal.getContent().querySelector(`[for=${input.id}]`)
+  assert.equal(label.innerText, inputLabel)
+
+  done()
+})
+
+QUnit.test('inputLabel: select/options input with label', (assert) => {
+  const done = assert.async()
+  const inputLabel = 'My Dropdown List Label'
+
+  Swal.fire({
+    input: 'select',
+    inputLabel,
+    inputOptions: {
+      'action': 'Action',
+      'comedy': 'Comedy',
+      'documentary': 'Documentary'
+    },
+  })
+
+  const input = Swal.getInput()
+  const label = Swal.getContent().querySelector(`[for=${input.id}]`)
+  assert.equal(label.innerText, inputLabel)
+
+  done()
+})
+
+QUnit.test('inputLabel: range input with label', (assert) => {
+  const done = assert.async()
+  const inputLabel = 'My Range Input Label'
+
+  Swal.fire({
+    input: 'range',
+    inputLabel,
+    inputAttributes: {
+      min: 8,
+      max: 120,
+      step: 1
+    }
+  })
+
+  const input = Swal.getInput()
+  const label = Swal.getLabel()
+  assert.equal(input.id, label.htmlFor)
+  assert.equal(label.innerText, inputLabel)
+
+  done()
+})


### PR DESCRIPTION
allows someone to provide `inputLabel` which will create a <label> element linked to the input (this is a significant improvement to accessibility)

```
  Swal.fire({
    input: 'text',
    inputLabel: 'Lorem Ipusum'
  })
```

![image](https://user-images.githubusercontent.com/21046709/95684475-04f93780-0bc0-11eb-9480-22f876762e92.png)
