### PR TITLE
changed button colors to be WCAG compliant

### DIFF
--- a/src/variables.scss
+++ b/src/variables.scss
@@ -104,7 +104,7 @@ $swal2-progress-step-height: 2em;
 $swal2-progress-step-border-radius: 2em;
 $swal2-progress-step-background: #add8e6 !default;
 $swal2-progress-step-color: $swal2-white !default;
-$swal2-active-step-background: #2778C4 !default;
+$swal2-active-step-background: #2778c4 !default;
 $swal2-active-step-color: $swal2-white !default;
 
 // FOOTER
@@ -152,7 +152,7 @@ $swal2-actions-padding: 0 1.6em !default;
 $swal2-confirm-button-order: null !default;
 $swal2-confirm-button-border: 0 !default;
 $swal2-confirm-button-border-radius: .25em !default;
-$swal2-confirm-button-background-color: #2778C4 !default;
+$swal2-confirm-button-background-color: #2778c4 !default;
 $swal2-confirm-button-color: $swal2-white !default;
 $swal2-confirm-button-font-size: 1.0625em !default;
 
@@ -160,7 +160,7 @@ $swal2-confirm-button-font-size: 1.0625em !default;
 $swal2-deny-button-order: null !default;
 $swal2-deny-button-border: 0 !default;
 $swal2-deny-button-border-radius: .25em !default;
-$swal2-deny-button-background-color: #D14529 !default;
+$swal2-deny-button-background-color: #d14529 !default;
 $swal2-deny-button-color: $swal2-white !default;
 $swal2-deny-button-font-size: 1.0625em !default;
 
@@ -189,7 +189,7 @@ $swal2-loader-animation: swal2-rotate-loading 1.5s linear 0s infinite normal !de
 $swal2-loader-border-width: .25em !default;
 $swal2-loader-border-style: solid !default;
 $swal2-loader-border-radius: 100% !default;
-$swal2-loader-border-color: #2778C4 transparent #2778C4 transparent !default;
+$swal2-loader-border-color: #2778c4 transparent #2778c4 transparent !default;
 
 // TOASTS
 $swal2-toast-show-animation: swal2-toast-show .5s !default;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -104,7 +104,7 @@ $swal2-progress-step-height: 2em;
 $swal2-progress-step-border-radius: 2em;
 $swal2-progress-step-background: #add8e6 !default;
 $swal2-progress-step-color: $swal2-white !default;
-$swal2-active-step-background: #3085d6 !default;
+$swal2-active-step-background: #2778C4 !default;
 $swal2-active-step-color: $swal2-white !default;
 
 // FOOTER
@@ -152,7 +152,7 @@ $swal2-actions-padding: 0 1.6em !default;
 $swal2-confirm-button-order: null !default;
 $swal2-confirm-button-border: 0 !default;
 $swal2-confirm-button-border-radius: .25em !default;
-$swal2-confirm-button-background-color: #3085d6 !default;
+$swal2-confirm-button-background-color: #2778C4 !default;
 $swal2-confirm-button-color: $swal2-white !default;
 $swal2-confirm-button-font-size: 1.0625em !default;
 
@@ -160,7 +160,7 @@ $swal2-confirm-button-font-size: 1.0625em !default;
 $swal2-deny-button-order: null !default;
 $swal2-deny-button-border: 0 !default;
 $swal2-deny-button-border-radius: .25em !default;
-$swal2-deny-button-background-color: #dd6b55 !default;
+$swal2-deny-button-background-color: #D14529 !default;
 $swal2-deny-button-color: $swal2-white !default;
 $swal2-deny-button-font-size: 1.0625em !default;
 
@@ -168,7 +168,7 @@ $swal2-deny-button-font-size: 1.0625em !default;
 $swal2-cancel-button-order: null !default;
 $swal2-cancel-button-border: 0 !default;
 $swal2-cancel-button-border-radius: .25em !default;
-$swal2-cancel-button-background-color: #aaa !default;
+$swal2-cancel-button-background-color: #757575 !default;
 $swal2-cancel-button-color: $swal2-white !default;
 $swal2-cancel-button-font-size: 1.0625em !default;
 
@@ -189,7 +189,7 @@ $swal2-loader-animation: swal2-rotate-loading 1.5s linear 0s infinite normal !de
 $swal2-loader-border-width: .25em !default;
 $swal2-loader-border-style: solid !default;
 $swal2-loader-border-radius: 100% !default;
-$swal2-loader-border-color: #3085d6 transparent #3085d6 transparent !default;
+$swal2-loader-border-color: #2778C4 transparent #2778C4 transparent !default;
 
 // TOASTS
 $swal2-toast-show-animation: swal2-toast-show .5s !default;


### PR DESCRIPTION
Updated the color contrast on the orange, blue, and gray buttons to pass WCAG 2.0 AA standard.  Previous colors did not pass the 4.5:1 ratio expected