### PR TITLE
Set `display: inline-block` for confirm button

### DIFF
--- a/src/instanceMethods/hideLoading.js
+++ b/src/instanceMethods/hideLoading.js
@@ -14,7 +14,7 @@ function hideLoading () {
   const domCache = privateProps.domCache.get(this)
   dom.hide(domCache.loader)
   if (innerParams.showConfirmButton) {
-    dom.show(domCache.confirmButton)
+    dom.show(domCache.confirmButton, 'inline-block')
   } else if (!innerParams.showConfirmButton && !innerParams.showCancelButton) {
     dom.hide(domCache.actions)
   }

--- a/src/utils/dom/renderers/renderActions.js
+++ b/src/utils/dom/renderers/renderActions.js
@@ -1,7 +1,6 @@
 import { swalClasses } from '../../classes.js'
 import * as dom from '../../dom/index.js'
 import { capitalizeFirstLetter } from '../../utils.js'
-import { isLoading } from '../getters.js'
 
 export const renderActions = (instance, params) => {
   const actions = dom.getActions()
@@ -51,13 +50,6 @@ function handleButtonsStyling (confirmButton, denyButton, cancelButton, params) 
   }
   if (params.cancelButtonColor) {
     cancelButton.style.backgroundColor = params.cancelButtonColor
-  }
-
-  // Loading state
-  if (!isLoading()) {
-    const confirmButtonBackgroundColor = window.getComputedStyle(confirmButton).getPropertyValue('background-color')
-    confirmButton.style.borderLeftColor = confirmButtonBackgroundColor
-    confirmButton.style.borderRightColor = confirmButtonBackgroundColor
   }
 }
 

--- a/test/qunit/methods/hideLoading.js
+++ b/test/qunit/methods/hideLoading.js
@@ -1,4 +1,10 @@
-import { Swal, ensureClosed } from '../helpers.js'
+import { Swal, ensureClosed, SwalWithoutAnimation } from '../helpers.js'
+
+QUnit.test('hideLoading should set display: inline-block to confirmButton', (assert) => {
+  SwalWithoutAnimation.fire()
+  Swal.hideLoading()
+  assert.equal(Swal.getConfirmButton().style.display, 'inline-block')
+})
 
 QUnit.test('hideLoading should not fail with closed popup', (assert) => {
   ensureClosed()


### PR DESCRIPTION
Fixes #2080