### PR TITLE
Fix params precedence

### DIFF
--- a/cypress/integration/params/template.spec.js
+++ b/cypress/integration/params/template.spec.js
@@ -55,8 +55,10 @@ describe('template', () => {
     template.id = 'my-template-string'
     template.innerHTML = '<swal-title>Are you sure?</swal-title>'
     document.body.appendChild(template)
-    SwalWithoutAnimation.fire({
+    const mixin = SwalWithoutAnimation.mixin({
       title: 'this title should be overriden by template',
+    })
+    mixin.fire({
       template: '#my-template-string',
     })
     expect(Swal.getTitle().textContent).to.equal('Are you sure?')
@@ -69,13 +71,15 @@ describe('template', () => {
     template.innerHTML = `
       <swal-foo>bar</swal-foo>
       <swal-title value="hey!"></swal-title>
-      <swal-image src="https://sweetalert2.github.io/images/SweetAlert2.png" height="100" alt="" foo="1">Are you sure?</swal-image>
+      <swal-image src="https://sweetalert2.github.io/images/SweetAlert2.png" width="100" height="100" alt="" foo="1">Are you sure?</swal-image>
       <swal-input bar>Are you sure?</swal-input>
     `
     document.body.appendChild(template)
-    SwalWithoutAnimation.fire({
+    const mixin = SwalWithoutAnimation.mixin({
       imageAlt: 'this alt should be overriden by template',
-      imageWidth: 200,
+    })
+    mixin.fire({
+      imageWidth: 200, // user param should override <swal-image width="100">
       template: '#my-template-with-unexpected-attributes',
     })
     expect(Swal.getImage().src).to.equal('https://sweetalert2.github.io/images/SweetAlert2.png')

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -15,15 +15,15 @@ import { addKeydownHandler, setFocus } from './keydown-handler.js'
 import { handlePopupClick } from './popup-click-handler.js'
 import { DismissReason } from '../utils/DismissReason.js'
 
-export function _main (userParams) {
-  showWarningsForParams(userParams)
+export function _main (userParams, mixinParams = {}) {
+  showWarningsForParams(Object.assign({}, mixinParams, userParams))
 
   if (globalState.currentInstance) {
     globalState.currentInstance._destroy()
   }
   globalState.currentInstance = this
 
-  const innerParams = prepareParams(userParams)
+  const innerParams = prepareParams(userParams, mixinParams)
   setParameters(innerParams)
   Object.freeze(innerParams)
 
@@ -45,11 +45,11 @@ export function _main (userParams) {
   return swalPromise(this, domCache, innerParams)
 }
 
-const prepareParams = (userParams) => {
-  const showClass = Object.assign({}, defaultParams.showClass, userParams.showClass)
-  const hideClass = Object.assign({}, defaultParams.hideClass, userParams.hideClass)
+const prepareParams = (userParams, mixinParams) => {
   const templateParams = getTemplateParams(userParams)
-  const params = Object.assign({}, defaultParams, userParams, templateParams)
+  const showClass = Object.assign({}, defaultParams.showClass, mixinParams.showClass, templateParams.showClass, userParams.showClass)
+  const hideClass = Object.assign({}, defaultParams.hideClass, mixinParams.hideClass, templateParams.hideClass, userParams.hideClass)
+  const params = Object.assign({}, defaultParams, mixinParams, templateParams, userParams) // precedence is described in #2131
   params.showClass = showClass
   params.hideClass = hideClass
   // @deprecated

--- a/src/staticMethods/mixin.js
+++ b/src/staticMethods/mixin.js
@@ -18,8 +18,8 @@
  */
 export function mixin (mixinParams) {
   class MixinSwal extends this {
-    _main (params) {
-      return super._main(Object.assign({}, mixinParams, params))
+    _main (params, prevMixinParams) {
+      return super._main(params, Object.assign({}, prevMixinParams, mixinParams))
     }
   }
 

--- a/test/qunit/params/template.js
+++ b/test/qunit/params/template.js
@@ -52,8 +52,10 @@ QUnit.test('template as string', (assert) => {
   template.id = 'my-template-string'
   template.innerHTML = '<swal-title>Are you sure?</swal-title>'
   document.body.appendChild(template)
-  SwalWithoutAnimation.fire({
+  const mixin = SwalWithoutAnimation.mixin({
     title: 'this title should be overriden by template',
+  })
+  mixin.fire({
     template: '#my-template-string',
   })
   assert.equal(Swal.getTitle().textContent, 'Are you sure?')
@@ -67,13 +69,15 @@ QUnit.test('should throw a warning when attempting to use unrecognized elements 
   template.innerHTML = `
     <swal-foo>bar</swal-foo>
     <swal-title value="hey!"></swal-title>
-    <swal-image src="https://sweetalert2.github.io/images/SweetAlert2.png" height="100" alt="" foo="1">Are you sure?</swal-image>
+    <swal-image src="https://sweetalert2.github.io/images/SweetAlert2.png" width="100" height="100" alt="" foo="1">Are you sure?</swal-image>
     <swal-input bar>Are you sure?</swal-input>
   `
   document.body.appendChild(template)
-  SwalWithoutAnimation.fire({
+  const mixin = SwalWithoutAnimation.mixin({
     imageAlt: 'this alt should be overriden by template',
-    imageWidth: 200,
+  })
+  mixin.fire({
+    imageWidth: 200, // user param should override <swal-image width="100">
     template: '#my-template-with-unexpected-attributes',
   })
   assert.equal(Swal.getImage().src, 'https://sweetalert2.github.io/images/SweetAlert2.png')


### PR DESCRIPTION
Fixes #2131 

Now params priority is:

1. User params, params passed to the `.fire()` method
2. Template params (from the `<template>` which was set in the `template` param)
3. Mixin params, params passed to `.mixin()`