### PR TITLE
customClass default value: undefined -> empty object

### DIFF
--- a/cypress/integration/params/template.spec.js
+++ b/cypress/integration/params/template.spec.js
@@ -14,6 +14,7 @@ describe('template', () => {
         <swal-input-option value="b">bb</swal-input-option>
       </swal-input>
       <swal-param name="inputAttributes" value='{ "hey": "there" }'></swal-param>
+      <swal-param name="customClass" value='{ "popup": "my-popup" }'></swal-param>
       <swal-param name="showConfirmButton" value="false"></swal-param>
       <swal-button type="deny" color="red">Denyyy</swal-button>
       <swal-button type="cancel" aria-label="no no">Nooo</swal-button>
@@ -23,9 +24,7 @@ describe('template', () => {
     SwalWithoutAnimation.fire({
       template: document.querySelector('#my-template'),
     })
-    expect(Swal.getTitle().textContent).to.equal('Are you sure?')
-    expect(isVisible(Swal.getCancelButton())).to.be.true
-
+    expect(Swal.getPopup().classList.contains('my-popup')).to.be.true
     expect(Swal.getTitle().textContent).to.equal('Are you sure?')
     expect(Swal.getImage().src).to.equal('https://sweetalert2.github.io/images/SweetAlert2.png')
     expect(Swal.getImage().style.width).to.equal('300px')

--- a/src/scss/_toasts.scss
+++ b/src/scss/_toasts.scss
@@ -88,7 +88,7 @@
     }
 
     .swal2-styled {
-      margin: 0 .3125em;
+      margin: .125em .3125em;
       padding: .3125em .625em;
       font-size: $swal2-toast-buttons-font-size;
 

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -22,7 +22,7 @@ export const defaultParams = {
     backdrop: 'swal2-backdrop-hide',
     icon: 'swal2-icon-hide',
   },
-  customClass: undefined,
+  customClass: {},
   target: 'body',
   backdrop: true,
   heightAuto: true,

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -678,7 +678,7 @@ declare module 'sweetalert2' {
      * })
      * ```
      *
-     * @default undefined
+     * @default {}
      */
     customClass?: SweetAlertCustomClass;
 

--- a/test/qunit/params/template.js
+++ b/test/qunit/params/template.js
@@ -14,6 +14,7 @@ QUnit.test('template as HTMLTemplateElement', (assert) => {
       <swal-input-option value="b">bb</swal-input-option>
     </swal-input>
     <swal-param name="inputAttributes" value='{ "hey": "there" }'></swal-param>
+    <swal-param name="customClass" value='{ "popup": "my-popup" }'></swal-param>
     <swal-param name="showConfirmButton" value="false"></swal-param>
     <swal-button type="deny" color="red">Denyyy</swal-button>
     <swal-button type="cancel" aria-label="no no">Nooo</swal-button>
@@ -23,6 +24,7 @@ QUnit.test('template as HTMLTemplateElement', (assert) => {
   SwalWithoutAnimation.fire({
     template: document.querySelector('#my-template'),
   })
+  assert.ok(Swal.getPopup().classList.contains('my-popup'))
   assert.equal(Swal.getTitle().textContent, 'Are you sure?')
   assert.equal(Swal.getImage().src, 'https://sweetalert2.github.io/images/SweetAlert2.png')
   assert.equal(Swal.getImage().style.width, '300px')


### PR DESCRIPTION
In order to parse `customClass` properly in `<swal-param name="customClass" value='{ "popup": "my-popup" }'></swal-param>` it should be `typeof 'object'`.

Connected to #2112

---

Also, a small CSS adjustment in toasts.

Before:

![image](https://user-images.githubusercontent.com/6059356/101993114-a4ba6b00-3cc0-11eb-9a2d-b07793021dc4.png)

After:

![image](https://user-images.githubusercontent.com/6059356/101993118-a97f1f00-3cc0-11eb-9a5b-9d5b003a8db7.png)
