### PR TITLE
fix: mixin params added later should take precedence over mixin params added earlier

### DIFF
--- a/src/staticMethods/mixin.js
+++ b/src/staticMethods/mixin.js
@@ -18,8 +18,8 @@
  */
 export function mixin (mixinParams) {
   class MixinSwal extends this {
-    _main (params, prevMixinParams) {
-      return super._main(params, Object.assign({}, prevMixinParams, mixinParams))
+    _main (params, priorityMixinParams) {
+      return super._main(params, Object.assign({}, mixinParams, priorityMixinParams))
     }
   }
 


### PR DESCRIPTION
Fixes #2174 

This is just a quick fix. It doesn't address the other issues introduced by #2133. I will leave some comments on that PR.