### PR TITLE
fix: mixin params added later should take precedence over mixin params added earlier 

### DIFF
--- a/cypress/integration/mixins.spec.js
+++ b/cypress/integration/mixins.spec.js
@@ -1,0 +1,43 @@
+import { Swal } from '../utils'
+
+describe('mixins', () => {
+  it('basic mixin', (done) => {
+    const MySwal = Swal.mixin({ title: '1_title' })
+    const swal = MySwal.fire({
+      didOpen: () => {
+        expect(MySwal.getTitle().textContent).to.equal('1_title')
+        MySwal.clickConfirm()
+      }
+    })
+    expect(swal instanceof MySwal).to.be.true
+    expect(swal instanceof Swal).to.be.true
+    swal.then((result) => {
+      expect(result).to.eql({
+        value: true,
+        isConfirmed: true,
+        isDenied: false,
+        isDismissed: false,
+      })
+      done()
+    })
+  })
+
+  it('mixins and shorthand calls', (done) => {
+    const MySwal = Swal.mixin({
+      title: 'no effect',
+      html: 'no effect',
+      didOpen: () => {
+        expect(MySwal.getTitle().textContent).to.equal('2_title')
+        expect(MySwal.getContent().textContent).to.equal('2_html')
+        MySwal.clickConfirm()
+        done()
+      }
+    })
+    MySwal.fire('2_title', '2_html')
+  })
+
+  it('mixins precedence', () => {
+    Swal.mixin({ title: '1' }).mixin({ title: '2' }).fire()
+    expect(Swal.getTitle().textContent).to.equal('2')
+  })
+})

--- a/src/staticMethods/mixin.js
+++ b/src/staticMethods/mixin.js
@@ -18,8 +18,8 @@
  */
 export function mixin (mixinParams) {
   class MixinSwal extends this {
-    _main (params, prevMixinParams) {
-      return super._main(params, Object.assign({}, prevMixinParams, mixinParams))
+    _main (params, priorityMixinParams) {
+      return super._main(params, Object.assign({}, mixinParams, priorityMixinParams))
     }
   }
 

--- a/test/qunit/api/mixins.js
+++ b/test/qunit/api/mixins.js
@@ -36,3 +36,8 @@ QUnit.test('mixins and shorthand calls', (assert) => {
   })
   MySwal.fire('2_title', '2_html')
 })
+
+QUnit.test('mixins precedence', (assert) => {
+  Swal.mixin({ title: '1' }).mixin({ title: '2' }).fire()
+  assert.equal(Swal.getTitle().textContent, '2')
+})


### PR DESCRIPTION
Fixes #2174 

The same as #2175 + tests (closes #2175)