### PR TITLE
Remove `display: none` from .swal2-validation-message

### DIFF
--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -496,8 +496,7 @@
 }
 
 .swal2-validation-message {
-  display: none;
-  align-items: center;
+  align-items: $swal2-validation-message-align-items;
   justify-content: $swal2-validation-message-justify-content;
   margin: $swal2-validation-message-margin;
   padding: $swal2-validation-message-padding;

--- a/src/utils/dom/renderers/renderPopup.js
+++ b/src/utils/dom/renderers/renderPopup.js
@@ -21,6 +21,8 @@ export const renderPopup = (instance, params) => {
     popup.style.background = params.background
   }
 
+  dom.hide(dom.getValidationMessage())
+
   // Classes
   addClasses(popup, params)
 }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -91,6 +91,7 @@ $swal2-input-label-margin: 1em auto !default;
 $swal2-input-label-justify-content: center !default;
 
 // VALIDATION MESSAGE
+$swal2-validation-message-align-items: center !default;
 $swal2-validation-message-justify-content: center !default;
 $swal2-validation-message-margin: 0 -2.7em !default;
 $swal2-validation-message-padding: .625em !default;


### PR DESCRIPTION
So `.swal2-validation-message` can be used for showing custom validation errors