### PR TITLE
Switch to CSS Grid Layout

### DIFF
--- a/src/globalState.js
+++ b/src/globalState.js
@@ -21,12 +21,12 @@ export const restoreActiveElement = (returnFocus) => {
     }
     const x = window.scrollX
     const y = window.scrollY
+
     globalState.restoreFocusTimeout = setTimeout(() => {
       focusPreviousActiveElement()
       resolve()
     }, RESTORE_FOCUS_TIMEOUT) // issues/900
-    if (typeof x !== 'undefined' && typeof y !== 'undefined') { // IE doesn't have scrollX/scrollY support
-      window.scrollTo(x, y)
-    }
+
+    window.scrollTo(x, y)
   })
 }

--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -155,12 +155,6 @@
       margin: auto;
     }
   }
-
-  @include ie {
-    .swal2-modal {
-      margin: 0 !important;
-    }
-  }
 }
 
 .swal2-popup {

--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -161,8 +161,6 @@
   display: none;
   position: relative;
   box-sizing: border-box;
-  flex-direction: column;
-  justify-content: center;
   width: $swal2-width;
   max-width: 100%;
   padding: $swal2-padding;
@@ -322,7 +320,7 @@
   position: $swal2-close-button-position;
   z-index: 2; // sweetalert2/issues/1617
   align-items: $swal2-close-button-align-items;
-  align-self: $swal2-close-button-align-self;
+  justify-self: $swal2-close-button-justify-self;
   justify-content: $swal2-close-button-justify-content;
   width: $swal2-close-button-width;
   height: $swal2-close-button-height;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,9 +1,3 @@
-@mixin ie {
-  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-    @content;
-  }
-}
-
 // https://stackoverflow.com/a/30250161
 @mixin not($ignor-list...) {
   @if (length($ignor-list) == 1) {

--- a/src/scss/_toasts.scss
+++ b/src/scss/_toasts.scss
@@ -66,10 +66,6 @@
         align-items: center;
         font-size: $swal2-toast-icon-font-size;
         font-weight: bold;
-
-        @include ie {
-          font-size: .25em;
-        }
       }
 
       &.swal2-success {

--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -78,7 +78,7 @@ const addClasses = (container, popup, params) => {
   dom.addClass(container, params.showClass.backdrop)
   // the workaround with setting/unsetting opacity is needed for #2019 and 2059
   popup.style.setProperty('opacity', '0', 'important')
-  dom.show(popup)
+  dom.show(popup, 'grid')
   setTimeout(() => {
     // Animate popup right after showing it
     dom.addClass(popup, params.showClass.popup)

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -130,7 +130,7 @@ $swal2-timer-progress-bar-height: .25em;
 $swal2-timer-progress-bar-background: rgba($swal2-black, .2) !default;
 
 // CLOSE BUTTON
-$swal2-close-button-align-self: flex-end !default;
+$swal2-close-button-justify-self: end !default;
 $swal2-close-button-align-items: center !default;
 $swal2-close-button-justify-content: center !default;
 $swal2-close-button-width: 1.2em !default;


### PR DESCRIPTION
Since the IE11 support is dropped, we're free to use CSS Grid Layout.

https://caniuse.com/css-grid

The reason is that CSS Grid Layout will give much more freedom for custom positioning of different parts, e.g. https://github.com/sweetalert2/sweetalert2/issues/2222