### PR TITLE
Switch to CSS Grid Layout

### DIFF
--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -161,8 +161,6 @@
   display: none;
   position: relative;
   box-sizing: border-box;
-  flex-direction: column;
-  justify-content: center;
   width: $swal2-width;
   max-width: 100%;
   padding: $swal2-padding;
@@ -322,7 +320,7 @@
   position: $swal2-close-button-position;
   z-index: 2; // sweetalert2/issues/1617
   align-items: $swal2-close-button-align-items;
-  align-self: $swal2-close-button-align-self;
+  justify-self: $swal2-close-button-justify-self;
   justify-content: $swal2-close-button-justify-content;
   width: $swal2-close-button-width;
   height: $swal2-close-button-height;

--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -78,7 +78,7 @@ const addClasses = (container, popup, params) => {
   dom.addClass(container, params.showClass.backdrop)
   // the workaround with setting/unsetting opacity is needed for #2019 and 2059
   popup.style.setProperty('opacity', '0', 'important')
-  dom.show(popup)
+  dom.show(popup, 'grid')
   setTimeout(() => {
     // Animate popup right after showing it
     dom.addClass(popup, params.showClass.popup)

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -119,8 +119,8 @@ $swal2-active-step-background: #2778c4 !default;
 $swal2-active-step-color: $swal2-white !default;
 
 // FOOTER
-$swal2-footer-margin: 0 !default;
-$swal2-footer-padding: 1em 0 !default;
+$swal2-footer-margin: 1em 0 0 !default;
+$swal2-footer-padding: 1em 0 0 !default;
 $swal2-footer-border-color: #eee !default;
 $swal2-footer-color: lighten($swal2-black, 33) !default;
 $swal2-footer-font-size: 1em !default;
@@ -130,7 +130,7 @@ $swal2-timer-progress-bar-height: .25em;
 $swal2-timer-progress-bar-background: rgba($swal2-black, .2) !default;
 
 // CLOSE BUTTON
-$swal2-close-button-align-self: flex-end !default;
+$swal2-close-button-justify-self: end !default;
 $swal2-close-button-align-items: center !default;
 $swal2-close-button-justify-content: center !default;
 $swal2-close-button-width: 1.2em !default;


### PR DESCRIPTION
Since the IE11 support is dropped, we're free to use CSS Grid Layout.

https://caniuse.com/css-grid

The reason is that CSS Grid Layout will give much more freedom for custom positioning of different parts, e.g. https://github.com/sweetalert2/sweetalert2/issues/2222