### PR TITLE
Fix overflowing children of html-container

### DIFF
--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -138,6 +138,7 @@
   display: none;
   position: relative;
   box-sizing: border-box;
+  grid-template-columns: minmax(0, 100%);
   width: $swal2-width;
   max-width: 100%;
   padding: $swal2-padding;
@@ -357,6 +358,7 @@
   justify-content: $swal2-html-container-justify-content;
   margin: $swal2-html-container-margin;
   padding: $swal2-html-container-padding;
+  overflow: $swal2-html-container-overflow;
   color: $swal2-html-container-color;
   font-size: $swal2-html-container-font-size;
   font-weight: $swal2-html-container-font-weight;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -58,8 +58,9 @@ $swal2-title-text-align: center !default;
 
 // HTML CONTAINER
 $swal2-html-container-justify-content: center !default;
-$swal2-html-container-margin: 0 !default;
-$swal2-html-container-padding: 1em 1.6em .3em !default;
+$swal2-html-container-margin: 1em 1.6em .3em !default;
+$swal2-html-container-padding: 0 !default;
+$swal2-html-container-overflow: auto !default;
 $swal2-html-container-color: lighten($swal2-black, 33) !default;
 $swal2-html-container-font-size: 1.125em !default;
 $swal2-html-container-font-weight: normal !default;


### PR DESCRIPTION
```js
Swal.fire({
  html: `<div style="width: 600px; border: 3px solid green; background: lightgreen; padding: 30px;">
    I am wider than my container
  </div>`,
})
```

### Before

<img width="723" alt="CleanShot 2021-07-24 at 00 23 23@2x" src="https://user-images.githubusercontent.com/6059356/126842922-f3bd3968-60dc-43ee-bb29-2afa5ded2965.png">


### After

![CleanShot 2021-07-24 at 00 22 56](https://user-images.githubusercontent.com/6059356/126842933-4ef49947-6a25-43e1-a1aa-cb0aac3be333.gif)
