### PR TITLE
Shadow DOM support

### DIFF
--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -122,6 +122,17 @@ describe('Accessibility:', () => {
     expect(Swal.getPopup().getAttribute('aria-live')).to.equal('polite')
     expect(Swal.getPopup().getAttribute('aria-modal')).to.be.null
   })
+
+  it('should set toast ARIA attributes inside Shadow DOM', () => {
+    const container = document.createElement('test-container')
+    container.attachShadow({ mode: 'open' })
+    document.body.appendChild(container)
+    Swal.fire({ target: container.shadowRoot, title: 'Toast', toast: true })
+    expect(container.shadowRoot.contains(Swal.getPopup())).to.be.true
+    expect(Swal.getPopup().getAttribute('role')).to.equal('alert')
+    expect(Swal.getPopup().getAttribute('aria-live')).to.equal('polite')
+    expect(Swal.getPopup().getAttribute('aria-modal')).to.be.null
+  })
 })
 
 describe('should trap focus in modals', () => {

--- a/src/utils/dom/getters.js
+++ b/src/utils/dom/getters.js
@@ -2,9 +2,9 @@ import { swalClasses } from '../classes.js'
 import { uniqueArray, toArray } from '../utils.js'
 import { isVisible } from './domUtils.js'
 
-let target = document.body;
+let target = document.body
 export const setTarget = (targetElement) => {
-  target = targetElement;
+  target = targetElement
 }
 
 export const getContainer = () => target.querySelector(`.${swalClasses.container}`)

--- a/src/utils/dom/getters.js
+++ b/src/utils/dom/getters.js
@@ -2,7 +2,12 @@ import { swalClasses } from '../classes.js'
 import { uniqueArray, toArray } from '../utils.js'
 import { isVisible } from './domUtils.js'
 
-export const getContainer = () => document.body.querySelector(`.${swalClasses.container}`)
+let target = document.body;
+export const setTarget = (targetElement) => {
+  target = targetElement;
+}
+
+export const getContainer = () => target.querySelector(`.${swalClasses.container}`)
 
 export const elementBySelector = (selectorString) => {
   const container = getContainer()

--- a/src/utils/dom/init.js
+++ b/src/utils/dom/init.js
@@ -1,5 +1,5 @@
 import { swalClasses } from '../classes.js'
-import { getContainer, getPopup } from './getters.js'
+import { getContainer, getPopup, setTarget } from './getters.js'
 import { addClass, removeClass, getChildByClass, setInnerHtml } from './domUtils.js'
 import { isNodeEnv } from '../isNodeEnv.js'
 import { error } from '../utils.js'
@@ -106,7 +106,7 @@ const setupAccessibility = (params) => {
 }
 
 const setupRTL = (targetElement) => {
-  if (window.getComputedStyle(targetElement).direction === 'rtl') {
+  if (window.getComputedStyle(targetElement.host || targetElement).direction === 'rtl') {
     addClass(getContainer(), swalClasses.rtl)
   }
 }
@@ -132,6 +132,7 @@ export const init = (params) => {
   setInnerHtml(container, sweetHTML)
 
   const targetElement = getTarget(params.target)
+  setTarget(targetElement)
   targetElement.appendChild(container)
 
   setupAccessibility(params)

--- a/src/utils/dom/init.js
+++ b/src/utils/dom/init.js
@@ -117,7 +117,7 @@ const setupRTL = (targetElement) => {
 export const init = (params) => {
   const targetElement = getTarget(params.target)
   setTarget(targetElement)
-  
+
   // Clean up the old popup container if it exists
   const oldContainerExisted = resetOldContainer()
 

--- a/src/utils/dom/init.js
+++ b/src/utils/dom/init.js
@@ -115,6 +115,9 @@ const setupRTL = (targetElement) => {
  * Add modal + backdrop to DOM
  */
 export const init = (params) => {
+  const targetElement = getTarget(params.target)
+  setTarget(targetElement)
+  
   // Clean up the old popup container if it exists
   const oldContainerExisted = resetOldContainer()
 
@@ -131,8 +134,6 @@ export const init = (params) => {
   }
   setInnerHtml(container, sweetHTML)
 
-  const targetElement = getTarget(params.target)
-  setTarget(targetElement)
   targetElement.appendChild(container)
 
   setupAccessibility(params)


### PR DESCRIPTION
There is a `target` parameter but this is not queried when getting descendants, the body is always queried. So if a shadow root is given as the `target`, the container would not be found (using `document.body.querySelector`) and therefore everything would fail.

(I use shadow DOM as part of a browser extension which injects elements into third-party pages.)

This PR adds shadow DOM support and includes a little test.