### PR TITLE
preConfirm & preDeny promise rejections rejects the main Swal.fire promise

### DIFF
--- a/cypress/integration/params/preConfirm.spec.js
+++ b/cypress/integration/params/preConfirm.spec.js
@@ -40,4 +40,22 @@ describe('preConfirm', () => {
       done()
     })
   })
+
+  it('preConfirm promise is rejected', (done) => {
+    let thenTriggered = false
+    const errorMsg = 'message1'
+    SwalWithoutAnimation.fire({
+      preConfirm: () => {
+        return Promise.reject(new Error(errorMsg))
+      },
+    }).then(() => {
+      thenTriggered = true
+    }).catch(result => {
+      expect(thenTriggered).to.equal(false)
+      expect(result.message).to.equal(errorMsg)
+      done()
+    })
+    Swal.clickConfirm()
+    expect(Swal.isVisible()).to.be.true
+  })
 })

--- a/cypress/integration/params/preDeny.spec.js
+++ b/cypress/integration/params/preDeny.spec.js
@@ -50,4 +50,22 @@ describe('preDeny', () => {
       done()
     })
   })
+
+  it('preDeny promise is rejected', (done) => {
+    let thenTriggered = false
+    const errorMsg = 'message1'
+    SwalWithoutAnimation.fire({
+      preDeny: () => {
+        return Promise.reject(new Error(errorMsg))
+      },
+    }).then(() => {
+      thenTriggered = true
+    }).catch(result => {
+      expect(thenTriggered).to.equal(false)
+      expect(result.message).to.equal(errorMsg)
+      done()
+    })
+    Swal.clickDeny()
+    expect(Swal.isVisible()).to.be.true
+  })
 })

--- a/src/instanceMethods/_main.js
+++ b/src/instanceMethods/_main.js
@@ -61,13 +61,14 @@ const prepareParams = (userParams, mixinParams) => {
 }
 
 const swalPromise = (instance, domCache, innerParams) => {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     // functions to handle all closings/dismissals
     const dismissWith = (dismiss) => {
       instance.closePopup({ isDismissed: true, dismiss })
     }
 
     privateMethods.swalPromiseResolve.set(instance, resolve)
+    privateMethods.swalPromiseReject.set(instance, reject)
 
     domCache.confirmButton.onclick = () => handleConfirmButtonClick(instance, innerParams)
     domCache.denyButton.onclick = () => handleDenyButtonClick(instance, innerParams)

--- a/src/instanceMethods/buttons-handlers.js
+++ b/src/instanceMethods/buttons-handlers.js
@@ -68,7 +68,7 @@ const deny = (instance, innerParams, value) => {
   if (innerParams.preDeny) {
     const preDenyPromise = Promise.resolve().then(() => asPromise(
       innerParams.preDeny(value, innerParams.validationMessage))
-    )
+    ).catch((error) => instance.rejectPopup(error))
     preDenyPromise.then(
       (preDenyValue) => {
         if (preDenyValue === false) {
@@ -96,7 +96,7 @@ const confirm = (instance, innerParams, value) => {
     instance.resetValidationMessage()
     const preConfirmPromise = Promise.resolve().then(() => asPromise(
       innerParams.preConfirm(value, innerParams.validationMessage))
-    )
+    ).catch((error) => instance.rejectPopup(error))
     preConfirmPromise.then(
       (preConfirmValue) => {
         if (isVisible(getValidationMessage()) || preConfirmValue === false) {

--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -75,6 +75,13 @@ export function close (resolveValue) {
   swalPromiseResolve(resolveValue)
 }
 
+export function reject (error) {
+  const swalPromiseReject = privateMethods.swalPromiseReject.get(this)
+
+  // Reject Swal promise
+  swalPromiseReject(error)
+}
+
 const prepareResolveValue = (resolveValue) => {
   // When user calls Swal.close()
   if (typeof resolveValue === 'undefined') {
@@ -140,6 +147,9 @@ const triggerDidCloseAndDispose = (instance, didClose) => {
 }
 
 export {
+  reject as rejectPopup,
+  reject as rejectModal,
+  reject as rejectToast,
   close as closePopup,
   close as closeModal,
   close as closeToast

--- a/src/privateMethods.js
+++ b/src/privateMethods.js
@@ -9,5 +9,6 @@
  */
 
 export default {
-  swalPromiseResolve: new WeakMap()
+  swalPromiseResolve: new WeakMap(),
+  swalPromiseReject: new WeakMap()
 }

--- a/test/require-in-node.js
+++ b/test/require-in-node.js
@@ -1,2 +1,2 @@
-require('../dist/sweetalert2')
-require('../dist/sweetalert2.all')
+require('../dist/sweetalert2.js')
+require('../dist/sweetalert2.all.js')


### PR DESCRIPTION
PR Proposition that follows https://github.com/sweetalert2/sweetalert2/issues/2333 

- Add a new feature/bug fix that allows the main promise returned by `Swal.fire` to be rejected when either `preDeny` or `preConfirm` gets rejected.
- Add 2 new tests to assure that the rejection works


