### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/instanceMethods/_destroy.js
+++ b/src/instanceMethods/_destroy.js
@@ -41,7 +41,7 @@ const disposeSwal = (instance) => {
 }
 
 const disposeWeakMaps = (instance) => {
-  // If the current instance is awaiting a promise result, we keep the privateMethods to call them once the promise result is retreived #2335
+  // If the current instance is awaiting a promise result, we keep the privateMethods to call them once the promise result is retrieved #2335
   if (instance.isAwaitingPromise()) {
     unsetWeakMaps(privateProps, instance)
     privateProps.awaitingPromise.set(instance, true)

--- a/src/privateMethods.js
+++ b/src/privateMethods.js
@@ -1,5 +1,5 @@
 /**
- * This module containts `WeakMap`s for each effectively-"private  property" that a `Swal` has.
+ * This module contains `WeakMap`s for each effectively-"private  property" that a `Swal` has.
  * For example, to set the private property "foo" of `this` to "bar", you can `privateProps.foo.set(this, 'bar')`
  * This is the approach that Babel will probably take to implement private methods/fields
  *   https://github.com/tc39/proposal-private-methods

--- a/src/privateProps.js
+++ b/src/privateProps.js
@@ -1,5 +1,5 @@
 /**
- * This module containts `WeakMap`s for each effectively-"private  property" that a `Swal` has.
+ * This module contains `WeakMap`s for each effectively-"private  property" that a `Swal` has.
  * For example, to set the private property "foo" of `this` to "bar", you can `privateProps.foo.set(this, 'bar')`
  * This is the approach that Babel will probably take to implement private methods/fields
  *   https://github.com/tc39/proposal-private-methods


### PR DESCRIPTION
There are small typos in:
- src/instanceMethods/_destroy.js
- src/privateMethods.js
- src/privateProps.js

Fixes:
- Should read `contains` rather than `containts`.
- Should read `retrieved` rather than `retreived`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md