### PR TITLE
Improve buttons contrast ratio to 4.5

### DIFF
--- a/src/variables.scss
+++ b/src/variables.scss
@@ -187,7 +187,7 @@ $swal2-button-focus-box-shadow: 0 0 0 3px $swal2-outline-color !default;
 $swal2-confirm-button-order: null !default;
 $swal2-confirm-button-border: 0 !default;
 $swal2-confirm-button-border-radius: .25em !default;
-$swal2-confirm-button-background-color: #7367f0 !default;
+$swal2-confirm-button-background-color: #7066e0 !default;
 $swal2-confirm-button-color: $swal2-white !default;
 $swal2-confirm-button-font-size: 1em !default;
 $swal2-confirm-button-focus-box-shadow: 0 0 0 3px rgba($swal2-confirm-button-background-color, .5) !default;
@@ -196,7 +196,7 @@ $swal2-confirm-button-focus-box-shadow: 0 0 0 3px rgba($swal2-confirm-button-bac
 $swal2-deny-button-order: null !default;
 $swal2-deny-button-border: 0 !default;
 $swal2-deny-button-border-radius: .25em !default;
-$swal2-deny-button-background-color: #ea5455 !default;
+$swal2-deny-button-background-color: #dc3741 !default;
 $swal2-deny-button-color: $swal2-white !default;
 $swal2-deny-button-font-size: 1em !default;
 $swal2-deny-button-focus-box-shadow: 0 0 0 3px rgba($swal2-deny-button-background-color, .5) !default;
@@ -205,7 +205,7 @@ $swal2-deny-button-focus-box-shadow: 0 0 0 3px rgba($swal2-deny-button-backgroun
 $swal2-cancel-button-order: null !default;
 $swal2-cancel-button-border: 0 !default;
 $swal2-cancel-button-border-radius: .25em !default;
-$swal2-cancel-button-background-color: #6e7d88 !default;
+$swal2-cancel-button-background-color: #6e7881 !default;
 $swal2-cancel-button-color: $swal2-white !default;
 $swal2-cancel-button-font-size: 1em !default;
 $swal2-cancel-button-focus-box-shadow: 0 0 0 3px rgba($swal2-cancel-button-background-color, .5) !default;


### PR DESCRIPTION
close #2354 

Before:

<img width="522" alt="CleanShot 2021-11-25 at 13 49 20@2x" src="https://user-images.githubusercontent.com/6059356/143436562-41beb856-dd0e-451b-9896-614354790e10.png">

After:

<img width="521" alt="CleanShot 2021-11-25 at 13 48 47@2x" src="https://user-images.githubusercontent.com/6059356/143436470-21bfd4c5-0512-4f8e-b30b-c9f146c78145.png">
