### PR TITLE
Fix `allowEnterKey` when `input` is set

### DIFF
--- a/src/keydown-handler.js
+++ b/src/keydown-handler.js
@@ -79,8 +79,8 @@ const keydownHandler = (instance, e, dismissWith) => {
 }
 
 const handleEnter = (instance, e, innerParams) => {
-  // #720 #721
-  if (e.isComposing) {
+  // #2386 #720 #721
+  if (!callIfFunction(innerParams.allowEnterKey) || e.isComposing) {
     return
   }
 


### PR DESCRIPTION
Fixes #2386 