### PR TITLE
Auto-import styles in Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "A beautiful, responsive, customizable and accessible (WAI-ARIA) replacement for JavaScript's popup boxes, supported fork of sweetalert",
   "main": "dist/sweetalert2.all.js",
   "browser": "dist/sweetalert2.all.js",
-  "module": "src/sweetalert2.js",
+  "module": "dist/sweetalert2.all.js",
   "types": "sweetalert2.d.ts",
   "devDependencies": {
     "@babel/core": "^7.18.2",


### PR DESCRIPTION
Vite is using the `"module"` field and since it's getting quite a popular tool, it'd make sense to ship the best possible support for it.