### PR TITLE
fix: video/audio tags in Safari

### DIFF
--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -141,6 +141,7 @@ describe('Miscellaneous tests', function () {
     expect(Swal.getTitle().querySelectorAll('strong, em').length).to.equal(2)
     expect(Swal.getHtmlContainer().querySelectorAll('style, p, img, button').length).to.equal(4)
     expect(Swal.getHtmlContainer().querySelector('button').style.width).to.equal('10px')
+    expect(window.getComputedStyle(Swal.getHtmlContainer().querySelector('p')).fontSize).to.equal('10px')
   })
 
   it('content/title is set (text)', () => {

--- a/src/utils/dom/domUtils.js
+++ b/src/utils/dom/domUtils.js
@@ -23,7 +23,11 @@ export const setInnerHtml = (elem, html) => {
       elem.appendChild(child)
     })
     Array.from(parsed.querySelector('body').childNodes).forEach((child) => {
-      elem.appendChild(child)
+      if (child instanceof HTMLVideoElement || child instanceof HTMLAudioElement) {
+        elem.appendChild(child.cloneNode(true)) // https://github.com/sweetalert2/sweetalert2/issues/2507
+      } else {
+        elem.appendChild(child)
+      }
     })
   }
 }


### PR DESCRIPTION
fixes #2507 