### PR TITLE
Add ability to pass function as a template param

### DIFF
--- a/cypress/e2e/params/template.cy.js
+++ b/cypress/e2e/params/template.cy.js
@@ -72,6 +72,29 @@ describe('template', () => {
     expect(Swal.getTitle().textContent).to.equal('Are you sure?')
   })
 
+  it('swal-function-param', (done) => {
+    const _consoleLog = console.log // eslint-disable-line no-console
+    const spy = cy.spy(console, 'log')
+    const template = document.createElement('template')
+    template.id = 'my-template-functon-param'
+    const didOpen = (modal) => {
+      console.log(modal.querySelector('.swal2-title').innerText) // eslint-disable-line no-console
+    }
+    template.innerHTML = `
+      <swal-title>Function param</swal-title>
+      <swal-function-param name="didOpen" value="${didOpen}"></swal-function-param>
+    `
+    document.body.appendChild(template)
+    SwalWithoutAnimation.fire({
+      template: '#my-template-functon-param',
+    })
+    setTimeout(() => {
+      expect(spy.calledWith('Function param')).to.be.true
+      console.log = _consoleLog // eslint-disable-line no-console
+      done()
+    })
+  })
+
   it('should throw a warning when attempting to use unrecognized elements and attributes', () => {
     const spy = cy.spy(console, 'warn')
     const template = document.createElement('template')

--- a/src/utils/getTemplateParams.js
+++ b/src/utils/getTemplateParams.js
@@ -20,6 +20,7 @@ export const getTemplateParams = (params) => {
 
   const result = Object.assign(
     getSwalParams(templateContent),
+    getSwalFunctionParams(templateContent),
     getSwalButtons(templateContent),
     getSwalImage(templateContent),
     getSwalIcon(templateContent),
@@ -48,6 +49,22 @@ const getSwalParams = (templateContent) => {
     } else {
       result[paramName] = value
     }
+  })
+  return result
+}
+
+/**
+ * @param {DocumentFragment} templateContent
+ * @returns {SweetAlertOptions}
+ */
+const getSwalFunctionParams = (templateContent) => {
+  const result = {}
+  /** @type {HTMLElement[]} */
+  const swalFunctions = Array.from(templateContent.querySelectorAll('swal-function-param'))
+  swalFunctions.forEach((param) => {
+    const paramName = param.getAttribute('name')
+    const value = param.getAttribute('value')
+    result[paramName] = new Function(`return ${value}`)()
   })
   return result
 }
@@ -186,6 +203,7 @@ const getSwalStringParams = (templateContent, paramNames) => {
 const showWarningsForElements = (templateContent) => {
   const allowedElements = swalStringParams.concat([
     'swal-param',
+    'swal-function-param',
     'swal-button',
     'swal-image',
     'swal-icon',


### PR DESCRIPTION
closes #2518

here's how it'll work:

```html
<template id="my-swal">
  <swal-title>Function param</swal-title>
  <swal-param name="input" value="text"></swal-param>
  <swal-function-param name="didOpen" value="modal => console.log(modal)"></swal-function-param>
</template>
```