### PR TITLE
fix: scrolling page in the background on iOS (#1956)

### DIFF
--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -15,6 +15,7 @@
     'bottom-start  bottom-center  bottom-end';
   grid-template-rows: minmax(min-content, auto) minmax(min-content, auto) minmax(min-content, auto);
   height: 100%; // Safari
+  overscroll-behavior: none; // Safari - ensure page can't be scrolled in the background
   padding: $swal2-container-padding;
   overflow-x: hidden;
   transition: $swal2-backdrop-transition;


### PR DESCRIPTION
This pull request fixes a bug where you could scroll the background (page) when you reached the end of the alert.
Closes #1956