### PR TITLE
fix: should not throw console warning for `{ allowOutsideClick: true }` since default value of `backdrop` is `true`

### DIFF
--- a/cypress/e2e/params/allowOutsideClick.cy.js
+++ b/cypress/e2e/params/allowOutsideClick.cy.js
@@ -47,6 +47,14 @@ describe('allowOutsideClick', () => {
     ).to.be.true
   })
 
+  it('should not throw console warning for { allowOutsideClick: true }', () => {
+    const spy = cy.spy(console, 'warn')
+    SwalWithoutAnimation.fire({
+      allowOutsideClick: true,
+    })
+    expect(spy.notCalled).to.be.true
+  })
+
   it('should not throw console warning for { backdrop: false }', () => {
     const spy = cy.spy(console, 'warn')
     SwalWithoutAnimation.fire({

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -213,7 +213,7 @@ const checkIfParamIsDeprecated = (param) => {
  * @param {SweetAlertOptions} params
  */
 export const showWarningsForParams = (params) => {
-  if (!params.backdrop && params.allowOutsideClick) {
+  if (!(params.backdrop ?? defaultParams.backdrop) && params.allowOutsideClick) {
     warn('"allowOutsideClick" parameter requires `backdrop` parameter to be set to `true`')
   }
 


### PR DESCRIPTION
`npm run cypress:open` passing.