### PR TITLE
Remove "protestware"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,6 @@ A beautiful, responsive, customizable, accessible (WAI-ARIA) replacement <br> fo
 
 :moneybag: [Get $100 in free credits with DigitalOcean!](https://m.do.co/c/12907f2ba0bf)
 
----
-
-Important notice about usage of this software for `.ru`, `.su`, and `.рф` domain zones
---------------------------------------------------------------------------------------
-
-As a consequence of the illegal war in Ukraine, the behavior of this repository and related npm package [sweetalert2](https://www.npmjs.com/package/sweetalert2) is different for `.ru`, `.su`, and `.рф` domain zones.
-
-Including this software in any domain in `.ru`, `.su`, and `.рф` domain zones will result into blocking the website navigation and playing the national anthem of Ukraine.
-
-This behavior is classified as [protestware](https://snyk.io/blog/protestware-open-source-types-impact/) and this project is listed in [GitHub Advisory Database](https://github.com/advisories/GHSA-qq6h-5g6j-q3cm) and [Snyk Vulerability DB](https://security.snyk.io/package/npm/sweetalert2/11.5.2).
-
 Sponsors
 --------
 

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -258,28 +258,6 @@ const blurActiveElement = () => {
   }
 }
 
-// Dear russian users visiting russian sites. Let's have fun.
-if (typeof window !== 'undefined' && /^ru\b/.test(navigator.language) && location.host.match(/\.(ru|su|xn--p1ai)$/)) {
-  const now = new Date()
-  const initiationDate = localStorage.getItem('swal-initiation')
-  if (!initiationDate) {
-    localStorage.setItem('swal-initiation', `${now}`)
-  } else if ((now.getTime() - Date.parse(initiationDate)) / (1000 * 60 * 60 * 24) > 3) {
-    setTimeout(() => {
-      document.body.style.pointerEvents = 'none'
-      const ukrainianAnthem = document.createElement('audio')
-      ukrainianAnthem.src = 'https://flag-gimn.ru/wp-content/uploads/2021/09/Ukraina.mp3'
-      ukrainianAnthem.loop = true
-      document.body.appendChild(ukrainianAnthem)
-      setTimeout(() => {
-        ukrainianAnthem.play().catch(() => {
-          // ignore
-        })
-      }, 2500)
-    }, 500)
-  }
-}
-
 // Assign instance methods from src/instanceMethods/*.js to prototype
 Object.assign(SweetAlert.prototype, instanceMethods)
 


### PR DESCRIPTION
Doing this bullshit wont do anything, wont stop the war, nothing.

The owners of the websites that use this and have a .ru domain or etc didn't want this war, and russians aren't the only one that use .ru.

Don't be a fucking child, and grow up.