### PR TITLE
fix: styles specificity

### DIFF
--- a/cypress/e2e/styling.cy.js
+++ b/cypress/e2e/styling.cy.js
@@ -1,0 +1,111 @@
+/// <reference types="cypress" />
+
+import { Swal } from '../utils'
+
+describe('Styling', () => {
+  it('overriding styles with customClass', (done) => {
+    const style = document.createElement('style')
+    style.textContent = `
+      .my-container {
+        z-index: 9999;
+      }
+      .my-popup {
+        width: 500px;
+      }
+      .my-title {
+        font-size: 10px;
+      }
+      .my-close-button {
+        font-size: 11px;
+      }
+      .my-icon {
+        width: 12px;
+      }
+      .my-image {
+        max-width: 13px;
+      }
+      .my-input {
+        font-size: 14px;
+      }
+      .my-input-label {
+        margin: 0;
+      }
+      .my-validation-message {
+        padding: 0;
+      }
+      .my-actions {
+        padding: 1px;
+      }
+      .my-confirm-button {
+        padding: 2px;
+      }
+      .my-deny-button {
+        padding: 3px;
+      }
+      .my-cancel-button {
+        padding: 4px;
+      }
+      .my-loader {
+        border-width: 7px;
+      }
+      .my-footer {
+        padding: 8px;
+      }
+      .my-timer-progress-bar {
+        height: 9px;
+      }
+    `
+    document.head.prepend(style)
+    Swal.fire({
+      title: 'title',
+      icon: 'success',
+      imageUrl: '/assets/swal2-logo.png',
+      input: 'text',
+      inputLabel: 'inputLabel',
+      showDenyButton: true,
+      showCancelButton: true,
+      footer: 'footer',
+      timer: 1000,
+      timerProgressBar: true,
+      customClass: {
+        container: 'my-container',
+        popup: 'my-popup',
+        title: 'my-title',
+        closeButton: 'my-close-button',
+        icon: 'my-icon',
+        image: 'my-image',
+        input: 'my-input',
+        inputLabel: 'my-input-label',
+        validationMessage: 'my-validation-message',
+        actions: 'my-actions',
+        confirmButton: 'my-confirm-button',
+        denyButton: 'my-deny-button',
+        cancelButton: 'my-cancel-button',
+        loader: 'my-loader',
+        footer: 'my-footer',
+        timerProgressBar: 'my-timer-progress-bar',
+      },
+      didOpen: () => {
+        expect(window.getComputedStyle(Swal.getContainer()).zIndex).to.equal('9999')
+        expect(window.getComputedStyle(Swal.getPopup()).width).to.equal('500px')
+        expect(window.getComputedStyle(Swal.getTitle()).fontSize).to.equal('10px')
+        expect(window.getComputedStyle(Swal.getCloseButton()).fontSize).to.equal('11px')
+        expect(window.getComputedStyle(Swal.getIcon()).width).to.equal('12px')
+        expect(window.getComputedStyle(Swal.getImage()).maxWidth).to.equal('13px')
+        expect(window.getComputedStyle(Swal.getInput()).fontSize).to.equal('14px')
+        expect(window.getComputedStyle(Swal.getInputLabel()).margin).to.equal('0px')
+        Swal.showValidationMessage('validationMessage')
+        expect(window.getComputedStyle(Swal.getValidationMessage()).padding).to.equal('0px')
+        expect(window.getComputedStyle(Swal.getActions()).padding).to.equal('1px')
+        expect(window.getComputedStyle(Swal.getConfirmButton()).padding).to.equal('2px')
+        expect(window.getComputedStyle(Swal.getDenyButton()).padding).to.equal('3px')
+        expect(window.getComputedStyle(Swal.getCancelButton()).padding).to.equal('4px')
+        Swal.showLoading()
+        expect(window.getComputedStyle(Swal.getLoader()).borderWidth).to.equal('7px')
+        expect(window.getComputedStyle(Swal.getFooter()).padding).to.equal('8px')
+        expect(window.getComputedStyle(Swal.getTimerProgressBar()).height).to.equal('9px')
+        done()
+      },
+    })
+  })
+})

--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -1,6 +1,6 @@
 @use 'sass:math';
 
-.swal2-container {
+:where(.swal2-container) {
   display: grid;
   position: fixed;
   z-index: 1060;
@@ -123,7 +123,7 @@
   }
 }
 
-.swal2-popup {
+:where(.swal2-popup) {
   display: none;
   position: relative;
   box-sizing: border-box;
@@ -147,7 +147,7 @@
   }
 }
 
-.swal2-title {
+:where(.swal2-title) {
   position: $swal2-title-position;
   max-width: $swal2-title-max-width;
   margin: $swal2-title-margin;
@@ -160,7 +160,7 @@
   word-wrap: break-word;
 }
 
-.swal2-actions {
+:where(.swal2-actions) {
   display: flex;
   z-index: 1; // prevent success icon from overlapping buttons
   box-sizing: border-box;
@@ -188,7 +188,7 @@
   }
 }
 
-.swal2-loader {
+:where(.swal2-loader) {
   display: none;
   align-items: $swal2-loader-align-items;
   justify-content: $swal2-loader-justify-content;
@@ -202,7 +202,7 @@
   border-color: $swal2-loader-border-color;
 }
 
-.swal2-styled {
+:where(.swal2-styled) {
   margin: $swal2-button-margin;
   padding: $swal2-button-padding;
   transition: $swal2-button-transition;
@@ -270,7 +270,7 @@
   }
 }
 
-.swal2-footer {
+:where(.swal2-footer) {
   justify-content: center;
   margin: $swal2-footer-margin;
   padding: $swal2-footer-padding;
@@ -290,18 +290,18 @@
   border-bottom-left-radius: $swal2-border-radius;
 }
 
-.swal2-timer-progress-bar {
+:where(.swal2-timer-progress-bar) {
   width: 100%;
   height: $swal2-timer-progress-bar-height;
   background: $swal2-timer-progress-bar-background;
 }
 
-.swal2-image {
+:where(.swal2-image) {
   max-width: 100%;
   margin: $swal2-image-margin;
 }
 
-.swal2-close {
+:where(.swal2-close) {
   position: $swal2-close-button-position;
   z-index: 2; // sweetalert2/issues/1617
   align-items: $swal2-close-button-align-items;
@@ -355,18 +355,18 @@
   word-break: $swal2-html-container-word-break;
 }
 
-.swal2-input,
-.swal2-file,
-.swal2-textarea,
-.swal2-select,
-.swal2-radio,
-.swal2-checkbox {
+:where(.swal2-input),
+:where(.swal2-file),
+:where(.swal2-textarea),
+:where(.swal2-select),
+:where(.swal2-radio),
+:where(.swal2-checkbox) {
   margin: $swal2-input-margin;
 }
 
-.swal2-input,
-.swal2-file,
-.swal2-textarea {
+:where(.swal2-input),
+:where(.swal2-file),
+:where(.swal2-textarea) {
   box-sizing: border-box;
   width: $swal2-input-width;
   transition: $swal2-input-transition;
@@ -462,13 +462,13 @@
   }
 }
 
-.swal2-input-label {
+:where(.swal2-input-label) {
   display: flex;
   justify-content: $swal2-input-label-justify-content;
   margin: $swal2-input-label-margin;
 }
 
-.swal2-validation-message {
+:where(.swal2-validation-message) {
   align-items: $swal2-validation-message-align-items;
   justify-content: $swal2-validation-message-justify-content;
   margin: $swal2-validation-message-margin;
@@ -502,7 +502,7 @@
 }
 $icon-zoom: math.div(strip-units($swal2-icon-size), 5);
 
-.swal2-icon {
+:where(.swal2-icon) {
   position: relative;
   box-sizing: content-box;
   justify-content: center;


### PR DESCRIPTION
`:where` will reset CSS specificity to 0 and allow users to override styles without using `!important`. Learnt that from amazing @kevin-powell 🙌  

Video tutorial: https://www.youtube.com/watch?v=3ncFpP8GP4g

before | after
-|-
![CleanShot 2023-05-30 at 14 40 58@2x](https://github.com/sweetalert2/sweetalert2/assets/6059356/e3fa4668-6d91-4149-8b98-9a5a013b259b) | ![CleanShot 2023-05-30 at 14 40 15@2x](https://github.com/sweetalert2/sweetalert2/assets/6059356/559f2003-0efb-4baf-af84-4353b9680e8a)

fixes #2626
