### PR TITLE
fix: when resizing textarea take params.width into consideration

### DIFF
--- a/cypress/e2e/inputs.cy.js
+++ b/cypress/e2e/inputs.cy.js
@@ -371,6 +371,23 @@ describe('Inputs', () => {
     })
   })
 
+  it('popup should keep the custom width when textarea value is a promise', (done) => {
+    SwalWithoutAnimation.fire({
+      input: 'textarea',
+      width: 600,
+      inputValue: new Promise((resolve) => {
+        setTimeout(() => {
+          resolve('foo')
+        }, 10)
+      }),
+    })
+    setTimeout(() => {
+      expect(Swal.getInput().value).to.equal('foo')
+      expect(Swal.getPopup().style.width).to.equal('600px')
+      done()
+    }, 20)
+  })
+
   it('returnInputValueOnDeny: true should pass the input value as result.value', (done) => {
     SwalWithoutAnimation.fire({
       input: 'text',

--- a/src/utils/dom/renderers/renderInput.js
+++ b/src/utils/dom/renderers/renderInput.js
@@ -272,7 +272,7 @@ renderInputType.textarea = (textarea, params) => {
         if (textareaWidth > initialPopupWidth) {
           dom.getPopup().style.width = `${textareaWidth}px`
         } else {
-          dom.getPopup().style.width = null
+          dom.applyNumericalStyle(dom.getPopup(), 'width', params.width)
         }
       }
       new MutationObserver(textareaResizeHandler).observe(textarea, {


### PR DESCRIPTION
fixes #2653 

thank you @dansleboby for investigating the issue, it was exactly what you mention [here](https://github.com/sweetalert2/sweetalert2/issues/2653#issuecomment-1635970370)