### PR TITLE
fix: always adjust padding right when body has overflow-y: scroll

### DIFF
--- a/cypress/e2e/scrollbar.cy.js
+++ b/cypress/e2e/scrollbar.cy.js
@@ -64,12 +64,12 @@ describe('Vertical scrollbar', () => {
     Swal.close()
   })
 
-  it('should not adjust body padding if overflow-y: scroll is set on body', () => {
-    const talltDiv = document.createElement('div')
-    talltDiv.innerHTML = Array(100).join('<div>lorem ipsum</div>')
-    document.body.appendChild(talltDiv)
+  it('should adjust body padding if overflow-y: scroll is set on body', () => {
+    document.body.innerHTML = ''
     document.body.style.overflowY = 'scroll'
     document.body.style.paddingRight = '30px'
+
+    const scrollbarWidth = measureScrollbar()
 
     SwalWithoutAnimation.fire({
       title: 'no padding right adjustment when overflow-y: scroll is set on body',
@@ -79,7 +79,7 @@ describe('Vertical scrollbar', () => {
     })
 
     const bodyStyles = window.getComputedStyle(document.body)
-    expect(bodyStyles.paddingRight).to.equal('30px')
+    expect(bodyStyles.paddingRight).to.equal(`${scrollbarWidth + 30}px`)
   })
 
   it('should be restored before a toast is fired after a modal', (done) => {

--- a/src/utils/scrollbarFix.js
+++ b/src/utils/scrollbarFix.js
@@ -8,16 +8,15 @@ let previousBodyPadding = null
 
 export const fixScrollbar = () => {
   const bodyStyles = window.getComputedStyle(document.body)
-  // https://github.com/sweetalert2/sweetalert2/issues/2663
-  if (bodyStyles.overflowY === 'scroll') {
-    return
-  }
   // for queues, do not do this more than once
   if (previousBodyPadding !== null) {
     return
   }
   // if the body has overflow
-  if (document.body.scrollHeight > window.innerHeight) {
+  if (
+    document.body.scrollHeight > window.innerHeight ||
+    bodyStyles.overflowY === 'scroll' // https://github.com/sweetalert2/sweetalert2/issues/2663
+  ) {
     // add padding so the content doesn't shift after removal of scrollbar
     previousBodyPadding = parseInt(bodyStyles.getPropertyValue('padding-right'))
     document.body.style.paddingRight = `${previousBodyPadding + measureScrollbar()}px`


### PR DESCRIPTION
the previous PR #2664  was incorrect 

this one fixes #2663 properly