### PR TITLE
fix: resolve swal promise when its dismissed by another swal

### DIFF
--- a/cypress/e2e/methods/destroy.cy.js
+++ b/cypress/e2e/methods/destroy.cy.js
@@ -13,107 +13,12 @@ describe('_destroy()', () => {
     expect(privateMethods.swalPromiseResolve.get(instance)).to.equal(undefined)
     done()
   })
+
   it('should empty the private props', (done) => {
     Swal.fire({})
     const instance = globalState.currentInstance
     Swal.fire({})
     expect(privateProps.innerParams.get(instance)).to.equal(undefined)
     done()
-  })
-  it('should empty the private methods after having received a reject of an async call', (done) => {
-    let instance = null
-    Swal.fire({
-      preConfirm: () => new Promise((resolve, reject) => cy.wait(500).then(() => reject(new Error('msg3')))),
-    })
-      .then(() => {
-        //
-      })
-      .catch(() => {
-        expect(privateMethods.swalPromiseResolve.get(instance)).to.equal(undefined)
-        done()
-      })
-    instance = globalState.currentInstance
-    Swal.clickConfirm()
-    Swal.fire({})
-    expect(privateMethods.swalPromiseResolve.get(instance)).to.not.equal(undefined)
-  })
-  it('should empty the private methods after having received a resolve of an async call', (done) => {
-    let instance = null
-    Swal.fire({
-      preConfirm: () => new Promise((resolve) => cy.wait(500).then(resolve)),
-    }).then(() => {
-      expect(privateMethods.swalPromiseResolve.get(instance)).to.equal(undefined)
-      done()
-    })
-    instance = globalState.currentInstance
-    Swal.clickConfirm()
-    Swal.fire({})
-    expect(privateMethods.swalPromiseResolve.get(instance)).to.not.equal(undefined)
-  })
-  it('should empty the private methods after the result of an async call in preConfirm even when another unrelated swal is fired', (done) => {
-    let instance = null
-    Swal.fire({
-      preConfirm: () =>
-        new Promise((resolve) => {
-          Swal.fire({
-            test: 'Unrelated Swal',
-            didOpen: () => {
-              expect(privateProps.innerParams.get(instance)).to.equal(undefined)
-              expect(privateMethods.swalPromiseResolve.get(instance)).to.not.equal(undefined)
-            },
-          })
-          cy.wait(500).then(resolve)
-        }),
-    }).then(() => {
-      expect(privateMethods.swalPromiseResolve.get(instance)).to.equal(undefined)
-      done()
-    })
-    instance = globalState.currentInstance
-    Swal.clickConfirm()
-  })
-  it('should destroy privateMethods after the result of an async call in preDeny even when another unrelated swal is fired', (done) => {
-    let instance = null
-    Swal.fire({
-      preDeny: () =>
-        new Promise((resolve) => {
-          Swal.fire({
-            test: 'Unrelated Swal',
-            didOpen: () => {
-              expect(privateProps.innerParams.get(instance)).to.equal(undefined)
-              expect(privateMethods.swalPromiseResolve.get(instance)).to.not.equal(undefined)
-            },
-          })
-          cy.wait(500).then(resolve)
-        }),
-    }).then(() => {
-      expect(privateMethods.swalPromiseResolve.get(instance)).to.equal(undefined)
-      done()
-    })
-    instance = globalState.currentInstance
-    Swal.clickDeny()
-  })
-  it('should destroy privateMethods after having received the result of the chained swal', (done) => {
-    let instance = null
-    let isResolved = false
-    Swal.fire({
-      preConfirm: () => {
-        return Swal.fire({
-          preConfirm: () => {
-            return Promise.resolve()
-          },
-          didOpen: () => {
-            expect(isResolved).to.equal(false)
-            expect(privateMethods.swalPromiseResolve.get(instance)).to.not.equal(undefined)
-            Swal.clickConfirm()
-          },
-        })
-      },
-    }).then(() => {
-      isResolved = true
-      expect(privateMethods.swalPromiseResolve.get(instance)).to.equal(undefined)
-      done()
-    })
-    instance = globalState.currentInstance
-    Swal.clickConfirm()
   })
 })

--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -489,9 +489,7 @@ describe('Miscellaneous tests', function () {
   it('swal dismissed by another swal should resolve', (done) => {
     SwalWithoutAnimation.fire().then((result) => {
       expect(result).to.eql({
-        isConfirmed: false,
-        isDenied: false,
-        isDismissed: false,
+        isDismissed: true,
       })
       done()
     })

--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -486,6 +486,18 @@ describe('Miscellaneous tests', function () {
     })
   })
 
+  it('swal dismissed by another swal should resolve', (done) => {
+    SwalWithoutAnimation.fire().then((result) => {
+      expect(result).to.eql({
+        isConfirmed: false,
+        isDenied: false,
+        isDismissed: false,
+      })
+      done()
+    })
+    SwalWithoutAnimation.fire()
+  })
+
   it('animation enabled', (done) => {
     Swal.fire({
       animation: true,

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -54,9 +54,7 @@ export class SweetAlert {
     showWarningsForParams(Object.assign({}, mixinParams, userParams))
 
     if (globalState.currentInstance) {
-      const swalPromiseResolve = privateMethods.swalPromiseResolve.get(globalState.currentInstance)
-      globalState.currentInstance._destroy()
-      swalPromiseResolve({ isConfirmed: false, isDenied: false, isDismissed: false })
+      globalState.currentInstance.close({ isDismissed: true })
       if (dom.isModal()) {
         unsetAriaHidden()
       }

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -54,7 +54,9 @@ export class SweetAlert {
     showWarningsForParams(Object.assign({}, mixinParams, userParams))
 
     if (globalState.currentInstance) {
-      globalState.currentInstance.close({ isDismissed: true })
+      const swalPromiseResolve = privateMethods.swalPromiseResolve.get(globalState.currentInstance)
+      globalState.currentInstance._destroy()
+      swalPromiseResolve({ isDismissed: true })
       if (dom.isModal()) {
         unsetAriaHidden()
       }

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -54,7 +54,9 @@ export class SweetAlert {
     showWarningsForParams(Object.assign({}, mixinParams, userParams))
 
     if (globalState.currentInstance) {
+      const swalPromiseResolve = privateMethods.swalPromiseResolve.get(globalState.currentInstance)
       globalState.currentInstance._destroy()
+      swalPromiseResolve({ isConfirmed: false, isDenied: false, isDismissed: false })
       if (dom.isModal()) {
         unsetAriaHidden()
       }


### PR DESCRIPTION
closes #2681 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented a new feature for SweetAlert modals to resolve with specific object properties when dismissed by another modal.

- **Tests**
  - Added test cases to ensure that SweetAlert modals resolve correctly when dismissed by another modal, with and without animations.

- **Refactor**
  - Updated SweetAlert dismissal process to use the `close` method for better state management and resolution handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->