### PR TITLE
fix: fix typing in inputValidator method

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -1092,7 +1092,7 @@ declare module 'sweetalert2' {
      *
      * @default undefined
      */
-    inputValidator?(inputValue: string, validationMessage?: string): SyncOrAsync<string | null | false | void>
+    inputValidator?(inputValue: T, validationMessage?: string): SyncOrAsync<string | null | false | void>
 
     /**
      * If you want to return the input value as `result.value` when denying the popup, set to `true`.


### PR DESCRIPTION
Depending on the input type, the typing is incorrect, for example, when the input is a file

```ts
const { value } = await swal.fire<File>({
  title: 'File',
  text: 'Select a file',
  input: 'file',
  inputValidator: (value) => {
    // ts-ignore is required because the typing of value is string before this PR
    // @ts-ignore
    if (!(value instanceof File) {
      return 'invalid value'
    }
    return value
  }
})

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the 'inputValidator' function in the 'sweetalert2' module to accept various input types, increasing its flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->