### PR TITLE
fix: resolve swal promise when its dismissed by another swal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 dist
 cypress/fixtures
 cypress/screenshots
+cypress/downloads
 .idea
 .vscode

--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -486,6 +486,30 @@ describe('Miscellaneous tests', function () {
     })
   })
 
+  it('swal dismissed by another swal should resolve', (done) => {
+    Swal.fire().then((result) => {
+      expect(result).to.eql({
+        isDismissed: true,
+      })
+      done()
+    })
+    Swal.fire()
+  })
+
+  it('swal dismissed by another swal should resolve even when another swal was called after clickConfirm()', (done) => {
+    Swal.fire().then((result) => {
+      expect(result).to.eql({
+        value: true,
+        isConfirmed: true,
+        isDenied: false,
+        isDismissed: false,
+      })
+      done()
+    })
+    Swal.clickConfirm()
+    Swal.fire()
+  })
+
   it('animation enabled', (done) => {
     Swal.fire({
       animation: true,

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -54,7 +54,12 @@ export class SweetAlert {
     showWarningsForParams(Object.assign({}, mixinParams, userParams))
 
     if (globalState.currentInstance) {
+      const swalPromiseResolve = privateMethods.swalPromiseResolve.get(globalState.currentInstance)
+      const { isAwaitingPromise } = globalState.currentInstance
       globalState.currentInstance._destroy()
+      if (!isAwaitingPromise) {
+        swalPromiseResolve({ isDismissed: true })
+      }
       if (dom.isModal()) {
         unsetAriaHidden()
       }


### PR DESCRIPTION
closes https://github.com/sweetalert2/sweetalert2/issues/2681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced modal interaction by allowing a SweetAlert modal to be dismissed by another modal, improving user experience with chained modals.

- **Bug Fixes**
  - Ensured that promises are correctly resolved when a modal is dismissed by another modal, maintaining the reliability of modal behavior.

- **Tests**
  - Added new end-to-end tests to verify the correct dismissal and promise resolution of SweetAlert modals.

- **Chores**
  - Updated `.gitignore` to exclude the `cypress/downloads` directory, keeping the repository clean from test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->