### PR TITLE
fix: allow single quotes in default email validator

### DIFF
--- a/cypress/e2e/inputs.cy.js
+++ b/cypress/e2e/inputs.cy.js
@@ -585,20 +585,44 @@ describe('Validation', () => {
     }, TIMEOUT)
   })
 
+  it('default email validator: test@example.com', (done) => {
+    defaultInputValidators.email('test@example.com').then((data) => {
+      expect(data).be.undefined
+      done()
+    })
+  })
+
+  it(`default email validator: o'test@example.com`, (done) => {
+    defaultInputValidators.email(`o'test@example.com`).then((data) => {
+      expect(data).be.undefined
+      done()
+    })
+  })
+
+  it(`default email validator: invalid email`, (done) => {
+    defaultInputValidators.email(`invalid email@example.com`).then((data) => {
+      expect(data).to.equal('Invalid email address')
+      done()
+    })
+  })
+
   it('default URL validator: https://google.com', (done) => {
-    defaultInputValidators.url('https://google.com').then(() => {
+    defaultInputValidators.url('https://google.com').then((data) => {
+      expect(data).be.undefined
       done()
     })
   })
 
   it('default URL validator: http://g.co', (done) => {
-    defaultInputValidators.url('http://g.co').then(() => {
+    defaultInputValidators.url('http://g.co').then((data) => {
+      expect(data).be.undefined
       done()
     })
   })
 
   it('default URL validator: http://foo.localhost/', (done) => {
-    defaultInputValidators.url('http://foo.localhost/').then(() => {
+    defaultInputValidators.url('http://foo.localhost/').then((data) => {
+      expect(data).be.undefined
       done()
     })
   })

--- a/src/utils/defaultInputValidators.js
+++ b/src/utils/defaultInputValidators.js
@@ -5,7 +5,7 @@ export default {
    * @returns {Promise<string | void>}
    */
   email: (string, validationMessage) => {
-    return /^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9-]{2,24}$/.test(string)
+    return /^[a-zA-Z0-9.+_'-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9-]+$/.test(string)
       ? Promise.resolve()
       : Promise.resolve(validationMessage || 'Invalid email address')
   },


### PR DESCRIPTION
fixes #2715 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added tests for email and URL validation using various formats.
- **Bug Fixes**
	- Updated email validation to support apostrophes in the local part of the email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->