### PR TITLE
Improve performance by pulling querySelector out of the loop

### DIFF
--- a/src/utils/aria.js
+++ b/src/utils/aria.js
@@ -6,9 +6,10 @@ import { getContainer } from './dom/getters.js'
 // reader’s list of elements (headings, form controls, landmarks, etc.) in the document.
 
 export const setAriaHidden = () => {
+  const container = getContainer()
   const bodyChildren = Array.from(document.body.children)
   bodyChildren.forEach((el) => {
-    if (el === getContainer() || el.contains(getContainer())) {
+    if (el.contains(container)) {
       return
     }
 


### PR DESCRIPTION
A small change which improves the performance of opening a modal if the `<body>` tag has a lot of children.

This was tested in Firefox 124.0 on Windows.

## Performance Results

**Before**

Note that 206 profiler ticks are being spent inside of `getContainer()`.
The total amount of profiler ticks amounts to 302.

![getting-the-container-on-every-loop-iteration](https://github.com/Gavin-Optimizers/sweetalert2/assets/164033335/84b1dbcf-31e6-4dba-be5b-758650605381)

**After**

Note that only 2 ticks are being spent inside of `getContainer()`.
The total amount of profiler ticks amounts to 88.
_This is a 250% speed-up._

![getting-the-container-before-the-loop](https://github.com/Gavin-Optimizers/sweetalert2/assets/164033335/fde769ae-bc63-421d-be88-d364df5601ce)

The document used for this test is included in the first comment on this GH thread.

## Explanation

_This code change does not affect the observable behavior._

`setAriaHidden` in src/utils/aria.js executes `getContainer()` in a loop.
`getContainer()` calls `document.body.querySelector(swalClasses.container)`.
The body of the loop does not add or remove the `swalClasses.container` class to a DOMNode.
It also doesn't invoke any user provided callbacks that could make such a modification.
From this we can conclude that `getContainer()` will always return the same DOMNode.
Computing the result once and reusing it will not change the observable behavior of the program.

A small (pointless) change, removing the `el === getContainer()`.
`Node.contains()` is defined to return `true` when `this` and `other` are the same:
From [MDN Node.contains](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains):
 > Note: A node is contained inside itself.
 
Since `el` is always an `Element` (which subclasses `Node`), we can remove this check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Optimized accessibility features by reducing redundant calls within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->