### PR TITLE
fix: prevent popup content from being selected on double click on the container

### DIFF
--- a/src/popup-click-handler.js
+++ b/src/popup-click-handler.js
@@ -71,7 +71,11 @@ const handleModalMousedown = (domCache) => {
  * @param {DomCache} domCache
  */
 const handleContainerMousedown = (domCache) => {
-  domCache.container.onmousedown = () => {
+  domCache.container.onmousedown = (e) => {
+    // prevent the modal text from being selected on double click on the container (allowOutsideClick: false)
+    if (e.target === domCache.container) {
+      e.preventDefault()
+    }
     domCache.popup.onmouseup = function (e) {
       domCache.popup.onmouseup = () => {}
       // We also need to check if the mouseup target is a child of the popup


### PR DESCRIPTION
fixing this:

![CleanShot 2024-04-17 at 17 31 27](https://github.com/sweetalert2/sweetalert2/assets/6059356/95b6bc12-0b75-4b20-bb68-0c416806fdc8)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved user interaction by preventing text selection on double-click within modal containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->