### PR TITLE
feat: focus `[autofocus]` element in a popup

### DIFF
--- a/cypress/e2e/accessibility.cy.js
+++ b/cypress/e2e/accessibility.cy.js
@@ -280,4 +280,15 @@ describe('Focus', () => {
     })
     expect(document.activeElement).to.equal(Swal.getDenyButton())
   })
+
+  it('[autofocus]', () => {
+    Swal.fire({
+      html: `
+        <a href>link 1</a>
+        <a href autofocus>link 2</a>
+        <a href autofocus>link 3</a>
+      `,
+    })
+    expect(document.activeElement.innerText).to.equal('link 2')
+  })
 })

--- a/cypress/e2e/accessibility.cy.js
+++ b/cypress/e2e/accessibility.cy.js
@@ -285,10 +285,11 @@ describe('Focus', () => {
     Swal.fire({
       html: `
         <a href>link 1</a>
-        <a href autofocus>link 2</a>
+        <a href autofocus style="display: none">link 2</a>
         <a href autofocus>link 3</a>
+        <a href autofocus>link 4</a>
       `,
     })
-    expect(document.activeElement.innerText).to.equal('link 2')
+    expect(document.activeElement.innerText).to.equal('link 3')
   })
 })

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -237,7 +237,7 @@ const initFocus = (domCache, innerParams) => {
   if (innerParams.toast) {
     return
   }
-  // TODO: this is dumb, remove `allowEnterKey` param in the next major version
+
   if (!callIfFunction(innerParams.allowEnterKey)) {
     blurActiveElement()
     return
@@ -259,10 +259,12 @@ const initFocus = (domCache, innerParams) => {
  * @returns {boolean}
  */
 const focusAutofocus = (domCache) => {
-  const autofocusElement = domCache.popup.querySelector('[autofocus]')
-  if (autofocusElement instanceof HTMLElement && dom.isVisible(autofocusElement)) {
-    autofocusElement.focus()
-    return true
+  const autofocusElements = domCache.popup.querySelectorAll('[autofocus]')
+  for (const autofocusElement of autofocusElements) {
+    if (autofocusElement instanceof HTMLElement && dom.isVisible(autofocusElement)) {
+      autofocusElement.focus()
+      return true
+    }
   }
   return false
 }

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -221,6 +221,15 @@ const setupTimer = (globalState, innerParams, dismissWith) => {
 }
 
 /**
+ * Initialize focus in the popup:
+ *
+ * 1. If `toast` is `true`, don't steal focus from the document.
+ * 2. Else if there is an [autofocus] element, focus it.
+ * 3. Else if `focusConfirm` is `true` and confirm button is visible, focus it.
+ * 4. Else if `focusDeny` is `true` and deny button is visible, focus it.
+ * 5. Else if `focusCancel` is `true` and cancel button is visible, focus it.
+ * 6. Else focus the first focusable element in a popup (if any).
+ *
  * @param {DomCache} domCache
  * @param {SweetAlertOptions} innerParams
  */
@@ -228,15 +237,34 @@ const initFocus = (domCache, innerParams) => {
   if (innerParams.toast) {
     return
   }
-
+  // TODO: this is dumb, remove `allowEnterKey` param in the next major version
   if (!callIfFunction(innerParams.allowEnterKey)) {
     blurActiveElement()
     return
   }
 
-  if (!focusButton(domCache, innerParams)) {
-    setFocus(-1, 1)
+  if (focusAutofocus(domCache)) {
+    return
   }
+
+  if (focusButton(domCache, innerParams)) {
+    return
+  }
+
+  setFocus(-1, 1)
+}
+
+/**
+ * @param {DomCache} domCache
+ * @returns {boolean}
+ */
+const focusAutofocus = (domCache) => {
+  const autofocusElement = domCache.popup.querySelector('[autofocus]')
+  if (autofocusElement instanceof HTMLElement && dom.isVisible(autofocusElement)) {
+    autofocusElement.focus()
+    return true
+  }
+  return false
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced focus behavior in modal dialogs by ensuring elements with the `autofocus` attribute receive initial focus.
  
- **Tests**
  - Added a new end-to-end test case to verify the focus behavior of modal dialogs with the `autofocus` attribute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->