### PR TITLE
chore: deprecate `allowEnterKey` param

### DIFF
--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -15,7 +15,7 @@ import { getTemplateParams } from './utils/getTemplateParams.js'
 import { openPopup } from './utils/openPopup.js'
 import defaultParams, { showWarningsForParams } from './utils/params.js'
 import setParameters from './utils/setParameters.js'
-import { callIfFunction } from './utils/utils.js'
+import { callIfFunction, warnAboutDeprecation } from './utils/utils.js'
 
 /** @type {SweetAlert} */
 let currentInstance
@@ -228,8 +228,9 @@ const initFocus = (domCache, innerParams) => {
   if (innerParams.toast) {
     return
   }
-
+  // TODO: this is dumb, remove `allowEnterKey` param in the next major version
   if (!callIfFunction(innerParams.allowEnterKey)) {
+    warnAboutDeprecation('allowEnterKey')
     blurActiveElement()
     return
   }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -50,11 +50,13 @@ export const warnOnce = (message) => {
  * Show a one-time console warning about deprecated params/methods
  *
  * @param {string} deprecatedParam
- * @param {string} useInstead
+ * @param {string?} useInstead
  */
-export const warnAboutDeprecation = (deprecatedParam, useInstead) => {
+export const warnAboutDeprecation = (deprecatedParam, useInstead = null) => {
   warnOnce(
-    `"${deprecatedParam}" is deprecated and will be removed in the next major release. Please use "${useInstead}" instead.`
+    `"${deprecatedParam}" is deprecated and will be removed in the next major release.${
+      useInstead ? ` Use "${useInstead}" instead.` : ''
+    }`
   )
 }
 


### PR DESCRIPTION
Everything is dumb about this param, its purpose, its implementation, everything.