### PR TITLE
fix: customClass for buttons

### DIFF
--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -3766,12 +3766,15 @@ describe('Styling', () => {
       }
       .my-confirm-button {
         padding: 2px;
+        color: red;
       }
       .my-deny-button {
         padding: 3px;
+        color: red;
       }
       .my-cancel-button {
         padding: 4px;
+        color: red;
       }
       .my-loader {
         border-width: 7px;
@@ -3826,9 +3829,12 @@ describe('Styling', () => {
         expect(window.getComputedStyle(Swal.getValidationMessage()).padding).to.equal('0px')
         expect(window.getComputedStyle(Swal.getActions()).padding).to.equal('1px')
         expect(window.getComputedStyle(Swal.getConfirmButton()).padding).to.equal('2px')
+        expect(window.getComputedStyle(Swal.getConfirmButton()).color).to.equal('rgb(255, 0, 0)')
         expect(window.getComputedStyle(Swal.getDenyButton()).padding).to.equal('3px')
+        expect(window.getComputedStyle(Swal.getDenyButton()).color).to.equal('rgb(255, 0, 0)')
         expect(window.getComputedStyle(Swal.getCancelButton()).padding).to.equal('4px')
         Swal.showLoading()
+        expect(window.getComputedStyle(Swal.getCancelButton()).color).to.equal('rgb(255, 0, 0)')
         expect(window.getComputedStyle(Swal.getLoader()).borderWidth).to.equal('7px')
         expect(window.getComputedStyle(Swal.getFooter()).padding).to.equal('8px')
         expect(window.getComputedStyle(Swal.getTimerProgressBar()).height).to.equal('9px')

--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -206,7 +206,7 @@ div:where(.swal2-container) {
       cursor: pointer;
     }
 
-    &.swal2-confirm {
+    &:where(.swal2-confirm) {
       order: $swal2-confirm-button-order;
       border: $swal2-confirm-button-border;
       border-radius: $swal2-confirm-button-border-radius;
@@ -220,7 +220,7 @@ div:where(.swal2-container) {
       }
     }
 
-    &.swal2-deny {
+    &:where(.swal2-deny) {
       order: $swal2-deny-button-order;
       border: $swal2-deny-button-border;
       border-radius: $swal2-deny-button-border-radius;
@@ -234,7 +234,7 @@ div:where(.swal2-container) {
       }
     }
 
-    &.swal2-cancel {
+    &:where(.swal2-cancel) {
       order: $swal2-cancel-button-order;
       border: $swal2-cancel-button-border;
       border-radius: $swal2-cancel-button-border-radius;


### PR DESCRIPTION
connected to #2740 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated button colors for confirm, deny, and cancel actions to red.

- **Tests**
  - Added assertions to verify the color of confirm, deny, and cancel buttons.

- **Chores**
  - Updated test scripts and dependencies in `package.json`.
  - Modified SCSS selectors to use the `:where` pseudo-class for improved styling consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->