### PR TITLE
fix: set babel browser targets to default targets

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,6 +33,7 @@ export default {
     babel({
       babelHelpers: 'bundled',
       presets: ['@babel/preset-env'],
+      targets: 'defaults',
     }),
   ],
   input: 'src/sweetalert2.js',


### PR DESCRIPTION
Closes https://github.com/sweetalert2/sweetalert2/issues/2758.

For reference: `defaults` means `> 0.5%, last 2 versions, Firefox ESR, not dead` [according to browserslist](https://github.com/browserslist/browserslist?tab=readme-ov-file#full-list) (which is what `babel` uses). So that means:
* Every version with more than 0.5% usage globally
* The most recent 2 versions of every browser
* The current Firefox ESR
* But *excluding* browsers that are considered dead, e.g. Internet Explorer

You can see the current targets by running `yarn browserslist "defaults"` (or `npx browserslist "defaults"` or similar). The data it uses for queries like `last 2 versions` and `Firefox ESR` is based on the `caniuse-lite` dependency, see [here](https://github.com/browserslist/browserslist?tab=readme-ov-file#update-caniuse-lite) for how to update it / keep it updated (I'm not entirely sure how this works with `yarn.lock`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced compatibility across various environments by updating the JavaScript compilation settings.
  
- **Bug Fixes**
	- Improved performance and adherence to standards in the bundled JavaScript output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->