### PR TITLE
fixing bug where checkbox input-type doesn't get label properly populated

### DIFF
--- a/src/utils/dom/renderers/renderInput.js
+++ b/src/utils/dom/renderers/renderInput.js
@@ -274,7 +274,7 @@ renderInputType.checkbox = (checkboxContainer, params) => {
   checkbox.value = '1'
   checkbox.checked = Boolean(params.inputValue)
   const label = checkboxContainer.querySelector('span')
-  dom.setInnerHtml(label, params.inputPlaceholder)
+  dom.setInnerHtml(label, params.inputLabel)
   return checkbox
 }
 

--- a/src/utils/dom/renderers/renderInput.js
+++ b/src/utils/dom/renderers/renderInput.js
@@ -274,7 +274,7 @@ renderInputType.checkbox = (checkboxContainer, params) => {
   checkbox.value = '1'
   checkbox.checked = Boolean(params.inputValue)
   const label = checkboxContainer.querySelector('span')
-  dom.setInnerHtml(label, params.inputLabel)
+  dom.setInnerHtml(label, params.inputPlaceholder || params.inputLabel)
   return checkbox
 }
 


### PR DESCRIPTION
Fixed: incorrectly using `inputPlaceholder` param to populate `<label>`, instead of `inputLabel` param.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved checkbox label rendering by adding a fallback to ensure a label is displayed even if a placeholder is absent, enhancing flexibility and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->