### PR TITLE
fix: avoid using deprecated sass lighten function

### DIFF
--- a/src/scss/_icons.scss
+++ b/src/scss/_icons.scss
@@ -1,3 +1,6 @@
+@use 'sass:color';
+@use 'sass:math';
+
 // https://stackoverflow.com/a/12335841/1331425
 @function strip-units($number) {
   @return math.div($number, ($number * 0 + 1));
@@ -72,7 +75,7 @@ div:where(.swal2-icon) {
   }
 
   &.swal2-warning {
-    border-color: lighten($swal2-warning, 7);
+    border-color: color.adjust($swal2-warning, $lightness: 7%);
     color: $swal2-warning;
 
     // Warning icon animation
@@ -88,7 +91,7 @@ div:where(.swal2-icon) {
   }
 
   &.swal2-info {
-    border-color: lighten($swal2-info, 20);
+    border-color: color.adjust($swal2-info, $lightness: 20%);
     color: $swal2-info;
 
     // Info icon animation
@@ -104,7 +107,7 @@ div:where(.swal2-icon) {
   }
 
   &.swal2-question {
-    border-color: lighten($swal2-question, 20);
+    border-color: color.adjust($swal2-question, $lightness: 20%);
     color: $swal2-question;
 
     // Question icon animation

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $swal2-white: #fff !default;
 $swal2-black: #000 !default;
 $swal2-outline-color: rgba(100, 150, 200, 0.5) !default;
@@ -9,7 +11,7 @@ $swal2-container-padding: 0.625em !default;
 $swal2-width: 32em !default;
 $swal2-padding: 0 0 1.25em !default;
 $swal2-border: none !default;
-$swal2-color: lighten($swal2-black, 33) !default;
+$swal2-color: color.adjust($swal2-black, $lightness: 33%) !default;
 $swal2-border-radius: 5px !default;
 $swal2-box-shadow: #d9d9d9 !default;
 
@@ -74,7 +76,7 @@ $swal2-input-margin: 1em 2em 3px !default;
 $swal2-input-width: auto !default;
 $swal2-input-height: 2.625em !default;
 $swal2-input-padding: 0 0.75em !default;
-$swal2-input-border: 1px solid lighten($swal2-black, 85) !default;
+$swal2-input-border: 1px solid color.adjust($swal2-black, $lightness: 85%) !default;
 $swal2-input-border-radius: 0.1875em !default;
 $swal2-input-box-shadow:
   inset 0 1px 1px rgba($swal2-black, 0.06),
@@ -106,8 +108,8 @@ $swal2-validation-message-align-items: center !default;
 $swal2-validation-message-justify-content: center !default;
 $swal2-validation-message-margin: 1em 0 0 !default;
 $swal2-validation-message-padding: 0.625em !default;
-$swal2-validation-message-background: lighten($swal2-black, 94) !default;
-$swal2-validation-message-color: lighten($swal2-black, 40) !default;
+$swal2-validation-message-background: color.adjust($swal2-black, $lightness: 94%) !default;
+$swal2-validation-message-color: color.adjust($swal2-black, $lightness: 40%) !default;
 $swal2-validation-message-font-size: 1em !default;
 $swal2-validation-message-font-weight: 300 !default;
 $swal2-validation-message-icon-background: $swal2-error !default;


### PR DESCRIPTION
closes #2766

Hi! This PR adds support for Sass v1.79.0. Since the `lighten` function is deprecated in this version, warnings appear during the build process. More details about the sass api changes can be found [here](https://sass-lang.com/documentation/breaking-changes/color-functions/#single-channel-adjustment-functions). 

I replaced `lighten` function with [`color.adjust`](https://sass-lang.com/documentation/modules/color/#adjust) that gives exactly the same result. According to Sass recommendations it's event better to use [`color.scale`](https://sass-lang.com/documentation/modules/color/#scale) function to avoid using absolute terms but then the colors will be changed a little bit. I'm not sure how "serious" you are here about the colors... so I decide "just to fix it" without making any other changes.

I tested it with both Sass `1.55.0` and `1.79.0` versions, building and tests are ok now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced color manipulation for icon states and validation messages using a new color adjustment method.
  
- **Bug Fixes**
	- Improved consistency and flexibility in color adjustments for various UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->