### PR TITLE
fix: handle `transitionend` together with `animationend`

### DIFF
--- a/src/instanceMethods/close.js
+++ b/src/instanceMethods/close.js
@@ -187,12 +187,16 @@ const animatePopup = (instance, popup, container, returnFocus, didClose) => {
     returnFocus,
     didClose
   )
-  popup.addEventListener('animationend', function (e) {
+  const swalCloseAnimationFinished = function (e) {
     if (e.target === popup) {
       globalState.swalCloseEventFinishedCallback()
       delete globalState.swalCloseEventFinishedCallback
+      popup.removeEventListener('animationend', swalCloseAnimationFinished)
+      popup.removeEventListener('transitionend', swalCloseAnimationFinished)
     }
-  })
+  }
+  popup.addEventListener('animationend', swalCloseAnimationFinished)
+  popup.addEventListener('transitionend', swalCloseAnimationFinished)
 }
 
 /**

--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -57,6 +57,7 @@ const swalOpenAnimationFinished = (event) => {
   }
   const container = dom.getContainer()
   popup.removeEventListener('animationend', swalOpenAnimationFinished)
+  popup.removeEventListener('transitionend', swalOpenAnimationFinished)
   container.style.overflowY = 'auto'
 }
 
@@ -68,6 +69,7 @@ const setScrollingVisibility = (container, popup) => {
   if (dom.hasCssAnimation(popup)) {
     container.style.overflowY = 'hidden'
     popup.addEventListener('animationend', swalOpenAnimationFinished)
+    popup.addEventListener('transitionend', swalOpenAnimationFinished)
   } else {
     container.style.overflowY = 'auto'
   }


### PR DESCRIPTION
fixes #2743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of closing animations to prevent memory leaks.
	- Enhanced event handling for popup animations to ensure proper scrolling visibility.

- **Refactor**
	- Improved readability and maintainability of event handler functions related to animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->