### PR TITLE
fix: change default animation behavior to be less fancy (#2589)

### DIFF
--- a/src/scss/_animations.scss
+++ b/src/scss/_animations.scss
@@ -1,7 +1,19 @@
 @import 'toasts-animations';
 
-// Appearance animation
+// Appearance animations
 @keyframes swal2-show {
+  0% {
+    transform: scale(0.9);
+    opacity: 0;
+  }
+
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes swal2-show-fancy {
   0% {
     transform: scale(0.7);
   }

--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -550,6 +550,10 @@ div:where(.swal2-container) {
   animation: $swal2-show-animation;
 }
 
+.swal2-show-fancy {
+  animation: $swal2-show-fancy-animation;
+}
+
 .swal2-hide {
   animation: $swal2-hide-animation;
 }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -17,6 +17,7 @@ $swal2-box-shadow: #d9d9d9 !default;
 
 // ANIMATIONS
 $swal2-show-animation: swal2-show 0.3s !default;
+$swal2-show-fancy-animation: swal2-show-fancy 0.3s !default;
 $swal2-hide-animation: swal2-hide 0.15s forwards !default;
 
 // BACKGROUND

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -702,6 +702,7 @@ declare module 'sweetalert2' {
 
     /**
      * CSS classes for animations when showing a popup (fade in)
+     * Use `pop-up: 'swal2-show-fancy'` to see the old default fancy animation.
      *
      * @default { popup: 'swal2-show', backdrop: 'swal2-backdrop-show', icon: 'swal2-icon-show' }
      */


### PR DESCRIPTION
Improving the default show animation - ISSUE #2589
- Changed default animation to be "less fancy"
- Kept the old bouncing animation. To use it, configuration must be:
`Swal.fire({ title: 'Fancy animation', showClass: { popup: 'swal2-show-fancy'  }})`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new animations for SweetAlert2 modals, including `swal2-show` and `swal2-show-fancy`.
	- Added a new class `.swal2-show-fancy` for enhanced modal display effects.
	- Added a new variable for customizable animation duration: `$swal2-show-fancy-animation`.
	- Enhanced customization options with a new `showClass` property in SweetAlertOptions for custom CSS classes.

- **Bug Fixes**
	- Minor adjustments to comments for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->