### PR TITLE
fix: stop using deprecated sass `@import`s

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "playwright-webkit": "^1.37.1",
     "prettier": "^3.0.0",
     "rollup": "^4.0.0",
-    "sass": "~1.79.0",
+    "sass": "^1.83.0",
     "stylelint": "^16.0.0",
     "typescript": "4.8.4",
     "vite": "^6.0.0",

--- a/src/scss/_animations.scss
+++ b/src/scss/_animations.scss
@@ -1,4 +1,4 @@
-@import 'toasts-animations';
+@use 'toasts-animations';
 
 // Appearance animation
 @keyframes swal2-show {

--- a/src/scss/_body.scss
+++ b/src/scss/_body.scss
@@ -1,4 +1,5 @@
-@import 'toasts-body';
+@use 'toasts-body';
+@use "../variables";
 
 @mixin sweetalert2-body() {
   &.swal2-shown:not(.swal2-no-backdrop, .swal2-toast-shown) {
@@ -19,7 +20,7 @@
       }
 
       .swal2-modal {
-        box-shadow: 0 0 10px $swal2-backdrop;
+        box-shadow: 0 0 10px variables.$swal2-backdrop;
       }
     }
   }

--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -1,3 +1,5 @@
+@use "sass:meta";
+@use "../variables";
 @use 'sass:math';
 
 div:where(.swal2-container) {
@@ -12,16 +14,16 @@ div:where(.swal2-container) {
     'bottom-start  bottom-center  bottom-end';
   grid-template-rows: minmax(min-content, auto) minmax(min-content, auto) minmax(min-content, auto);
   height: 100%; // Safari
-  padding: $swal2-container-padding;
+  padding: variables.$swal2-container-padding;
   overflow-x: hidden;
-  transition: $swal2-backdrop-transition;
+  transition: variables.$swal2-backdrop-transition;
 
   // sweetalert2/issues/905
   -webkit-overflow-scrolling: touch;
 
   &.swal2-backdrop-show,
   &.swal2-noanimation {
-    background: $swal2-backdrop;
+    background: variables.$swal2-backdrop;
   }
 
   &.swal2-backdrop-hide {
@@ -121,15 +123,15 @@ div:where(.swal2-container) {
     position: relative;
     box-sizing: border-box;
     grid-template-columns: minmax(0, 100%);
-    width: $swal2-width;
+    width: variables.$swal2-width;
     max-width: 100%;
-    padding: $swal2-padding;
-    border: $swal2-border;
-    border-radius: $swal2-border-radius;
-    background: $swal2-background;
-    color: $swal2-color;
-    font-family: $swal2-font;
-    font-size: $swal2-font-size;
+    padding: variables.$swal2-padding;
+    border: variables.$swal2-border;
+    border-radius: variables.$swal2-border-radius;
+    background: variables.$swal2-background;
+    color: variables.$swal2-color;
+    font-family: variables.$swal2-font;
+    font-size: variables.$swal2-font-size;
 
     &:focus {
       outline: none;
@@ -157,14 +159,14 @@ div:where(.swal2-container) {
   }
 
   h2:where(.swal2-title) {
-    position: $swal2-title-position;
-    max-width: $swal2-title-max-width;
-    margin: $swal2-title-margin;
-    padding: $swal2-title-padding;
-    color: $swal2-title-color;
-    font-size: $swal2-title-font-size;
-    font-weight: $swal2-title-font-weight;
-    text-align: $swal2-title-text-align;
+    position: variables.$swal2-title-position;
+    max-width: variables.$swal2-title-max-width;
+    margin: variables.$swal2-title-margin;
+    padding: variables.$swal2-title-padding;
+    color: variables.$swal2-title-color;
+    font-size: variables.$swal2-title-font-size;
+    font-weight: variables.$swal2-title-font-weight;
+    text-align: variables.$swal2-title-text-align;
     text-transform: none;
     word-wrap: break-word;
     cursor: initial;
@@ -174,12 +176,12 @@ div:where(.swal2-container) {
     display: flex;
     z-index: 1; // prevent success icon from overlapping buttons
     box-sizing: border-box;
-    flex-wrap: $swal2-actions-flex-wrap;
-    align-items: $swal2-actions-align-items;
-    justify-content: $swal2-actions-justify-content;
-    width: $swal2-actions-width;
-    margin: $swal2-actions-margin;
-    padding: $swal2-actions-padding;
+    flex-wrap: variables.$swal2-actions-flex-wrap;
+    align-items: variables.$swal2-actions-align-items;
+    justify-content: variables.$swal2-actions-justify-content;
+    width: variables.$swal2-actions-width;
+    margin: variables.$swal2-actions-margin;
+    padding: variables.$swal2-actions-padding;
 
     &:not(.swal2-loading) {
       .swal2-styled {
@@ -188,11 +190,11 @@ div:where(.swal2-container) {
         }
 
         &:hover {
-          background-image: linear-gradient($swal2-button-darken-hover, $swal2-button-darken-hover);
+          background-image: linear-gradient(variables.$swal2-button-darken-hover, variables.$swal2-button-darken-hover);
         }
 
         &:active {
-          background-image: linear-gradient($swal2-button-darken-active, $swal2-button-darken-active);
+          background-image: linear-gradient(variables.$swal2-button-darken-active, variables.$swal2-button-darken-active);
         }
       }
     }
@@ -200,79 +202,79 @@ div:where(.swal2-container) {
 
   div:where(.swal2-loader) {
     display: none;
-    align-items: $swal2-loader-align-items;
-    justify-content: $swal2-loader-justify-content;
-    width: $swal2-loader-width;
-    height: $swal2-loader-height;
-    margin: $swal2-loader-margin;
-    animation: $swal2-loader-animation;
-    border-width: $swal2-loader-border-width;
-    border-style: $swal2-loader-border-style;
-    border-radius: $swal2-loader-border-radius;
-    border-color: $swal2-loader-border-color;
+    align-items: variables.$swal2-loader-align-items;
+    justify-content: variables.$swal2-loader-justify-content;
+    width: variables.$swal2-loader-width;
+    height: variables.$swal2-loader-height;
+    margin: variables.$swal2-loader-margin;
+    animation: variables.$swal2-loader-animation;
+    border-width: variables.$swal2-loader-border-width;
+    border-style: variables.$swal2-loader-border-style;
+    border-radius: variables.$swal2-loader-border-radius;
+    border-color: variables.$swal2-loader-border-color;
   }
 
   button:where(.swal2-styled) {
-    margin: $swal2-button-margin;
-    padding: $swal2-button-padding;
-    transition: $swal2-button-transition;
-    box-shadow: $swal2-button-box-shadow;
-    font-weight: $swal2-button-font-weight;
+    margin: variables.$swal2-button-margin;
+    padding: variables.$swal2-button-padding;
+    transition: variables.$swal2-button-transition;
+    box-shadow: variables.$swal2-button-box-shadow;
+    font-weight: variables.$swal2-button-font-weight;
 
     &:not([disabled]) {
       cursor: pointer;
     }
 
     &:where(.swal2-confirm) {
-      order: $swal2-confirm-button-order;
-      border: $swal2-confirm-button-border;
-      border-radius: $swal2-confirm-button-border-radius;
+      order: variables.$swal2-confirm-button-order;
+      border: variables.$swal2-confirm-button-border;
+      border-radius: variables.$swal2-confirm-button-border-radius;
       background: initial;
-      background-color: $swal2-confirm-button-background-color;
-      color: $swal2-confirm-button-color;
-      font-size: $swal2-confirm-button-font-size;
+      background-color: variables.$swal2-confirm-button-background-color;
+      color: variables.$swal2-confirm-button-color;
+      font-size: variables.$swal2-confirm-button-font-size;
 
       &:focus-visible {
-        box-shadow: $swal2-confirm-button-focus-box-shadow;
+        box-shadow: variables.$swal2-confirm-button-focus-box-shadow;
       }
     }
 
     &:where(.swal2-deny) {
-      order: $swal2-deny-button-order;
-      border: $swal2-deny-button-border;
-      border-radius: $swal2-deny-button-border-radius;
+      order: variables.$swal2-deny-button-order;
+      border: variables.$swal2-deny-button-border;
+      border-radius: variables.$swal2-deny-button-border-radius;
       background: initial;
-      background-color: $swal2-deny-button-background-color;
-      color: $swal2-deny-button-color;
-      font-size: $swal2-deny-button-font-size;
+      background-color: variables.$swal2-deny-button-background-color;
+      color: variables.$swal2-deny-button-color;
+      font-size: variables.$swal2-deny-button-font-size;
 
       &:focus-visible {
-        box-shadow: $swal2-deny-button-focus-box-shadow;
+        box-shadow: variables.$swal2-deny-button-focus-box-shadow;
       }
     }
 
     &:where(.swal2-cancel) {
-      order: $swal2-cancel-button-order;
-      border: $swal2-cancel-button-border;
-      border-radius: $swal2-cancel-button-border-radius;
+      order: variables.$swal2-cancel-button-order;
+      border: variables.$swal2-cancel-button-border;
+      border-radius: variables.$swal2-cancel-button-border-radius;
       background: initial;
-      background-color: $swal2-cancel-button-background-color;
-      color: $swal2-cancel-button-color;
-      font-size: $swal2-cancel-button-font-size;
+      background-color: variables.$swal2-cancel-button-background-color;
+      color: variables.$swal2-cancel-button-color;
+      font-size: variables.$swal2-cancel-button-font-size;
 
       &:focus-visible {
-        box-shadow: $swal2-cancel-button-focus-box-shadow;
+        box-shadow: variables.$swal2-cancel-button-focus-box-shadow;
       }
     }
 
     &.swal2-default-outline {
       &:focus-visible {
-        box-shadow: $swal2-button-focus-box-shadow;
+        box-shadow: variables.$swal2-button-focus-box-shadow;
       }
     }
 
     &:focus-visible {
-      outline: $swal2-button-focus-outline;
+      outline: variables.$swal2-button-focus-outline;
     }
 
     &::-moz-focus-inner {
@@ -281,12 +283,12 @@ div:where(.swal2-container) {
   }
 
   div:where(.swal2-footer) {
-    margin: $swal2-footer-margin;
-    padding: $swal2-footer-padding;
-    border-top: 1px solid $swal2-footer-border-color;
-    color: $swal2-footer-color;
-    font-size: $swal2-footer-font-size;
-    text-align: $swal2-footer-text-align;
+    margin: variables.$swal2-footer-margin;
+    padding: variables.$swal2-footer-padding;
+    border-top: 1px solid variables.$swal2-footer-border-color;
+    color: variables.$swal2-footer-color;
+    font-size: variables.$swal2-footer-font-size;
+    text-align: variables.$swal2-footer-text-align;
     cursor: initial;
   }
 
@@ -297,54 +299,54 @@ div:where(.swal2-container) {
     left: 0;
     grid-column: auto !important;
     overflow: hidden;
-    border-bottom-right-radius: $swal2-border-radius;
-    border-bottom-left-radius: $swal2-border-radius;
+    border-bottom-right-radius: variables.$swal2-border-radius;
+    border-bottom-left-radius: variables.$swal2-border-radius;
   }
 
   div:where(.swal2-timer-progress-bar) {
     width: 100%;
-    height: $swal2-timer-progress-bar-height;
-    background: $swal2-timer-progress-bar-background;
+    height: variables.$swal2-timer-progress-bar-height;
+    background: variables.$swal2-timer-progress-bar-background;
   }
 
   img:where(.swal2-image) {
     max-width: 100%;
-    margin: $swal2-image-margin;
+    margin: variables.$swal2-image-margin;
     cursor: initial;
   }
 
   button:where(.swal2-close) {
-    position: $swal2-close-button-position;
+    position: variables.$swal2-close-button-position;
     z-index: 2; // sweetalert2/issues/1617
-    align-items: $swal2-close-button-align-items;
-    justify-content: $swal2-close-button-justify-content;
-    width: $swal2-close-button-width;
-    height: $swal2-close-button-height;
-    margin-top: $swal2-close-button-gap;
-    margin-right: $swal2-close-button-gap;
-    margin-bottom: -$swal2-close-button-height;
-    padding: $swal2-close-button-padding;
+    align-items: variables.$swal2-close-button-align-items;
+    justify-content: variables.$swal2-close-button-justify-content;
+    width: variables.$swal2-close-button-width;
+    height: variables.$swal2-close-button-height;
+    margin-top: variables.$swal2-close-button-gap;
+    margin-right: variables.$swal2-close-button-gap;
+    margin-bottom: -(variables.$swal2-close-button-height);
+    padding: variables.$swal2-close-button-padding;
     overflow: hidden;
-    transition: $swal2-close-button-transition;
-    border: $swal2-close-button-border;
-    border-radius: $swal2-close-button-border-radius;
-    outline: $swal2-close-button-outline;
-    background: $swal2-close-button-background;
-    color: $swal2-close-button-color;
-    font-family: $swal2-close-button-font-family;
-    font-size: $swal2-close-button-font-size;
+    transition: variables.$swal2-close-button-transition;
+    border: variables.$swal2-close-button-border;
+    border-radius: variables.$swal2-close-button-border-radius;
+    outline: variables.$swal2-close-button-outline;
+    background: variables.$swal2-close-button-background;
+    color: variables.$swal2-close-button-color;
+    font-family: variables.$swal2-close-button-font-family;
+    font-size: variables.$swal2-close-button-font-size;
     cursor: pointer;
-    justify-self: $swal2-close-button-justify-self;
+    justify-self: variables.$swal2-close-button-justify-self;
 
     &:hover {
-      transform: $swal2-close-button-hover-transform;
-      background: $swal2-close-button-hover-background;
-      color: $swal2-close-button-hover-color;
+      transform: variables.$swal2-close-button-hover-transform;
+      background: variables.$swal2-close-button-hover-background;
+      color: variables.$swal2-close-button-hover-color;
     }
 
     &:focus-visible {
-      outline: $swal2-close-button-focus-outline;
-      box-shadow: $swal2-close-button-focus-box-shadow;
+      outline: variables.$swal2-close-button-focus-outline;
+      box-shadow: variables.$swal2-close-button-focus-box-shadow;
     }
 
     &::-moz-focus-inner {
@@ -354,17 +356,17 @@ div:where(.swal2-container) {
 
   div:where(.swal2-html-container) {
     z-index: 1; // prevent success icon overlapping the content
-    justify-content: $swal2-html-container-justify-content;
-    margin: $swal2-html-container-margin;
-    padding: $swal2-html-container-padding;
-    overflow: $swal2-html-container-overflow;
-    color: $swal2-html-container-color;
-    font-size: $swal2-html-container-font-size;
-    font-weight: $swal2-html-container-font-weight;
-    line-height: $swal2-html-container-line-height;
-    text-align: $swal2-html-container-text-align;
-    word-wrap: $swal2-html-container-word-wrap;
-    word-break: $swal2-html-container-word-break;
+    justify-content: variables.$swal2-html-container-justify-content;
+    margin: variables.$swal2-html-container-margin;
+    padding: variables.$swal2-html-container-padding;
+    overflow: variables.$swal2-html-container-overflow;
+    color: variables.$swal2-html-container-color;
+    font-size: variables.$swal2-html-container-font-size;
+    font-weight: variables.$swal2-html-container-font-weight;
+    line-height: variables.$swal2-html-container-line-height;
+    text-align: variables.$swal2-html-container-text-align;
+    word-wrap: variables.$swal2-html-container-word-wrap;
+    word-break: variables.$swal2-html-container-word-break;
     cursor: initial;
   }
 
@@ -374,31 +376,31 @@ div:where(.swal2-container) {
   select:where(.swal2-select),
   div:where(.swal2-radio),
   label:where(.swal2-checkbox) {
-    margin: $swal2-input-margin;
+    margin: variables.$swal2-input-margin;
   }
 
   input:where(.swal2-input),
   input:where(.swal2-file),
   textarea:where(.swal2-textarea) {
     box-sizing: border-box;
-    width: $swal2-input-width;
-    transition: $swal2-input-transition;
-    border: $swal2-input-border;
-    border-radius: $swal2-input-border-radius;
-    background: $swal2-input-background;
-    box-shadow: $swal2-input-box-shadow;
-    color: $swal2-input-color;
-    font-size: $swal2-input-font-size;
+    width: variables.$swal2-input-width;
+    transition: variables.$swal2-input-transition;
+    border: variables.$swal2-input-border;
+    border-radius: variables.$swal2-input-border-radius;
+    background: variables.$swal2-input-background;
+    box-shadow: variables.$swal2-input-box-shadow;
+    color: variables.$swal2-input-color;
+    font-size: variables.$swal2-input-font-size;
 
     &.swal2-inputerror {
-      border-color: $swal2-error !important;
-      box-shadow: 0 0 2px $swal2-error !important;
+      border-color: variables.$swal2-error !important;
+      box-shadow: 0 0 2px variables.$swal2-error !important;
     }
 
     &:focus {
-      border: $swal2-input-focus-border;
-      outline: $swal2-input-focus-outline;
-      box-shadow: $swal2-input-focus-box-shadow;
+      border: variables.$swal2-input-focus-border;
+      outline: variables.$swal2-input-focus-outline;
+      box-shadow: variables.$swal2-input-focus-box-shadow;
     }
 
     &::placeholder {
@@ -407,8 +409,8 @@ div:where(.swal2-container) {
   }
 
   .swal2-range {
-    margin: $swal2-input-margin;
-    background: $swal2-background;
+    margin: variables.$swal2-input-margin;
+    background: variables.$swal2-background;
 
     input {
       width: 80%;
@@ -416,57 +418,57 @@ div:where(.swal2-container) {
 
     output {
       width: 20%;
-      color: $swal2-input-color;
+      color: variables.$swal2-input-color;
       font-weight: 600;
       text-align: center;
     }
 
     input,
     output {
-      height: $swal2-input-height;
+      height: variables.$swal2-input-height;
       padding: 0;
-      font-size: $swal2-input-font-size;
-      line-height: $swal2-input-height;
+      font-size: variables.$swal2-input-font-size;
+      line-height: variables.$swal2-input-height;
     }
   }
 
   .swal2-input {
-    height: $swal2-input-height;
-    padding: $swal2-input-padding;
+    height: variables.$swal2-input-height;
+    padding: variables.$swal2-input-padding;
   }
 
   .swal2-file {
     width: 75%;
     margin-right: auto;
     margin-left: auto;
-    background: $swal2-input-background;
-    font-size: $swal2-input-font-size;
+    background: variables.$swal2-input-background;
+    font-size: variables.$swal2-input-font-size;
   }
 
   .swal2-textarea {
-    height: $swal2-textarea-height;
-    padding: $swal2-textarea-padding;
+    height: variables.$swal2-textarea-height;
+    padding: variables.$swal2-textarea-padding;
   }
 
   .swal2-select {
     min-width: 50%;
     max-width: 100%;
     padding: 0.375em 0.625em;
-    background: $swal2-input-background;
-    color: $swal2-input-color;
-    font-size: $swal2-input-font-size;
+    background: variables.$swal2-input-background;
+    color: variables.$swal2-input-color;
+    font-size: variables.$swal2-input-font-size;
   }
 
   .swal2-radio,
   .swal2-checkbox {
     align-items: center;
     justify-content: center;
-    background: $swal2-background;
-    color: $swal2-input-color;
+    background: variables.$swal2-background;
+    color: variables.$swal2-input-color;
 
     label {
       margin: 0 0.6em;
-      font-size: $swal2-input-font-size;
+      font-size: variables.$swal2-input-font-size;
     }
 
     input {
@@ -477,20 +479,20 @@ div:where(.swal2-container) {
 
   label:where(.swal2-input-label) {
     display: flex;
-    justify-content: $swal2-input-label-justify-content;
-    margin: $swal2-input-label-margin;
+    justify-content: variables.$swal2-input-label-justify-content;
+    margin: variables.$swal2-input-label-margin;
   }
 
   div:where(.swal2-validation-message) {
-    align-items: $swal2-validation-message-align-items;
-    justify-content: $swal2-validation-message-justify-content;
-    margin: $swal2-validation-message-margin;
-    padding: $swal2-validation-message-padding;
+    align-items: variables.$swal2-validation-message-align-items;
+    justify-content: variables.$swal2-validation-message-justify-content;
+    margin: variables.$swal2-validation-message-margin;
+    padding: variables.$swal2-validation-message-padding;
     overflow: hidden;
-    background: $swal2-validation-message-background;
-    color: $swal2-validation-message-color;
-    font-size: $swal2-validation-message-font-size;
-    font-weight: $swal2-validation-message-font-weight;
+    background: variables.$swal2-validation-message-background;
+    color: variables.$swal2-validation-message-color;
+    font-size: variables.$swal2-validation-message-font-size;
+    font-weight: variables.$swal2-validation-message-font-weight;
 
     &::before {
       content: '!';
@@ -499,10 +501,10 @@ div:where(.swal2-container) {
       min-width: 1.5em;
       height: 1.5em;
       margin: 0 0.625em;
-      zoom: $swal2-validation-message-icon-zoom;
+      zoom: variables.$swal2-validation-message-icon-zoom;
       border-radius: 50%;
-      background-color: $swal2-validation-message-icon-background;
-      color: $swal2-validation-message-icon-color;
+      background-color: variables.$swal2-validation-message-icon-background;
+      color: variables.$swal2-validation-message-icon-color;
       font-weight: 600;
       line-height: 1.5em;
       text-align: center;
@@ -510,13 +512,13 @@ div:where(.swal2-container) {
   }
 
   .swal2-progress-steps {
-    flex-wrap: $swal2-progress-steps-flex-wrap;
-    align-items: $swal2-progress-steps-align-items;
-    max-width: $swal2-progress-steps-max-width;
-    margin: $swal2-progress-steps-margin;
-    padding: $swal2-progress-steps-padding;
-    background: $swal2-progress-steps-background;
-    font-weight: $swal2-progress-steps-font-weight;
+    flex-wrap: variables.$swal2-progress-steps-flex-wrap;
+    align-items: variables.$swal2-progress-steps-align-items;
+    max-width: variables.$swal2-progress-steps-max-width;
+    margin: variables.$swal2-progress-steps-margin;
+    padding: variables.$swal2-progress-steps-padding;
+    background: variables.$swal2-progress-steps-background;
+    font-weight: variables.$swal2-progress-steps-font-weight;
 
     li {
       display: inline-block;
@@ -526,24 +528,24 @@ div:where(.swal2-container) {
     .swal2-progress-step {
       z-index: 20;
       flex-shrink: 0;
-      width: $swal2-progress-step-width;
-      height: $swal2-progress-step-height;
-      border-radius: $swal2-progress-step-border-radius;
-      background: $swal2-active-step-background;
-      color: $swal2-active-step-color;
-      line-height: $swal2-progress-step-height;
+      width: variables.$swal2-progress-step-width;
+      height: variables.$swal2-progress-step-height;
+      border-radius: variables.$swal2-progress-step-border-radius;
+      background: variables.$swal2-active-step-background;
+      color: variables.$swal2-active-step-color;
+      line-height: variables.$swal2-progress-step-height;
       text-align: center;
 
       &.swal2-active-progress-step {
-        background: $swal2-active-step-background;
+        background: variables.$swal2-active-step-background;
 
         ~ .swal2-progress-step {
-          background: $swal2-progress-step-background;
-          color: $swal2-progress-step-color;
+          background: variables.$swal2-progress-step-background;
+          color: variables.$swal2-progress-step-color;
         }
 
         ~ .swal2-progress-step-line {
-          background: $swal2-progress-step-background;
+          background: variables.$swal2-progress-step-background;
         }
       }
     }
@@ -551,15 +553,15 @@ div:where(.swal2-container) {
     .swal2-progress-step-line {
       z-index: 10;
       flex-shrink: 0;
-      width: $swal2-progress-steps-distance;
+      width: variables.$swal2-progress-steps-distance;
       height: 0.4em;
       margin: 0 -1px;
-      background: $swal2-active-step-background;
+      background: variables.$swal2-active-step-background;
     }
   }
 }
 
-@import 'icons';
+@include meta.load-css('icons');
 
 // github.com/sweetalert2/sweetalert2/issues/268
 [class^='swal2'] {
@@ -567,11 +569,11 @@ div:where(.swal2-container) {
 }
 
 .swal2-show {
-  animation: $swal2-show-animation;
+  animation: variables.$swal2-show-animation;
 }
 
 .swal2-hide {
-  animation: $swal2-hide-animation;
+  animation: variables.$swal2-hide-animation;
 }
 
 .swal2-noanimation {
@@ -591,7 +593,7 @@ div:where(.swal2-container) {
 .swal2-rtl {
   .swal2-close {
     margin-right: initial;
-    margin-left: $swal2-close-button-gap;
+    margin-left: variables.$swal2-close-button-gap;
   }
 
   .swal2-timer-progress-bar {

--- a/src/scss/_icons.scss
+++ b/src/scss/_icons.scss
@@ -1,3 +1,4 @@
+@use "../variables";
 @use 'sass:color';
 @use 'sass:math';
 
@@ -5,33 +6,33 @@
 @function strip-units($number) {
   @return math.div($number, ($number * 0 + 1));
 }
-$icon-zoom: math.div(strip-units($swal2-icon-size), 5);
+$icon-zoom: math.div(strip-units(variables.$swal2-icon-size), 5);
 
 div:where(.swal2-icon) {
   position: relative;
   box-sizing: content-box;
   justify-content: center;
-  width: $swal2-icon-size;
-  height: $swal2-icon-size;
-  margin: $swal2-icon-margin;
-  zoom: $swal2-icon-zoom;
+  width: variables.$swal2-icon-size;
+  height: variables.$swal2-icon-size;
+  margin: variables.$swal2-icon-margin;
+  zoom: variables.$swal2-icon-zoom;
   border: #{0.25em * $icon-zoom} solid transparent;
   border-radius: 50%;
-  border-color: $swal2-icon-border-color;
-  font-family: $swal2-icon-font-family;
-  line-height: $swal2-icon-size;
+  border-color: variables.$swal2-icon-border-color;
+  font-family: variables.$swal2-icon-font-family;
+  line-height: variables.$swal2-icon-size;
   cursor: default;
   user-select: none;
 
   .swal2-icon-content {
     display: flex;
     align-items: center;
-    font-size: $swal2-icon-font-size;
+    font-size: variables.$swal2-icon-font-size;
   }
 
   &.swal2-error {
-    border-color: $swal2-error;
-    color: $swal2-error;
+    border-color: variables.$swal2-error;
+    color: variables.$swal2-error;
 
     .swal2-x-mark {
       position: relative;
@@ -49,7 +50,7 @@ div:where(.swal2-icon) {
       width: 2.9375em;
       height: 0.3125em;
       border-radius: 0.125em;
-      background-color: $swal2-error;
+      background-color: variables.$swal2-error;
 
       &[class$='left'] {
         left: 1.0625em;
@@ -64,7 +65,7 @@ div:where(.swal2-icon) {
 
     // Error icon animation
     &.swal2-icon-show {
-      @if $swal2-icon-animations {
+      @if variables.$swal2-icon-animations {
         animation: swal2-animate-error-icon 0.5s;
 
         .swal2-x-mark {
@@ -75,12 +76,12 @@ div:where(.swal2-icon) {
   }
 
   &.swal2-warning {
-    border-color: color.adjust($swal2-warning, $lightness: 7%);
-    color: $swal2-warning;
+    border-color: color.adjust(variables.$swal2-warning, $lightness: 7%);
+    color: variables.$swal2-warning;
 
     // Warning icon animation
     &.swal2-icon-show {
-      @if $swal2-icon-animations {
+      @if variables.$swal2-icon-animations {
         animation: swal2-animate-error-icon 0.5s;
 
         .swal2-icon-content {
@@ -91,12 +92,12 @@ div:where(.swal2-icon) {
   }
 
   &.swal2-info {
-    border-color: color.adjust($swal2-info, $lightness: 20%);
-    color: $swal2-info;
+    border-color: color.adjust(variables.$swal2-info, $lightness: 20%);
+    color: variables.$swal2-info;
 
     // Info icon animation
     &.swal2-icon-show {
-      @if $swal2-icon-animations {
+      @if variables.$swal2-icon-animations {
         animation: swal2-animate-error-icon 0.5s;
 
         .swal2-icon-content {
@@ -107,12 +108,12 @@ div:where(.swal2-icon) {
   }
 
   &.swal2-question {
-    border-color: color.adjust($swal2-question, $lightness: 20%);
-    color: $swal2-question;
+    border-color: color.adjust(variables.$swal2-question, $lightness: 20%);
+    color: variables.$swal2-question;
 
     // Question icon animation
     &.swal2-icon-show {
-      @if $swal2-icon-animations {
+      @if variables.$swal2-icon-animations {
         animation: swal2-animate-error-icon 0.5s;
 
         .swal2-icon-content {
@@ -123,8 +124,8 @@ div:where(.swal2-icon) {
   }
 
   &.swal2-success {
-    border-color: $swal2-success;
-    color: $swal2-success;
+    border-color: variables.$swal2-success;
+    color: variables.$swal2-success;
 
     [class^='swal2-success-circular-line'] {
       // Emulate moving circular line
@@ -167,7 +168,7 @@ div:where(.swal2-icon) {
       box-sizing: content-box;
       width: 100%;
       height: 100%;
-      border: 0.25em solid $swal2-success-border;
+      border: 0.25em solid variables.$swal2-success-border;
       border-radius: 50%;
 
       @if $icon-zoom != 1 {
@@ -196,7 +197,7 @@ div:where(.swal2-icon) {
       z-index: 2;
       height: 0.3125em;
       border-radius: 0.125em;
-      background-color: $swal2-success;
+      background-color: variables.$swal2-success;
 
       &[class$='tip'] {
         top: 2.875em;
@@ -219,7 +220,7 @@ div:where(.swal2-icon) {
 
     // Success icon animation
     &.swal2-icon-show {
-      @if $swal2-icon-animations {
+      @if variables.$swal2-icon-animations {
         .swal2-success-line-tip {
           animation: swal2-animate-success-line-tip 0.75s;
         }

--- a/src/scss/_theming.scss
+++ b/src/scss/_theming.scss
@@ -1,7 +1,7 @@
 // base file for including when performing theming
 // doesn't include at-rules or root selectors (like body) which allows for more comprehensive extending
 
-@import '../variables';
-@import 'toasts';
-@import 'body';
-@import 'core';
+@use '../variables';
+@use 'toasts';
+@use 'body';
+@use 'core';

--- a/src/scss/_toasts-body.scss
+++ b/src/scss/_toasts-body.scss
@@ -1,8 +1,10 @@
+@use "../variables";
+
 @mixin sweetalert2-toasts-body() {
   &.swal2-toast-shown {
     .swal2-container {
       box-sizing: border-box;
-      width: $swal2-toast-width;
+      width: variables.$swal2-toast-width;
       max-width: 100%;
       background-color: transparent;
       pointer-events: none;

--- a/src/scss/_toasts.scss
+++ b/src/scss/_toasts.scss
@@ -1,13 +1,15 @@
+@use "../variables";
+
 .swal2-popup {
   &.swal2-toast {
     box-sizing: border-box;
     grid-column: 1/4 !important;
     grid-row: 1/4 !important;
     grid-template-columns: min-content auto min-content;
-    padding: $swal2-toast-padding;
+    padding: variables.$swal2-toast-padding;
     overflow-y: hidden;
-    background: $swal2-toast-background;
-    box-shadow: $swal2-toast-box-shadow;
+    background: variables.$swal2-toast-background;
+    box-shadow: variables.$swal2-toast-box-shadow;
     pointer-events: all;
 
     > * {
@@ -15,9 +17,9 @@
     }
 
     .swal2-title {
-      margin: $swal2-toast-title-margin;
-      padding: $swal2-toast-title-padding;
-      font-size: $swal2-toast-title-font-size;
+      margin: variables.$swal2-toast-title-margin;
+      padding: variables.$swal2-toast-title-padding;
+      font-size: variables.$swal2-toast-title-font-size;
       text-align: initial;
     }
 
@@ -26,36 +28,36 @@
     }
 
     .swal2-input {
-      height: $swal2-toast-input-height;
-      margin: $swal2-toast-input-margin;
-      font-size: $swal2-toast-input-font-size;
+      height: variables.$swal2-toast-input-height;
+      margin: variables.$swal2-toast-input-margin;
+      font-size: variables.$swal2-toast-input-font-size;
     }
 
     .swal2-validation-message {
-      font-size: $swal2-toast-validation-font-size;
+      font-size: variables.$swal2-toast-validation-font-size;
     }
 
     .swal2-footer {
-      margin: $swal2-toast-footer-margin;
-      padding: $swal2-toast-footer-margin;
-      font-size: $swal2-toast-footer-font-size;
+      margin: variables.$swal2-toast-footer-margin;
+      padding: variables.$swal2-toast-footer-margin;
+      font-size: variables.$swal2-toast-footer-font-size;
     }
 
     .swal2-close {
       grid-column: 3/3;
       grid-row: 1/99;
       align-self: center;
-      width: $swal2-toast-close-button-width;
-      height: $swal2-toast-close-button-height;
-      margin: $swal2-toast-close-button-margin;
-      font-size: $swal2-toast-close-button-font-size;
+      width: variables.$swal2-toast-close-button-width;
+      height: variables.$swal2-toast-close-button-height;
+      margin: variables.$swal2-toast-close-button-margin;
+      font-size: variables.$swal2-toast-close-button-font-size;
     }
 
     .swal2-html-container {
-      margin: $swal2-toast-html-container-margin;
-      padding: $swal2-toast-html-container-padding;
+      margin: variables.$swal2-toast-html-container-margin;
+      padding: variables.$swal2-toast-html-container-padding;
       overflow: initial;
-      font-size: $swal2-toast-html-container-font-size;
+      font-size: variables.$swal2-toast-html-container-font-size;
       text-align: initial;
 
       &:empty {
@@ -84,7 +86,7 @@
       .swal2-icon-content {
         display: flex;
         align-items: center;
-        font-size: $swal2-toast-icon-font-size;
+        font-size: variables.$swal2-toast-icon-font-size;
         font-weight: bold;
       }
 
@@ -122,11 +124,11 @@
     .swal2-styled {
       margin: 0.25em 0.5em;
       padding: 0.4em 0.6em;
-      font-size: $swal2-toast-buttons-font-size;
+      font-size: variables.$swal2-toast-buttons-font-size;
     }
 
     .swal2-success {
-      border-color: $swal2-success;
+      border-color: variables.$swal2-success;
 
       [class^='swal2-success-circular-line'] {
         // Emulate moving circular line
@@ -180,7 +182,7 @@
       }
 
       &.swal2-icon-show {
-        @if $swal2-icon-animations {
+        @if variables.$swal2-icon-animations {
           .swal2-success-line-tip {
             animation: swal2-toast-animate-success-line-tip 0.75s;
           }
@@ -193,11 +195,11 @@
     }
 
     &.swal2-show {
-      animation: $swal2-toast-show-animation;
+      animation: variables.$swal2-toast-show-animation;
     }
 
     &.swal2-hide {
-      animation: $swal2-toast-hide-animation;
+      animation: variables.$swal2-toast-hide-animation;
     }
   }
 }

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -1,10 +1,12 @@
 // SweetAlert2
 // github.com/sweetalert2/sweetalert2
 
-@import 'scss/theming';
-@import 'scss/animations';
+@use 'scss/theming';
+@use 'scss/animations';
+@use "scss/body";
+@use "scss/toasts-body";
 
 body {
-  @include sweetalert2-body();
-  @include sweetalert2-toasts-body();
+  @include body.sweetalert2-body();
+  @include toasts-body.sweetalert2-toasts-body();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2666,10 +2666,10 @@ ignore@^6.0.2:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-6.0.2.tgz#77cccb72a55796af1b6d2f9eb14fa326d24f4283"
   integrity sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==
 
-immutable@^4.0.0:
-  version "4.3.7"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.7.tgz#c70145fc90d89fb02021e65c84eb0226e4e5a381"
-  integrity sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==
+immutable@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.0.3.tgz#aa037e2313ea7b5d400cd9298fa14e404c933db1"
+  integrity sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==
 
 import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
@@ -3496,15 +3496,16 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass@~1.79.0:
-  version "1.79.6"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.79.6.tgz#35a53c3dbaf66a25f132979f47346521e4ef77cb"
-  integrity sha512-PVVjeeiUGx6Nj4PtEE/ecwu8ltwfPKzHxbbVmmLj4l1FYHhOyfA0scuVF8sVaa+b+VY4z7BVKjKq0cPUQdUU3g==
+sass@^1.83.0:
+  version "1.83.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.83.0.tgz#e36842c0b88a94ed336fd16249b878a0541d536f"
+  integrity sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==
   dependencies:
-    "@parcel/watcher" "^2.4.1"
     chokidar "^4.0.0"
-    immutable "^4.0.0"
+    immutable "^5.0.2"
     source-map-js ">=0.6.2 <2.0.0"
+  optionalDependencies:
+    "@parcel/watcher" "^2.4.1"
 
 semver@^6.3.1:
   version "6.3.1"


### PR DESCRIPTION
fixes #2780

Fixing these annoying warnings:

```
DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
6 │ @import 'body';
  │         ^^^^^^
  ╵
    src/scss/_theming.scss 6:9  @import
    src/sweetalert2.scss 4:9    root stylesheet
```

https://sass-lang.com/documentation/breaking-changes/import/

This PR is basically the result of running

```sh
sass-migrator module --migrate-deps src/sweetalert2.scss
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Updates**
	- Updated `sass` dependency to version 1.83.0, allowing more flexible updates.

- **Style Improvements**
	- Transitioned SCSS imports from `@import` to `@use` for better modularity.
	- Updated variable references to use a namespaced approach across stylesheets.
	- Improved organization of style variables and imports.

- **Technical Refactoring**
	- Standardized variable management in SCSS files.
	- Enhanced code structure for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->