### PR TITLE
feat: use CSS variables and built-in themes

### DIFF
--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -2056,6 +2056,38 @@ describe('global events and listeners', () => {
   })
 })
 
+describe('theme', () => {
+  it('should use light theme by default', () => {
+    SwalWithoutAnimation.fire()
+    const computedPopupStyle = window.getComputedStyle(Swal.getPopup())
+    expect(computedPopupStyle.backgroundColor).to.equal('rgb(255, 255, 255)')
+  })
+
+  it('should show dark theme', () => {
+    SwalWithoutAnimation.fire({ theme: 'dark' })
+    const computedPopupStyle = window.getComputedStyle(Swal.getPopup())
+    expect(computedPopupStyle.backgroundColor).to.equal('rgb(25, 25, 26)')
+  })
+
+  it('should show auto theme', () => {
+    SwalWithoutAnimation.fire({ theme: 'auto' })
+    const computedPopupStyle = window.getComputedStyle(Swal.getPopup())
+    if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+      expect(computedPopupStyle.backgroundColor).to.equal('rgb(255, 255, 255)')
+    } else {
+      expect(computedPopupStyle.backgroundColor).to.equal('rgb(25, 25, 26)')
+    }
+  })
+
+  it('should throw a warning when theme param is invalid', () => {
+    const spy = cy.spy(console, 'warn')
+    SwalWithoutAnimation.fire({
+      theme: 'foo',
+    })
+    expect(spy.calledWith(`SweetAlert2: Invalid theme "foo". Expected "light", "dark", or "auto"`)).to.be.true
+  })
+})
+
 describe('update()', () => {
   it('all updatableParams are valid', () => {
     expect(updatableParams.length).not.to.equal(0)
@@ -2297,6 +2329,13 @@ describe('update()', () => {
       done()
     })
     Swal.clickConfirm()
+  })
+
+  it('update() method should throw a warning about invalid new params', () => {
+    const spy = cy.spy(console, 'warn')
+    SwalWithoutAnimation.fire()
+    Swal.update({ theme: 'foo' })
+    expect(spy.calledWith(`SweetAlert2: Invalid theme "foo". Expected "light", "dark", or "auto"`)).to.be.true
   })
 })
 

--- a/src/instanceMethods/update.js
+++ b/src/instanceMethods/update.js
@@ -9,6 +9,7 @@ import privateProps from '../privateProps.js'
  * @param {SweetAlertOptions} params
  */
 export function update(params) {
+  const container = dom.getContainer()
   const popup = dom.getPopup()
   const innerParams = privateProps.innerParams.get(this)
 
@@ -23,6 +24,7 @@ export function update(params) {
 
   const updatedParams = Object.assign({}, innerParams, validUpdatableParams)
 
+  container.dataset['swal2Theme'] = updatedParams.theme
   dom.render(this, updatedParams)
 
   privateProps.innerParams.set(this, updatedParams)

--- a/src/instanceMethods/update.js
+++ b/src/instanceMethods/update.js
@@ -1,5 +1,5 @@
 import * as dom from '../../src/utils/dom/index.js'
-import { isUpdatableParameter } from '../../src/utils/params.js'
+import { isUpdatableParameter, showWarningsForParams } from '../../src/utils/params.js'
 import { warn } from '../../src/utils/utils.js'
 import privateProps from '../privateProps.js'
 
@@ -23,6 +23,7 @@ export function update(params) {
   const validUpdatableParams = filterValidParams(params)
 
   const updatedParams = Object.assign({}, innerParams, validUpdatableParams)
+  showWarningsForParams(updatedParams)
 
   container.dataset['swal2Theme'] = updatedParams.theme
   dom.render(this, updatedParams)

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -1,35 +1,86 @@
 // SweetAlert2
 // github.com/sweetalert2/sweetalert2
 
+// CSS Variables
+:root {
+  // CONTAINER
+  --swal2-container-padding: 0.625em;
+
+  // BACKDROP
+  --swal2-backdrop: rgba(0, 0, 0, 0.4);
+
+  // POPUP
+  --swal2-width: 32em;
+  --swal2-padding: 0 0 1.25em;
+  --swal2-border: none;
+  --swal2-border-radius: 0.3125rem;
+  --swal2-background: white;
+  --swal2-color: #545454;
+  --swal2-footer-border-color: #eee;
+
+  // INPUT
+  --swal2-input-background: transparent;
+
+  // VALIDATION MESSAGE
+  --swal2-validation-message-background: #f0f0f0;
+  --swal2-validation-message-color: #666;
+}
+
+// DARK THEME
+@mixin dark-theme {
+  --swal2-dark-theme-black: #19191a;
+  --swal2-dark-theme-white: #e1e1e1;
+
+  // POPUP
+  --swal2-background: var(--swal2-dark-theme-black);
+  --swal2-color: var(--swal2-dark-theme-white);
+  --swal2-footer-border-color: #555;
+
+  // INPUT
+  --swal2-input-background: color-mix(in srgb, var(--swal2-dark-theme-black), var(--swal2-dark-theme-white) 10%);
+
+  // VALIDATION MESSAGE
+  --swal2-validation-message-background: color-mix(in srgb, var(--swal2-dark-theme-black), var(--swal2-dark-theme-white) 10%);
+  --swal2-validation-message-color: var(--swal2-dark-theme-white);
+}
+
+[data-swal2-theme="dark"] {
+  @include dark-theme;
+}
+
+// AUTO THEME, based on prefers-color-scheme
+@media (prefers-color-scheme: dark) {
+  [data-swal2-theme="auto"] {
+    @include dark-theme;
+  }
+}
+
 $swal2-white: #fff !default;
 $swal2-black: #000 !default;
 $swal2-outline-color: rgba(100, 150, 200, 0.5) !default;
 
 // CONTAINER
-$swal2-container-padding: 0.625em !default;
+$swal2-container-padding: var(--swal2-container-padding) !default;
+
+// BACKDROP
+$swal2-backdrop: var(--swal2-backdrop) !default;
+$swal2-backdrop-transition: background-color .1s !default;
 
 // POPUP
-$swal2-width: 32em !default;
-$swal2-padding: 0 0 1.25em !default;
-$swal2-border: none !default;
-$swal2-color: #545454 !default;
-$swal2-border-radius: 5px !default;
-$swal2-box-shadow: #d9d9d9 !default;
+$swal2-width: var(--swal2-width) !default;
+$swal2-padding: var(--swal2-padding) !default;
+$swal2-border: var(--swal2-border) !default;
+$swal2-border-radius: var(--swal2-border-radius) !default;
+$swal2-background: var(--swal2-background) !default;
+$swal2-color: var(--swal2-color) !default;
 
 // ANIMATIONS
 $swal2-show-animation: swal2-show 0.3s !default;
 $swal2-hide-animation: swal2-hide 0.15s forwards !default;
 
-// BACKGROUND
-$swal2-background: $swal2-white !default;
-
 // TYPOGRAPHY
 $swal2-font: inherit !default;
 $swal2-font-size: 1rem !default;
-
-// BACKDROP
-$swal2-backdrop: rgba($swal2-black, 0.4) !default;
-$swal2-backdrop-transition: background-color 0.1s !default;
 
 // ICONS
 $swal2-icon-size: 5em !default;
@@ -84,7 +135,7 @@ $swal2-input-box-shadow:
   inset 0 1px 1px rgba($swal2-black, 0.06),
   0 0 0 3px transparent !default;
 $swal2-input-font-size: 1.125em !default;
-$swal2-input-background: transparent !default;
+$swal2-input-background: var(--swal2-input-background) !default;
 $swal2-input-color: inherit !default;
 $swal2-input-transition:
   border-color 0.1s,
@@ -110,8 +161,8 @@ $swal2-validation-message-align-items: center !default;
 $swal2-validation-message-justify-content: center !default;
 $swal2-validation-message-margin: 1em 0 0 !default;
 $swal2-validation-message-padding: 0.625em !default;
-$swal2-validation-message-background: #f0f0f0 !default;
-$swal2-validation-message-color: #666 !default;
+$swal2-validation-message-background: var(--swal2-validation-message-background) !default;
+$swal2-validation-message-color: var(--swal2-validation-message-color) !default;
 $swal2-validation-message-font-size: 1em !default;
 $swal2-validation-message-font-weight: 300 !default;
 $swal2-validation-message-icon-background: $swal2-error !default;
@@ -138,7 +189,7 @@ $swal2-active-step-color: $swal2-white !default;
 // FOOTER
 $swal2-footer-margin: 1em 0 0 !default;
 $swal2-footer-padding: 1em 1em 0 !default;
-$swal2-footer-border-color: #eee !default;
+$swal2-footer-border-color: var(--swal2-footer-border-color) !default;
 $swal2-footer-color: inherit !default;
 $swal2-footer-font-size: 1em !default;
 $swal2-footer-text-align: center !default;

--- a/src/utils/dom/init.js
+++ b/src/utils/dom/init.js
@@ -142,6 +142,8 @@ export const init = (params) => {
   }
   setInnerHtml(container, sweetHTML)
 
+  container.dataset['swal2Theme'] = params.theme
+
   const targetElement = getTarget(params.target)
   targetElement.appendChild(container)
 

--- a/src/utils/dom/renderers/renderIcon.js
+++ b/src/utils/dom/renderers/renderIcon.js
@@ -43,6 +43,10 @@ export const renderIcon = (instance, params) => {
 
   // Animate icon
   dom.addClass(icon, params.showClass && params.showClass.icon)
+
+  // Re-adjust the success icon on system theme change
+  const colorSchemeQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+  colorSchemeQueryList.addEventListener('change', adjustSuccessIconBackgroundColor);
 }
 
 /**

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -228,6 +228,10 @@ export const showWarningsForParams = (params) => {
     warn('"allowOutsideClick" parameter requires `backdrop` parameter to be set to `true`')
   }
 
+  if (params.theme && !['light', 'dark', 'auto'].includes(params.theme)) {
+    warn(`Invalid theme "${params.theme}". Expected "light", "dark", or "auto"`)
+  }
+
   for (const param in params) {
     checkIfParamIsValid(param)
 

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -13,6 +13,7 @@ export const defaultParams = {
   toast: false,
   draggable: false,
   animation: true,
+  theme: 'light',
   showClass: {
     popup: 'swal2-show',
     backdrop: 'swal2-backdrop-show',
@@ -137,6 +138,7 @@ export const updatableParams = [
   'text',
   'title',
   'titleText',
+  'theme',
   'willClose',
 ]
 

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -420,6 +420,8 @@ declare module 'sweetalert2' {
         inputValidator?: (file: File | FileList | null) => SyncOrAsync<string | null | false | void>
       }
 
+  export type SweetAlertTheme = 'light' | 'dark' | 'auto'
+
   export type SweetAlertPosition =
     | 'top'
     | 'top-start'
@@ -706,6 +708,18 @@ declare module 'sweetalert2' {
      * @default true
      */
     animation?: boolean | undefined
+
+    /**
+     * Theme of the popup. 'light', 'dark', and 'auto' for now.
+     * This is a new feature, more themes are coming.
+     * Feel free to request new themes (or create your own and PR it).
+     *
+     * The defaul theme in the ideal world would be 'auto'. But for now, it's 'light'
+     * in order not to bring a breaking change to the existing users.
+     *
+     * @default 'light'
+     */
+    theme?: SweetAlertTheme
 
     /**
      * CSS classes for animations when showing a popup (fade in)


### PR DESCRIPTION
This PR introduces built-in support for light, dark, and auto (system-preferred) themes.

### Why is this important?
Many users expect native support for dark and light modes, especially in modern applications. I personally consider themes as a part of a11y.

Here's the new optional param that'll be available:

```js
Swal.fire({
  theme: 'light', // or 'dark' or 'auto'
})
```

In the ideal world the default theme would be `'auto'`. But for now, it's `'light'` in order not to bring a breaking change to the existing users.

Previously, users may have needed to implement theme switching manually (https://github.com/sweetalert2/sweetalert2/issues/2469#issuecomment-1219975933) which is a hustle that can be now avoided thanks for widely supported [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Introduced dynamic theming for pop-up notifications with selectable options: light, dark, and auto. The pop-up adapts to your system preferences.
	- Enhanced parameter validation now provides clear warnings when an invalid theme is selected.
- Style
	- Upgraded styling with modern customizable design properties for a smoother, more consistent look.
	- Success icons automatically adjust to align with the chosen theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->