### PR TITLE
fix: toast background color fixed to white in dark theme

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -296,7 +296,7 @@ $swal2-toast-box-shadow:
   1px 2px 4px hsl(0deg 0% 0% / 0.075),
   1px 3px 8px hsl(0deg 0% 0% / 0.075),
   2px 4px 16px hsl(0deg 0% 0% / 0.075) !default;
-$swal2-toast-background: $swal2-white !default;
+$swal2-toast-background: $swal2-background !default;
 $swal2-toast-close-button-width: 0.8em !default;
 $swal2-toast-close-button-height: 0.8em !default;
 $swal2-toast-close-button-margin: 0 !default;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the toast notification background to use a dynamic color, enhancing the visual consistency and adaptability of the notification display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->