### PR TITLE
feat: match outline color with custom button colors

### DIFF
--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -1244,7 +1244,7 @@ describe('template', () => {
     expect($('.swal2-select option:nth-child(3)').selected).to.be.true
     expect(isHidden(Swal.getConfirmButton())).to.be.true
     expect(isVisible(Swal.getCancelButton())).to.be.true
-    expect(Swal.getDenyButton().style.backgroundColor).to.equal('red')
+    expect(window.getComputedStyle(Swal.getDenyButton()).backgroundColor).to.equal('rgb(255, 0, 0)')
     expect(Swal.getPopup().style.width).to.equal('200px')
     expect(isVisible(Swal.getDenyButton())).to.be.true
     expect(Swal.getCancelButton().nextSibling).to.equal(Swal.getDenyButton())
@@ -2899,7 +2899,7 @@ describe('Miscellaneous tests', function () {
   })
 
   it('visual appearance', () => {
-    Swal.fire({
+    SwalWithoutAnimation.fire({
       padding: '2em',
       background: 'red',
       confirmButtonColor: 'green',
@@ -2908,10 +2908,19 @@ describe('Miscellaneous tests', function () {
     })
 
     expect(Swal.getPopup().style.padding).to.equal('2em')
-    expect(window.getComputedStyle(Swal.getPopup()).backgroundColor, 'rgb(255, 0).to.equal(0)')
-    expect(Swal.getConfirmButton().style.backgroundColor).to.equal('green')
-    expect(Swal.getDenyButton().style.backgroundColor).to.equal('red')
-    expect(Swal.getCancelButton().style.backgroundColor).to.equal('blue')
+    expect(window.getComputedStyle(Swal.getPopup()).backgroundColor).to.equal('rgb(255, 0, 0)')
+    expect(window.getComputedStyle(Swal.getConfirmButton()).backgroundColor).to.equal('rgb(0, 128, 0)')
+    expect(window.getComputedStyle(Swal.getDenyButton()).backgroundColor).to.equal('rgb(255, 0, 0)')
+    expect(window.getComputedStyle(Swal.getCancelButton()).backgroundColor).to.equal('rgb(0, 0, 255)')
+    expect(Swal.getConfirmButton().style.getPropertyValue('--swal2-action-button-outline')).to.equal(
+      '0 0 0 3px rgba(0, 128, 0, 0.5)'
+    )
+    expect(Swal.getDenyButton().style.getPropertyValue('--swal2-action-button-outline')).to.equal(
+      '0 0 0 3px rgba(255, 0, 0, 0.5)'
+    )
+    expect(Swal.getCancelButton().style.getPropertyValue('--swal2-action-button-outline')).to.equal(
+      '0 0 0 3px rgba(0, 0, 255, 0.5)'
+    )
   })
 
   it('null values', () => {

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -3,6 +3,8 @@
 
 // CSS Variables
 :root {
+  --swal2-outline: 0 0 0 3px rgba(100, 150, 200, 0.5);
+
   // CONTAINER
   --swal2-container-padding: 0.625em;
 
@@ -45,9 +47,20 @@
   --swal2-close-button-color: #ccc;
   --swal2-close-button-transition: color 0.1s, box-shadow 0.1s;
   --swal2-close-button-outline: initial;
+  --swal2-close-button-box-shadow: inset 0 0 0 3px transparent;
+  --swal2-close-button-focus-box-shadow: inset var(--swal2-outline);
 
   // CLOSE BUTTON:HOVER
   --swal2-close-button-hover-transform: none;
+
+  // CONFIRM BUTTON
+  --swal2-confirm-button-background-color: #7066e0;
+
+  // DENY BUTTON
+  --swal2-deny-button-background-color: #dc3741;
+
+  // CANCEL BUTTON
+  --swal2-cancel-button-background-color: #6e7881;
 }
 
 // DARK THEME
@@ -244,7 +257,7 @@ $swal2-close-button-background: transparent !default;
 $swal2-close-button-color: var(--swal2-close-button-color) !default;
 $swal2-close-button-font-family: monospace !default;
 $swal2-close-button-font-size: var(--swal2-close-button-font-size) !default;
-$swal2-close-button-box-shadow: inset 0 0 0 3px transparent !default;
+$swal2-close-button-box-shadow: var(--swal2-close-button-box-shadow) !default;
 
 // CLOSE BUTTON:HOVER
 $swal2-close-button-hover-transform: var(--swal2-close-button-hover-transform) !default;
@@ -253,7 +266,7 @@ $swal2-close-button-hover-background: transparent !default;
 
 // CLOSE BUTTON:FOCUS
 $swal2-close-button-focus-outline: none !default;
-$swal2-close-button-focus-box-shadow: inset 0 0 0 3px $swal2-outline-color !default;
+$swal2-close-button-focus-box-shadow: var(--swal2-close-button-focus-box-shadow) !default;
 
 // ACTIONS
 $swal2-actions-flex-wrap: wrap !default;
@@ -271,35 +284,30 @@ $swal2-button-box-shadow: 0 0 0 3px transparent !default;
 $swal2-button-font-weight: 500 !default;
 $swal2-button-darken-hover: rgba($swal2-black, 0.1) !default;
 $swal2-button-darken-active: rgba($swal2-black, 0.2) !default;
-$swal2-button-focus-outline: none !default;
-$swal2-button-focus-box-shadow: 0 0 0 3px $swal2-outline-color !default;
 
 // CONFIRM BUTTON
 $swal2-confirm-button-order: null !default;
 $swal2-confirm-button-border: 0 !default;
 $swal2-confirm-button-border-radius: 0.25em !default;
-$swal2-confirm-button-background-color: #7066e0 !default;
+$swal2-confirm-button-background-color: var(--swal2-confirm-button-background-color) !default;
 $swal2-confirm-button-color: $swal2-white !default;
 $swal2-confirm-button-font-size: 1em !default;
-$swal2-confirm-button-focus-box-shadow: 0 0 0 3px rgba($swal2-confirm-button-background-color, 0.5) !default;
 
 // DENY BUTTON
 $swal2-deny-button-order: null !default;
 $swal2-deny-button-border: 0 !default;
 $swal2-deny-button-border-radius: 0.25em !default;
-$swal2-deny-button-background-color: #dc3741 !default;
+$swal2-deny-button-background-color: var(--swal2-deny-button-background-color) !default;
 $swal2-deny-button-color: $swal2-white !default;
 $swal2-deny-button-font-size: 1em !default;
-$swal2-deny-button-focus-box-shadow: 0 0 0 3px rgba($swal2-deny-button-background-color, 0.5) !default;
 
 // CANCEL BUTTON
 $swal2-cancel-button-order: null !default;
 $swal2-cancel-button-border: 0 !default;
 $swal2-cancel-button-border-radius: 0.25em !default;
-$swal2-cancel-button-background-color: #6e7881 !default;
+$swal2-cancel-button-background-color: var(--swal2-cancel-button-background-color) !default;
 $swal2-cancel-button-color: $swal2-white !default;
 $swal2-cancel-button-font-size: 1em !default;
-$swal2-cancel-button-focus-box-shadow: 0 0 0 3px rgba($swal2-cancel-button-background-color, 0.5) !default;
 
 // LOADER
 $swal2-loader-align-items: center !default;
@@ -677,10 +685,6 @@ div:where(.swal2-container) {
       background-color: $swal2-confirm-button-background-color;
       color: $swal2-confirm-button-color;
       font-size: $swal2-confirm-button-font-size;
-
-      &:focus-visible {
-        box-shadow: $swal2-confirm-button-focus-box-shadow;
-      }
     }
 
     &:where(.swal2-deny) {
@@ -691,10 +695,6 @@ div:where(.swal2-container) {
       background-color: $swal2-deny-button-background-color;
       color: $swal2-deny-button-color;
       font-size: $swal2-deny-button-font-size;
-
-      &:focus-visible {
-        box-shadow: $swal2-deny-button-focus-box-shadow;
-      }
     }
 
     &:where(.swal2-cancel) {
@@ -705,20 +705,11 @@ div:where(.swal2-container) {
       background-color: $swal2-cancel-button-background-color;
       color: $swal2-cancel-button-color;
       font-size: $swal2-cancel-button-font-size;
-
-      &:focus-visible {
-        box-shadow: $swal2-cancel-button-focus-box-shadow;
-      }
-    }
-
-    &.swal2-default-outline {
-      &:focus-visible {
-        box-shadow: $swal2-button-focus-box-shadow;
-      }
     }
 
     &:focus-visible {
-      outline: $swal2-button-focus-outline;
+      outline: none;
+      box-shadow: var(--swal2-action-button-outline);
     }
 
     &::-moz-focus-inner {

--- a/src/types.js
+++ b/src/types.js
@@ -62,7 +62,6 @@
  *   | 'confirm'
  *   | 'deny'
  *   | 'cancel'
- *   | 'default-outline'
  *   | 'footer'
  *   | 'icon'
  *   | 'icon-content'

--- a/src/utils/classes.js
+++ b/src/utils/classes.js
@@ -30,7 +30,6 @@ const classNames = [
   'confirm',
   'deny',
   'cancel',
-  'default-outline',
   'footer',
   'icon',
   'icon-content',

--- a/src/utils/dom/renderers/renderActions.js
+++ b/src/utils/dom/renderers/renderActions.js
@@ -76,19 +76,33 @@ function handleButtonsStyling(confirmButton, denyButton, cancelButton, params) {
 
   dom.addClass([confirmButton, denyButton, cancelButton], swalClasses.styled)
 
-  // Buttons background colors
+  // Apply custom background colors to action buttons
   if (params.confirmButtonColor) {
-    confirmButton.style.backgroundColor = params.confirmButtonColor
-    dom.addClass(confirmButton, swalClasses['default-outline'])
+    confirmButton.style.setProperty('--swal2-confirm-button-background-color', params.confirmButtonColor)
   }
   if (params.denyButtonColor) {
-    denyButton.style.backgroundColor = params.denyButtonColor
-    dom.addClass(denyButton, swalClasses['default-outline'])
+    denyButton.style.setProperty('--swal2-deny-button-background-color', params.denyButtonColor)
   }
   if (params.cancelButtonColor) {
-    cancelButton.style.backgroundColor = params.cancelButtonColor
-    dom.addClass(cancelButton, swalClasses['default-outline'])
+    cancelButton.style.setProperty('--swal2-cancel-button-background-color', params.cancelButtonColor)
   }
+
+  // Apply the outline color to action buttons
+  applyOutlineColor(confirmButton)
+  applyOutlineColor(denyButton)
+  applyOutlineColor(cancelButton)
+}
+
+/**
+ * @param {HTMLElement} button
+ */
+function applyOutlineColor(button) {
+  const buttonStyle = window.getComputedStyle(button)
+  const outlineColor = buttonStyle.backgroundColor.replace(/rgba?\((\d+), (\d+), (\d+).*/, 'rgba($1, $2, $3, 0.5)')
+  button.style.setProperty(
+    '--swal2-action-button-outline',
+    buttonStyle.getPropertyValue('--swal2-outline').replace(/ rgba\(.*/, ` ${outlineColor}`)
+  )
 }
 
 /**

--- a/themes/embed-iframe.css
+++ b/themes/embed-iframe.css
@@ -10,7 +10,7 @@
   --swal2-close-button-font-size: 3em;
   --swal2-close-button-color: white;
   --swal2-close-button-transition: transform 0.3s ease-out;
-  --swal2-close-button-outline: none;
+  --swal2-close-button-focus-box-shadow: none;
 
   /* CLOSE BUTTON:HOVER */
   --swal2-close-button-hover-transform: rotate(90deg);


### PR DESCRIPTION
closes #2732

![CleanShot 2025-04-15 at 17 11 59](https://github.com/user-attachments/assets/c92f5b93-388b-4b9c-a8aa-f7b062fa740c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved theming flexibility by replacing hardcoded button background colors and outline styles with CSS custom properties.
  - Updated focus and box-shadow styles for action and close buttons to use new CSS variables, providing more consistent and customizable appearance.
  - Removed the "default-outline" style from action buttons.

- **Bug Fixes**
  - Enhanced consistency of button focus outlines and shadows across themes and states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->