### PR TITLE
fix(styles): use color-mix for buttons darkening

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -39,7 +39,7 @@
   --swal2-input-border-radius: 0.1875em;
   --swal2-input-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.06), 0 0 0 3px transparent;
   --swal2-input-background: transparent;
-  --swal2-input-transition: border-color 0.1s, box-shadow 0.1s;
+  --swal2-input-transition: border-color 0.2s, box-shadow 0.2s;
 
   // PROGRESS STEPS
   --swal2-progress-step-background: #add8e6;
@@ -53,7 +53,7 @@
   --swal2-close-button-inset: auto;
   --swal2-close-button-font-size: 2.5em;
   --swal2-close-button-color: #ccc;
-  --swal2-close-button-transition: color 0.1s, box-shadow 0.1s;
+  --swal2-close-button-transition: color 0.2s, box-shadow 0.2s;
   --swal2-close-button-outline: initial;
   --swal2-close-button-box-shadow: inset 0 0 0 3px transparent;
   --swal2-close-button-focus-box-shadow: inset var(--swal2-outline);
@@ -62,24 +62,25 @@
   --swal2-close-button-hover-transform: none;
 
   // COMMON VARIABLES FOR ALL ACTION BUTTONS
-  --swal2-button-darken-hover: rgba(0, 0, 0, 0.1);
-  --swal2-button-darken-active: rgba(0, 0, 0, 0.2);
-  --swal2-button-transition: box-shadow 0.1s;
+  --swal2-button-transition: background-color 0.2s, box-shadow 0.2s;
 
   // CONFIRM BUTTON
   --swal2-confirm-button-border: 0;
   --swal2-confirm-button-border-radius: 0.25em;
   --swal2-confirm-button-background-color: #7066e0;
+  --swal2-confirm-button-color: #fff;
 
   // DENY BUTTON
   --swal2-deny-button-border: 0;
   --swal2-deny-button-border-radius: 0.25em;
   --swal2-deny-button-background-color: #dc3741;
+  --swal2-deny-button-color: #fff;
 
   // CANCEL BUTTON
   --swal2-cancel-button-border: 0;
   --swal2-cancel-button-border-radius: 0.25em;
   --swal2-cancel-button-background-color: #6e7881;
+  --swal2-cancel-button-color: #fff;
 
   // TOASTS
   --swal2-toast-show-animation: swal2-toast-show 0.5s;
@@ -123,8 +124,6 @@
   }
 }
 
-$swal2-white: #fff !default;
-$swal2-black: #000 !default;
 $swal2-outline-color: rgba(100, 150, 200, 0.5) !default;
 
 // CONTAINER
@@ -207,7 +206,7 @@ $swal2-input-transition: var(--swal2-input-transition) !default;
 $swal2-input-focus-border: 1px solid #b4dbed !default;
 $swal2-input-focus-outline: none !default;
 $swal2-input-focus-box-shadow:
-  inset 0 1px 1px rgba($swal2-black, 0.06),
+  inset 0 1px 1px rgba(0, 0, 0, 0.06),
   0 0 0 3px $swal2-outline-color !default;
 
 // TEXTAREA SPECIFIC VARIABLES
@@ -228,7 +227,7 @@ $swal2-validation-message-color: var(--swal2-validation-message-color) !default;
 $swal2-validation-message-font-size: 1em !default;
 $swal2-validation-message-font-weight: 300 !default;
 $swal2-validation-message-icon-background: $swal2-error !default;
-$swal2-validation-message-icon-color: $swal2-white !default;
+$swal2-validation-message-icon-color: #fff !default;
 $swal2-validation-message-icon-zoom: null !default;
 
 // PROGRESS STEPS
@@ -244,9 +243,9 @@ $swal2-progress-step-width: 2em;
 $swal2-progress-step-height: 2em;
 $swal2-progress-step-border-radius: 2em;
 $swal2-progress-step-background: var(--swal2-progress-step-background) !default;
-$swal2-progress-step-color: $swal2-white !default;
+$swal2-progress-step-color: #fff !default;
 $swal2-active-step-background: #2778c4 !default;
-$swal2-active-step-color: $swal2-white !default;
+$swal2-active-step-color: #fff !default;
 
 // FOOTER
 $swal2-footer-margin: 1em 0 0 !default;
@@ -258,7 +257,7 @@ $swal2-footer-text-align: center !default;
 
 // TIMER PROGRESS BAR
 $swal2-timer-progress-bar-height: 0.25em;
-$swal2-timer-progress-bar-background: rgba($swal2-black, 0.2) !default;
+$swal2-timer-progress-bar-background: rgba(0, 0, 0, 0.2) !default;
 
 // CLOSE BUTTON
 $swal2-close-button-justify-self: end !default;
@@ -309,7 +308,7 @@ $swal2-confirm-button-order: null !default;
 $swal2-confirm-button-border: var(--swal2-confirm-button-border) !default;
 $swal2-confirm-button-border-radius: var(--swal2-confirm-button-border-radius) !default;
 $swal2-confirm-button-background-color: var(--swal2-confirm-button-background-color) !default;
-$swal2-confirm-button-color: $swal2-white !default;
+$swal2-confirm-button-color: var(--swal2-confirm-button-color) !default;
 $swal2-confirm-button-font-size: 1em !default;
 
 // DENY BUTTON
@@ -317,7 +316,7 @@ $swal2-deny-button-order: null !default;
 $swal2-deny-button-border: var(--swal2-deny-button-border) !default;
 $swal2-deny-button-border-radius: var(--swal2-deny-button-border-radius) !default;
 $swal2-deny-button-background-color: var(--swal2-deny-button-background-color) !default;
-$swal2-deny-button-color: $swal2-white !default;
+$swal2-deny-button-color: var(--swal2-deny-button-color) !default;
 $swal2-deny-button-font-size: 1em !default;
 
 // CANCEL BUTTON
@@ -325,7 +324,7 @@ $swal2-cancel-button-order: null !default;
 $swal2-cancel-button-border: var(--swal2-cancel-button-border) !default;
 $swal2-cancel-button-border-radius: var(--swal2-cancel-button-border-radius) !default;
 $swal2-cancel-button-background-color: var(--swal2-cancel-button-background-color) !default;
-$swal2-cancel-button-color: $swal2-white !default;
+$swal2-cancel-button-color: var(--swal2-cancel-button-color) !default;
 $swal2-cancel-button-font-size: 1em !default;
 
 // LOADER
@@ -654,22 +653,6 @@ div:where(.swal2-container) {
     width: $swal2-actions-width;
     margin: $swal2-actions-margin;
     padding: $swal2-actions-padding;
-
-    &:not(.swal2-loading) {
-      .swal2-styled {
-        &[disabled] {
-          opacity: 0.4;
-        }
-
-        &:hover {
-          background-image: linear-gradient(var(--swal2-button-darken-hover), var(--swal2-button-darken-hover));
-        }
-
-        &:active {
-          background-image: linear-gradient(var(--swal2-button-darken-active), var(--swal2-button-darken-active));
-        }
-      }
-    }
   }
 
   div:where(.swal2-loader) {
@@ -705,6 +688,14 @@ div:where(.swal2-container) {
       background-color: $swal2-confirm-button-background-color;
       color: $swal2-confirm-button-color;
       font-size: $swal2-confirm-button-font-size;
+
+      &:hover {
+        background-color: color-mix(in srgb, $swal2-confirm-button-background-color, black 10%);
+      }
+
+      &:active {
+        background-color: color-mix(in srgb, $swal2-confirm-button-background-color, black 20%);
+      }
     }
 
     &:where(.swal2-deny) {
@@ -715,6 +706,14 @@ div:where(.swal2-container) {
       background-color: $swal2-deny-button-background-color;
       color: $swal2-deny-button-color;
       font-size: $swal2-deny-button-font-size;
+
+      &:hover {
+        background-color: color-mix(in srgb, $swal2-deny-button-background-color, black 10%);
+      }
+
+      &:active {
+        background-color: color-mix(in srgb, $swal2-deny-button-background-color, black 20%);
+      }
     }
 
     &:where(.swal2-cancel) {
@@ -725,11 +724,25 @@ div:where(.swal2-container) {
       background-color: $swal2-cancel-button-background-color;
       color: $swal2-cancel-button-color;
       font-size: $swal2-cancel-button-font-size;
+
+      &:hover {
+        background-color: color-mix(in srgb, $swal2-cancel-button-background-color, black 10%);
+      }
+
+      &:active {
+        background-color: color-mix(in srgb, $swal2-cancel-button-background-color, black 20%);
+      }
     }
 
     &:focus-visible {
       outline: none;
       box-shadow: var(--swal2-action-button-outline);
+    }
+
+    &[disabled] {
+      &:not(.swal2-loading) {
+        opacity: 0.4;
+      }
     }
 
     &::-moz-focus-inner {


### PR DESCRIPTION
previously this workaround was used:

```css
background-image: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1));
```

that's cool and was good for pre `color-mix` era, but with it it's impossible to transition background colors. Now it is possible, added `transition: background-color 0.2s` for buttons so UX would be a little bit smoother.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved button color transitions and interaction effects for confirm, deny, and cancel actions.
  - Unified and clarified button text color and background styling.
  - Adjusted disabled button opacity for better visibility.
  - Enhanced overall consistency of button appearance and transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->