### PR TITLE
chore: move PR preview from netlify to render

### DIFF
--- a/tools/deploy-preview.sh
+++ b/tools/deploy-preview.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+yarn build
+curl https://sweetalert2.github.io -o index.html

--- a/tools/deploy-to-netlify.sh
+++ b/tools/deploy-to-netlify.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-yarn build
-curl https://sweetalert2.github.io -o index.html
-sed -i 's|"//cdn.jsdelivr|"https://cdn.jsdelivr|g' index.html
-sed -i 's|src="/|src="https://sweetalert2.github.io/|g' index.html
-sed -i 's|https://cdn.jsdelivr.net/npm/sweetalert2@11/||g' index.html
-sed -i 's|="./|="https://sweetalert2.github.io/|g' index.html
-sed -i 's|="/|="https://sweetalert2.github.io/|g' index.html


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a deployment preview script to build the project and fetch the homepage content for previews.
  * Removed the legacy Netlify deployment script, streamlining the deployment process by eliminating custom URL rewrites.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->