### PR TITLE
fix: workaround scrolling of tall popup with backdrop: false in iOS

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -410,7 +410,7 @@ body {
       pointer-events: none;
 
       .swal2-popup {
-        pointer-events: all;
+        pointer-events: auto;
       }
 
       .swal2-modal {
@@ -1322,7 +1322,7 @@ div:where(.swal2-icon) {
   border: $swal2-toast-border;
   background: $swal2-toast-background;
   box-shadow: $swal2-toast-box-shadow;
-  pointer-events: all;
+  pointer-events: auto;
 
   > * {
     grid-column: 2;

--- a/src/utils/iosFix.js
+++ b/src/utils/iosFix.js
@@ -4,6 +4,9 @@ import * as dom from './dom/index.js'
 // @ts-ignore
 export const isSafariOrIOS = typeof window !== 'undefined' && Boolean(window.GestureEvent) // true for Safari desktop + all iOS browsers https://stackoverflow.com/a/70585394
 
+// @ts-ignore
+export const isIOS = isSafariOrIOS && /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
+
 /**
  * Fix iOS scrolling
  * http://stackoverflow.com/q/39626302

--- a/src/utils/openPopup.js
+++ b/src/utils/openPopup.js
@@ -2,7 +2,7 @@ import globalState from '../globalState.js'
 import { setAriaHidden } from './aria.js'
 import { swalClasses } from './classes.js'
 import * as dom from './dom/index.js'
-import { iOSfix } from './iosFix.js'
+import { iOSfix, isIOS } from './iosFix.js'
 import { replaceScrollbarWithPadding } from './scrollbar.js'
 
 export const SHOW_CLASS_TIMEOUT = 10
@@ -35,13 +35,18 @@ export const openPopup = (params) => {
   }, SHOW_CLASS_TIMEOUT)
 
   if (dom.isModal()) {
-    // Using ternary instead of ?? operator for Webpack 4 compatibility
     fixScrollContainer(
       container,
       params.scrollbarPadding !== undefined ? params.scrollbarPadding : false,
       initialBodyOverflow
     )
     setAriaHidden()
+  }
+
+  // https://github.com/sweetalert2/sweetalert2/issues/2923
+  if (isIOS && params.backdrop === false && popup.scrollHeight > container.clientHeight) {
+    // remove pointer-events: none from container, it breaks scrolling tall popups in iOS
+    container.style.pointerEvents = 'auto'
   }
 
   if (!dom.isToast() && !globalState.previousActiveElement) {


### PR DESCRIPTION
this is a workaround for #2923 

it will enable scrolling but disable interacting with a document for a long popups in iOS